### PR TITLE
Refactor/skill discovery improvements

### DIFF
--- a/claude-code/skills/claude-agents/SKILL.md
+++ b/claude-code/skills/claude-agents/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: claude-agents
-description: Guide for creating custom agents for Claude Code with specialized behaviors and tools
-license: MIT
-allowed-tools:
-  - Read
-  - Write
-  - Edit
-  - Bash
-  - Glob
+description: Guide for creating custom agents for Claude Code. Use when creating specialized agents, configuring agent tools.
 ---
 
 # Claude Code Agents
@@ -122,15 +115,21 @@ timeout: 300                       # Optional: Timeout in seconds
 
 Restrict agent to specific tools:
 
+- Can read files
+- Can search code
+- Can find files
+- Cannot use Write, Edit, Bash, etc.
+
+Example:
+
 ```markdown
 ---
-tools:
-  - Read      # Can read files
-  - Grep      # Can search code
-  - Glob      # Can find files
-  # Cannot use Write, Edit, Bash, etc.
+tools: Read, Grep, Glob     
 ---
 ```
+
+
+
 
 **No tool restrictions** (access to all tools):
 
@@ -160,10 +159,7 @@ model: haiku        # Fast, cost-effective for simple tasks
 ---
 name: security-analyzer
 description: Analyzes code for security vulnerabilities
-tools:
-  - Read
-  - Grep
-  - Glob
+tools: Read, Grep, Glob
 model: sonnet
 ---
 
@@ -193,10 +189,7 @@ I perform security analysis on codebases.
 ---
 name: test-generator
 description: Generates comprehensive test suites
-tools:
-  - Read
-  - Write
-  - Glob
+tools: Read, Write, Glob
 model: sonnet
 ---
 
@@ -226,11 +219,7 @@ I create comprehensive test suites for your code.
 ---
 name: docs-generator
 description: Creates and updates project documentation
-tools:
-  - Read
-  - Write
-  - Glob
-  - Grep
+tools: Read, Write, Glob, Grep
 model: sonnet
 ---
 
@@ -260,12 +249,7 @@ I create and maintain project documentation.
 ---
 name: refactorer
 description: Safely refactors code while maintaining functionality
-tools:
-  - Read
-  - Write
-  - Edit
-  - Grep
-  - Glob
+tools: Read, Write, Edit, Grep, Glob
 model: sonnet
 max_iterations: 20
 ---
@@ -371,22 +355,14 @@ Only grant necessary tools:
 ```markdown
 ---
 # Analysis agent - read-only
-tools:
-  - Read
-  - Grep
-  - Glob
+tools: Read, Grep, Glob
 ---
 ```
 
 ```markdown
 ---
 # Implementation agent - can modify
-tools:
-  - Read
-  - Write
-  - Edit
-  - Glob
-  - Grep
+tools: Read, Write, Edit, Glob, Grep
 ---
 ```
 
@@ -475,10 +451,7 @@ Never hardcode:
 ---
 name: pr-reviewer
 description: Reviews pull requests for quality and completeness
-tools:
-  - Read
-  - Grep
-  - Glob
+tools: Read, Grep, Glob
 model: sonnet
 ---
 
@@ -510,12 +483,7 @@ Conducting thorough PR review...
 ---
 name: code-migrator
 description: Migrates code from one framework/version to another
-tools:
-  - Read
-  - Write
-  - Edit
-  - Glob
-  - Grep
+tools: Read, Write, Edit, Glob, Grep
 model: opus
 max_iterations: 30
 ---
@@ -563,6 +531,10 @@ Performing framework migration...
 - Test with verbose output
 
 ## References
+
+claude-agents/
+└── templates/
+    └── basic-agent.md (example basic agent)
 
 For more information:
 - Claude Code Agents Documentation: https://code.claude.com/docs/en/agents

--- a/claude-code/skills/claude-agents/templates/basic-agent.md
+++ b/claude-code/skills/claude-agents/templates/basic-agent.md
@@ -1,0 +1,9 @@
+---
+name: code-reviewer
+description: Reviews code for quality and best practices
+tools: Read, Glob, Grep
+model: sonnet
+---
+
+You are a code reviewer. When invoked, analyze the code and provide
+specific, actionable feedback on quality, security, and best practices.

--- a/claude-code/skills/claude-commands/SKILL.md
+++ b/claude-code/skills/claude-commands/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: claude-commands
-description: Guide for creating custom slash commands for Claude Code
-license: MIT
-allowed-tools:
-  - Read
-  - Write
-  - Edit
-  - Bash
-  - Glob
+description: Guide for creating custom slash commands for Claude Code. Use when adding new commands, defining command arguments, or implementing command workflows.
 ---
 
 # Claude Code Commands

--- a/claude-code/skills/claude-hooks/SKILL.md
+++ b/claude-code/skills/claude-hooks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-hooks
-description: Guide for creating hooks that trigger actions in response to Claude Code events
+description: Guide for creating event-driven hooks for Claude Code. Use when automating responses to tool calls, lifecycle events, or implementing custom validations.
 license: MIT
 allowed-tools:
   - Read

--- a/claude-code/skills/claude-plugins/SKILL.md
+++ b/claude-code/skills/claude-plugins/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-plugins
-description: Guide for creating and validating Claude Code plugin.json files with schema validation tools
+description: Guide for creating and validating Claude Code plugin.json files. Use when creating plugins, validating plugin schemas, or troubleshooting plugin configuration.
 license: MIT
 allowed-tools:
   - Read

--- a/claude-code/skills/claude-skills/SKILL.md
+++ b/claude-code/skills/claude-skills/SKILL.md
@@ -1,27 +1,11 @@
 ---
 name: claude-skills
-description: Guide for creating Agent Skills with progressive disclosure, SKILL.md structure, and best practices
-license: MIT
-allowed-tools:
-  - Read
-  - Write
-  - Edit
-  - Bash
-  - Glob
+description: Guide for creating Agent Skills with progressive disclosure and best practices. Use when creating new skills, understanding skill structure, or implementing progressive disclosure.
 ---
 
 # Agent Skills
 
 Comprehensive guide for creating modular, self-contained Agent Skills that extend Claude's capabilities with specialized knowledge.
-
-## When to Use This Skill
-
-Activate this skill when:
-- Creating new Agent Skills
-- Understanding skill structure and organization
-- Implementing progressive disclosure
-- Organizing skill resources (scripts, references, assets)
-- Following Agent Skills best practices
 
 ## What Are Agent Skills?
 
@@ -90,8 +74,31 @@ Main instructional content goes here...
 
 ### Required YAML Properties
 
-- `name`: Hyphen-case identifier matching directory name (lowercase alphanumeric and hyphens only)
-- `description`: Explains the skill's purpose and when Claude should utilize it
+- `name`:
+   Hyphen-case identifier matching directory name (lowercase alphanumeric and hyphens only, max 64 characters)
+   Maximum 64 characters
+   Must contain only lowercase letters, numbers, and hyphens
+   Cannot contain XML tags
+   Cannot contain reserved words: "anthropic", "claude"
+- `description`: 
+   Explains the skill's purpose and when Claude should utilize it
+   Must be non-empty
+   Maximum 1024 characters
+   Cannot contain XML tags
+   The description should include both what the Skill does and when Claude should use it. For complete authoring guidance, see the best practices guide.
+
+
+
+**Description Constraints** (from Anthropic best-practices):
+- Maximum 1024 characters
+- Must use third person (not "I can help you" or "You can use this")
+- Must include both **what it does** AND **when to use it**
+- Use pattern: `[What it does]. Use when [trigger conditions].`
+
+> **Critical**: The `description` is the ONLY text Claude sees during skill discovery (Level 1).
+> The body's "When to Use" section only loads AFTER activation (Level 2) and cannot trigger it.
+> All activation triggers must be in the description.
+
 
 ### Optional YAML Properties
 
@@ -216,16 +223,25 @@ The skill name and description heavily influence when Claude activates it. Pay p
 - **Name**: Should be clear and reflect the domain (e.g., `git-operations`, `elixir-phoenix`)
 - **Description**: Should specify both what the skill does and when to use it
 
+> **Critical**: The `description` is the ONLY text Claude sees during skill discovery (Level 1).
+> The body's "When to Use" section only loads AFTER activation (Level 2) and cannot trigger it.
+> All activation triggers must be in the description using patterns like "Use when [scenarios]".
+
 **Examples:**
 
 ✅ Good Description:
 ```yaml
-description: Guide for Git operations including commits, branches, rebasing, and conflict resolution
+description: Guide for Git operations including commits, branches, rebasing, and conflict resolution. Use when working with version control or the user mentions git, commits, or branches.
 ```
 
 ❌ Too Vague:
 ```yaml
 description: Helps with Git
+```
+
+❌ Missing "Use when" triggers:
+```yaml
+description: Guide for Git operations including commits, branches, rebasing, and conflict resolution
 ```
 
 Monitor real usage patterns and iterate based on actual behavior.
@@ -432,6 +448,13 @@ Activate when:
 ```
 
 ## References
+
+claude-skills/
+└── templates/
+    └── level1.md (example skill metadata)
+    └── level2.md (example skill body)
+    └── level3.md (example skill folder structure)
+    └── skill.md (example basic skill)
 
 For more information:
 - **Agent Skills Blog**: https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills

--- a/claude-code/skills/claude-skills/templates/level1.md
+++ b/claude-code/skills/claude-skills/templates/level1.md
@@ -1,0 +1,4 @@
+---
+name: pdf-processing
+description: Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when the user mentions PDFs, forms, or document extraction.
+---

--- a/claude-code/skills/claude-skills/templates/level2.md
+++ b/claude-code/skills/claude-skills/templates/level2.md
@@ -1,0 +1,28 @@
+# PDF Processing
+
+## Quick start
+
+Use pdfplumber to extract text from PDFs:
+
+```python
+import pdfplumber
+
+with pdfplumber.open("document.pdf") as pdf:
+    text = pdf.pages[0].extract_text()
+```
+
+For advanced form filling, see [FORMS.md](FORMS.md).
+
+## References
+
+folder structure:
+
+pdf-skill/
+├── SKILL.md (main instructions)
+├── FORMS.md (form-filling guide)
+├── REFERENCE.md (detailed API reference)
+└── scripts/
+    └── fill_form.py (utility script)
+
+For more information:
+- **PdfPlumber repo**: https://github.com/jsvine/pdfplumber

--- a/claude-code/skills/claude-skills/templates/level3.md
+++ b/claude-code/skills/claude-skills/templates/level3.md
@@ -1,0 +1,6 @@
+pdf-skill/
+├── SKILL.md (main instructions)
+├── FORMS.md (form-filling guide)
+├── REFERENCE.md (detailed API reference)
+└── scripts/
+    └── fill_form.py (utility script)

--- a/claude-code/skills/claude-skills/templates/skill.md
+++ b/claude-code/skills/claude-skills/templates/skill.md
@@ -1,0 +1,12 @@
+---
+name: your-skill-name
+description: Brief description of what this Skill does and when to use it
+---
+
+# Your Skill Name
+
+## Instructions
+[Clear, step-by-step guidance for Claude to follow]
+
+## Examples
+[Concrete examples of using this Skill]

--- a/claude-code/skills/plugin-marketplace/SKILL.md
+++ b/claude-code/skills/plugin-marketplace/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plugin-marketplace
-description: Guide for creating, validating, and managing Claude Code plugin marketplaces with schema validation tools
+description: Guide for creating and managing Claude Code plugin marketplaces. Use when setting up a marketplace, validating marketplace.json, or distributing plugins.
 license: MIT
 allowed-tools:
   - Read

--- a/claude-code/skills/sources.md
+++ b/claude-code/skills/sources.md
@@ -45,6 +45,25 @@ This file documents the sources used to create the claude-code plugin skills.
 - **Date Accessed**: 2025-11-15
 - **Used In**: skills/claude-skills/SKILL.md
 
+### Agent Skills Overview (Platform Documentation)
+- **URL**: https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview
+- **Purpose**: Official skill description patterns and discovery mechanism documentation
+- **Date Accessed**: 2025-01-23
+- **Key Finding**: Description field must contain "Use when [trigger conditions]" pattern since it's the ONLY metadata Claude sees during skill discovery (Level 1). Body content only loads after activation.
+- **Used In**: skills/claude-skills/SKILL.md
+
+### Agent Skills Best Practices (Platform Documentation)
+- **URL**: https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
+- **Purpose**: Skill authoring guidelines including description constraints
+- **Date Accessed**: 2025-01-23
+- **Key Constraints**:
+  - Description max 1024 chars
+  - Name max 64 chars
+  - Third person only (not "I can help you" or "You can use this")
+  - Include both what it does AND when to use it
+  - Pattern: `[What it does]. Use when [trigger conditions].`
+- **Used In**: skills/claude-skills/SKILL.md, scripts/validate-plugin.nu
+
 ## Claude Code Plugin Development
 
 ### Claude Code Plugins Documentation

--- a/core/agents/gcms.md
+++ b/core/agents/gcms.md
@@ -1,0 +1,40 @@
+---
+name: gcms
+description: "Analyzes git status and suggests brief conventional commit messages."
+tools: Bash, Grep, Read
+model: Haiku
+---
+
+You are a git commit message specialist. Your role is to analyze the current git repository state and suggest 1-3 brief, conventional commit messages.
+
+## Your Process:
+
+1. **Analyze Current State**: Run `git status` to see what files are staged, modified, or untracked
+2. **Review Changes**: Run `git diff --cached` for staged changes and `git diff` for unstaged changes  
+3. **Generate Messages**: Create 1-3 brief conventional commit messages following this format:
+   - `type(scope): description`
+   - Types: feat, fix, docs, style, refactor, test, chore
+   - Keep descriptions under 50 characters when possible
+   - Be specific but concise
+
+## Guidelines:
+
+- **Brief**: Aim for messages under 50 characters total
+- **Conventional**: Use conventional commit format (type: description or type(scope): description)
+- **Accurate**: Base suggestions on actual changes, not assumptions
+- **Prioritized**: List most likely/best option first
+- **Context-aware**: Consider the nature and scope of changes
+
+## Example Output Format:
+
+```
+Based on your changes, here are commit message suggestions:
+
+1. `feat: add user authentication`
+2. `fix(auth): resolve login redirect issue` 
+3. `refactor: simplify auth flow`
+```
+
+If there are no changes to commit, politely inform the user and suggest they stage changes first.
+
+If the unit of work is small enough or focused enough the three commit suggestions will be similar, if all three suggestions are about different topics suggest staging the work in different groups and the related suggested commit message.

--- a/core/commands/gcms.md
+++ b/core/commands/gcms.md
@@ -1,6 +1,5 @@
 ---
 description: "Generate brief conventional commit message suggestions"
-argument-hint: ""
 ---
 
-Please analyze the current git status and suggest 1-3 brief conventional commit messages based on the staged and unstaged changes. Use the git-commit-message subagent to perform this analysis.
+Use the gcms (git-commit-message-short) subagent to analyze the current git status and suggest 1-3 brief conventional commit messages

--- a/core/skills/accessibility/SKILL.md
+++ b/core/skills/accessibility/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: accessibility
-description: Guide for implementing web accessibility following W3C WAI principles (WCAG) when designing, developing, or reviewing web interfaces
+description: Guide for implementing web accessibility (WCAG). Use when designing UI components, reviewing interfaces for accessibility, or ensuring compliance with W3C WAI standards.
 ---
 
 # Web Accessibility

--- a/core/skills/anti-fabrication/SKILL.md
+++ b/core/skills/anti-fabrication/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: anti-fabrication
-description: Ensure factual accuracy by validating claims through tool execution, avoiding superlatives and unsubstantiated metrics, and marking uncertain information appropriately
+description: Validate claims through tool execution, avoid superlatives and unsubstantiated metrics. Use when reviewing codebases, analyzing systems, reporting test results, or making any factual claims about code or capabilities.
 license: MIT
 ---
 

--- a/core/skills/code-review/SKILL.md
+++ b/core/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Guide for conducting thorough code reviews focusing on correctness, security, performance, maintainability, and best practices
+description: Guide for conducting code reviews. Use when reviewing pull requests, auditing code quality, identifying security issues, or providing code feedback.
 ---
 
 # Code Review Best Practices

--- a/core/skills/documentation/SKILL.md
+++ b/core/skills/documentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: documentation-writing
-description: Guide for writing clear, comprehensive technical documentation including README files, API docs, guides, and inline documentation
+description: Guide for writing technical documentation. Use when creating README files, API documentation, guides, or inline code documentation.
 ---
 
 # Technical Documentation Writing

--- a/core/skills/git/SKILL.md
+++ b/core/skills/git/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-operations
-description: Guide for Git operations including commits, branches, rebasing, conflict resolution, and following Git best practices and conventional commits
+description: Guide for Git operations including commits, branches, rebasing, and conflict resolution. Use when working with version control, creating commits, managing branches, or resolving merge conflicts.
 ---
 
 # Git Operations and Best Practices

--- a/core/skills/material-design/SKILL.md
+++ b/core/skills/material-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: material-design
-description: Guide for implementing Material Design 3 (Material You) principles for Android, web, and cross-platform applications with dynamic theming
+description: Guide for implementing Material Design 3 (Material You). Use when designing Android apps, implementing dynamic theming, or following Material component patterns.
 ---
 
 # Material Design 3 (Material You)

--- a/core/skills/mise/SKILL.md
+++ b/core/skills/mise/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mise
-description: Guide for using mise (mise-en-place) to manage development tools, runtime versions, environment variables, and tasks across projects
+description: Guide for using mise to manage development tools and runtime versions. Use when configuring project tooling, managing environment variables, or defining project tasks.
 ---
 
 # mise - Development Environment Management

--- a/core/skills/nushell/SKILL.md
+++ b/core/skills/nushell/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nushell
-description: Guide for using Nushell (Nu), a modern shell with structured data pipelines, cross-platform compatibility, and programming language features
+description: Guide for using Nushell for structured data pipelines and scripting. Use when writing shell scripts, processing structured data, or working with cross-platform automation.
 ---
 
 # Nushell - Modern Structured Shell

--- a/core/skills/twelve-factor/SKILL.md
+++ b/core/skills/twelve-factor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: twelve-factor
-description: Guide for building cloud-native applications following the 12-Factor App methodology with Kubernetes, containers, and modern deployment practices
+description: Guide for 12-Factor cloud-native applications. Use when designing microservices, configuring containers, deploying to Kubernetes, or following cloud-native patterns.
 license: MIT
 ---
 

--- a/dagu/skills/rest-api/SKILL.md
+++ b/dagu/skills/rest-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dagu-rest-api
-description: Guide for using the Dagu REST API to programmatically manage and execute workflows, query status, and integrate with external systems
+description: Guide for using the Dagu REST API. Use when programmatically managing workflows, querying execution status, or integrating Dagu with external systems.
 ---
 
 # Dagu REST API

--- a/dagu/skills/webui/SKILL.md
+++ b/dagu/skills/webui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dagu-webui
-description: Guide for using the Dagu Web UI to manage, monitor, and execute workflows through the browser interface
+description: Guide for using the Dagu Web UI. Use when monitoring workflow executions, managing DAGs through the browser, or troubleshooting workflow issues.
 ---
 
 # Dagu Web UI

--- a/dagu/skills/workflows/SKILL.md
+++ b/dagu/skills/workflows/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dagu-workflows
-description: Guide for authoring Dagu workflows including YAML syntax, steps, executors, scheduling, dependencies, and workflow composition
+description: Guide for authoring Dagu workflows with YAML syntax. Use when creating workflow definitions, configuring steps and executors, or setting up scheduling and dependencies.
 ---
 
 # Dagu Workflow Authoring

--- a/elixir/skills/anti-patterns/SKILL.md
+++ b/elixir/skills/anti-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: elixir-anti-patterns
-description: Identifies and helps refactor Elixir anti-patterns including code smells, design issues, and bad practices
+description: Identify and refactor Elixir anti-patterns. Use when reviewing Elixir code for smells, refactoring problematic patterns, or improving code quality.
 ---
 
 # Elixir Anti-Patterns Detection and Refactoring

--- a/elixir/skills/config/SKILL.md
+++ b/elixir/skills/config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: elixir-config
-description: Guide for Elixir application configuration focusing on runtime vs compile-time config, config.exs, runtime.exs, Application.compile_env, and Application.get_env best practices
+description: Guide for Elixir application configuration. Use when configuring runtime vs compile-time settings, managing config.exs/runtime.exs, or using Application.get_env.
 license: MIT
 ---
 

--- a/elixir/skills/otp/SKILL.md
+++ b/elixir/skills/otp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: elixir-otp-concurrency
-description: Guide for building concurrent, fault-tolerant systems using OTP (GenServer, Supervisor, Task, Agent) and Elixir concurrency primitives
+description: Guide for OTP and Elixir concurrency. Use when implementing GenServers, designing supervision trees, or building fault-tolerant concurrent systems.
 ---
 
 # Elixir OTP and Concurrency

--- a/elixir/skills/phoenix/SKILL.md
+++ b/elixir/skills/phoenix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phoenix-framework
-description: Guide for building Phoenix web applications with LiveView, contexts, channels, and following Phoenix best practices
+description: Guide for Phoenix web applications. Use when building Phoenix apps, implementing LiveView, designing contexts, or setting up channels.
 ---
 
 # Phoenix Framework Development

--- a/elixir/skills/testing/SKILL.md
+++ b/elixir/skills/testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: elixir-testing
-description: Guide for writing comprehensive tests in Elixir using ExUnit, property-based testing, mocks, and test organization best practices
+description: Guide for Elixir testing with ExUnit. Use when writing unit tests, implementing property-based tests, setting up mocks, or organizing test suites.
 ---
 
 # Elixir Testing with ExUnit

--- a/github/skills/act/SKILL.md
+++ b/github/skills/act/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: act
-description: Test GitHub Actions workflows locally using act, including installation, configuration, debugging, and troubleshooting local workflow execution
+description: Test GitHub Actions locally using act. Use when debugging workflows locally, testing workflow changes before pushing, or troubleshooting action failures.
 ---
 
 # act - Local GitHub Actions Testing

--- a/github/skills/actions/SKILL.md
+++ b/github/skills/actions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-actions
-description: Create, configure, and optimize GitHub Actions including action types, triggers, runners, security practices, and marketplace integration
+description: Create and configure GitHub Actions. Use when building custom actions, setting up runners, implementing security practices, or publishing to the marketplace.
 ---
 
 # GitHub Actions

--- a/github/skills/workflows/SKILL.md
+++ b/github/skills/workflows/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-workflows
-description: Write, configure, and optimize GitHub Actions workflows including syntax, triggers, jobs, contexts, expressions, artifacts, and CI/CD patterns
+description: Write and optimize GitHub Actions workflows. Use when creating CI/CD pipelines, configuring workflow triggers, managing artifacts, or debugging workflow runs.
 ---
 
 # GitHub Workflows

--- a/rust/skills/SKILL.md
+++ b/rust/skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-language
-description: Guide for writing Rust code covering ownership, borrowing, lifetimes, error handling, async programming, and Rust best practices
+description: Guide for writing Rust code. Use when working with ownership and borrowing, implementing error handling, writing async code, or following Rust best practices.
 ---
 
 # Rust Programming Language

--- a/ui/skills/daisyui/SKILL.md
+++ b/ui/skills/daisyui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daisyui
-description: Guide for using daisyUI component library with Tailwind CSS for building UI components, theming, and responsive design
+description: Guide for daisyUI component library with Tailwind CSS. Use when building UI components, implementing themes, or creating responsive designs with daisyUI.
 ---
 
 # daisyUI Component Library


### PR DESCRIPTION
  - Standardize all 25 skill descriptions with "Use when [trigger]" pattern to improve Claude's skill discovery                                                  
  - Document skill description constraints (64 char name, 1024 char description) and add progressive disclosure templates                                        
  - Add SKILL.md frontmatter validation to enforce naming and description requirements                                                                           
  - Add gcms subagent using Haiku for fast commit message suggestions  