### PR TITLE
feat(container): add apple container cli skill for macos native containers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -32,9 +32,9 @@
       "source": "./core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "category": "development",
-      "keywords": ["git", "documentation", "code-review", "tools", "beads"]
+      "keywords": ["git", "documentation", "code-review", "tools", "beads", "container"]
     },
     {
       "name": "dagu",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -33,6 +33,7 @@
     "./core/skills/anti-fabrication",
     "./core/skills/security",
     "./core/skills/beads",
+    "./core/skills/container",
     "./dagu/skills/workflows",
     "./dagu/skills/webui",
     "./dagu/skills/rest-api",

--- a/core/.claude-plugin/plugin.json
+++ b/core/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "core",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["git", "documentation", "code-review", "tools", "accessibility", "material-design", "twelve-factor-app", "security", "gitleaks", "beads"],
+  "keywords": ["git", "documentation", "code-review", "tools", "accessibility", "material-design", "twelve-factor-app", "security", "gitleaks", "beads", "container"],
   "skills": [
     "./skills/git",
     "./skills/mise",
@@ -19,7 +19,8 @@
     "./skills/twelve-factor",
     "./skills/anti-fabrication",
     "./skills/security",
-    "./skills/beads"
+    "./skills/beads",
+    "./skills/container"
   ],
   "agents": [
     "./skills/beads/agents/beads-worker.md"

--- a/core/skills/container/SKILL.md
+++ b/core/skills/container/SKILL.md
@@ -1,0 +1,620 @@
+---
+name: container
+description: Guide for using Apple Container CLI to run Linux containers on Apple silicon Macs (macOS 26+). Use when managing OCI containers, building images, configuring networks/volumes, or working with container system services on macOS.
+license: MIT
+---
+
+# Apple Container CLI
+
+This skill activates when working with Apple Container for running Linux containers natively on Apple silicon Macs.
+
+## When to Use This Skill
+
+Activate when:
+- Running Linux containers on macOS 26+ with Apple silicon
+- Managing container lifecycle (run, stop, exec, logs, inspect)
+- Building OCI-compatible container images
+- Managing container images (pull, push, tag, save, load)
+- Configuring container networks and volumes
+- Managing the container system service
+- Migrating between Apple Container versions (0.4.x to 0.5.x)
+
+## What is Apple Container?
+
+Apple Container is a macOS-native tool for running Linux containers as lightweight virtual machines on Apple silicon:
+
+- **Swift-based**: Built on Apple's Virtualization.framework
+- **OCI-compatible**: Produces and runs standard OCI container images
+- **Apple silicon only**: Requires Apple silicon Mac (M1 or later)
+- **Pre-1.0**: Currently at version 0.5.0, breaking changes expected between minor versions
+- **Lightweight VMs**: Each container runs as a lightweight Linux VM
+
+## Prerequisites
+
+- macOS 26 or later (Tahoe)
+- Apple silicon Mac (M1, M2, M3, M4 series)
+- Install via signed `.pkg` from [GitHub releases](https://github.com/apple/container/releases)
+
+## System Management
+
+Manage the container system service that runs in the background:
+
+```bash
+# Start the system service
+container system start
+
+# Stop the system service
+container system stop
+
+# Check service status
+container system status
+
+# Show CLI version
+container system version
+
+# View system logs
+container system logs
+
+# Show disk usage
+container system df
+```
+
+### System Properties
+
+Configure system-level settings (consolidated in 0.5.0):
+
+```bash
+# List all properties
+container system property list
+
+# Get a specific property
+container system property get <key>
+
+# Set a property
+container system property set <key> <value>
+
+# Clear a property
+container system property clear <key>
+```
+
+### System DNS
+
+Manage DNS configuration for containers:
+
+```bash
+# Create a DNS entry
+container system dns create <name> <ip>
+
+# Delete a DNS entry
+container system dns delete <name>
+
+# List DNS entries
+container system dns list
+```
+
+### Custom Kernel
+
+Set a custom Linux kernel for containers:
+
+```bash
+# Set custom kernel
+container system kernel set <path>
+
+# Force set (0.5.0+)
+container system kernel set --force <path>
+```
+
+## Container Lifecycle
+
+### Run Containers
+
+```bash
+# Run interactively
+container run -it ubuntu:latest /bin/bash
+
+# Run detached
+container run -d --name myapp nginx:latest
+
+# Run with port mapping
+container run -d -p 8080:80 nginx:latest
+
+# Run with volume mount
+container run -v /host/path:/container/path ubuntu:latest
+
+# Run with environment variables
+container run -e FOO=bar -e BAZ=qux myimage:latest
+
+# Run with auto-remove
+container run --rm -it alpine:latest /bin/sh
+
+# Combined common flags
+container run -d --name web -p 8080:80 -v ./html:/usr/share/nginx/html -e ENV=prod nginx:latest
+```
+
+### Manage Running Containers
+
+```bash
+# List running containers
+container list
+container ls
+
+# List all containers (including stopped)
+container list --all
+
+# Start a stopped container
+container start <name-or-id>
+
+# Stop a running container
+container stop <name-or-id>
+
+# Kill a container (force stop)
+container kill <name-or-id>
+
+# Remove a container
+container delete <name-or-id>
+container rm <name-or-id>
+
+# Execute command in running container
+container exec -it <name-or-id> /bin/bash
+
+# View container logs
+container logs <name-or-id>
+container logs --follow <name-or-id>
+
+# Inspect container details
+container inspect <name-or-id>
+
+# Container resource stats
+container stats
+
+# Remove all stopped containers
+container prune
+```
+
+### Create Without Starting
+
+```bash
+# Create container without starting
+container create --name myapp nginx:latest
+
+# Start it later
+container start myapp
+```
+
+## Image Management
+
+```bash
+# Pull an image
+container image pull ubuntu:latest
+
+# Pull with platform specification
+container image pull --platform linux/arm64 nginx:latest
+container image pull --arch arm64 --os linux nginx:latest
+
+# List images
+container image list
+container image ls
+
+# Tag an image
+container image tag ubuntu:latest myregistry/ubuntu:v1
+
+# Push to registry
+container image push myregistry/ubuntu:v1
+
+# Save image to archive
+container image save ubuntu:latest -o ubuntu.tar
+
+# Load image from archive
+container image load -i ubuntu.tar
+
+# Delete an image
+container image delete ubuntu:latest
+
+# Inspect image metadata
+container image inspect ubuntu:latest
+
+# Remove unused images
+container image prune
+```
+
+### Platform Flags
+
+When pulling or building images, specify the target platform:
+
+```bash
+--platform linux/arm64       # Full platform string
+--arch arm64                 # Architecture only
+--os linux                   # OS only
+--scheme oci                 # Image scheme
+```
+
+## Build
+
+Build OCI-compatible images from Dockerfiles or Containerfiles:
+
+```bash
+# Build from current directory
+container build -t myimage:latest .
+
+# Build with specific Dockerfile
+container build -t myimage:latest -f Dockerfile.prod .
+
+# Build with build arguments
+container build -t myimage:latest --build-arg VERSION=1.0 .
+
+# Build without cache
+container build -t myimage:latest --no-cache .
+
+# Multi-stage build with target
+container build -t myimage:latest --target builder .
+
+# Build with platform
+container build -t myimage:latest --platform linux/arm64 .
+
+# Build with output
+container build -t myimage:latest -o type=local,dest=./output .
+```
+
+### Builder Management
+
+The builder runs as a separate process:
+
+```bash
+# Start the builder
+container builder start
+
+# Stop the builder
+container builder stop
+
+# Delete the builder
+container builder delete
+
+# Check builder status
+container builder status
+```
+
+## Network Management
+
+Create and manage container networks:
+
+```bash
+# Create a network
+container network create mynetwork
+
+# Create with subnet
+container network create --subnet 10.0.0.0/24 mynetwork
+
+# Create with labels
+container network create --labels env=dev mynetwork
+
+# List networks
+container network list
+
+# Inspect a network
+container network inspect mynetwork
+
+# Delete a network
+container network delete mynetwork
+
+# Remove unused networks
+container network prune
+```
+
+### Multi-Container Networking
+
+```bash
+# Create a shared network
+container network create app-net
+
+# Run containers on the network
+container run -d --name db --network app-net postgres:latest
+container run -d --name web --network app-net -p 8080:80 myapp:latest
+
+# Containers can reach each other by name
+container exec web curl http://db:5432
+```
+
+## Volume Management
+
+Create and manage persistent volumes:
+
+```bash
+# Create a volume
+container volume create mydata
+
+# Create with size limit
+container volume create -s 10G mydata
+
+# Create with labels
+container volume create --label env=prod mydata
+
+# Create with driver options
+container volume create --opt type=tmpfs mydata
+
+# List volumes
+container volume list
+
+# Inspect a volume
+container volume inspect mydata
+
+# Delete a volume
+container volume delete mydata
+
+# Remove unused volumes
+container volume prune
+```
+
+### Using Volumes
+
+```bash
+# Mount a named volume
+container run -v mydata:/data myimage:latest
+
+# Mount a host directory (bind mount)
+container run -v /host/path:/container/path myimage:latest
+
+# Read-only mount
+container run -v mydata:/data:ro myimage:latest
+```
+
+## Registry
+
+Authenticate with container registries:
+
+```bash
+# Log in to a registry
+container registry login <registry-url>
+
+# Log out from a registry
+container registry logout <registry-url>
+```
+
+**Note**: In 0.5.0, the keychain ID changed from `com.apple.container` to `com.apple.container.registry`. Re-login is required after upgrading from 0.4.x.
+
+## Version Differences (0.4.1 vs 0.5.0)
+
+### Breaking Changes in 0.5.0
+
+| Change | 0.4.1 | 0.5.0 |
+|--------|-------|-------|
+| Image listing | `container images` alias available | `container images` removed, use `container image list` |
+| System properties | Scattered subcommands | Consolidated to `container system property` |
+| Registry keychain | `com.apple.container` | `com.apple.container.registry` (re-login required) |
+
+### New Features in 0.5.0
+
+- Multi-image save (`container image save img1 img2 -o archive.tar`)
+- Network labels (`container network create --labels key=val`)
+- Kernel force set (`container system kernel set --force`)
+- CVE-2026-20613 fix
+- Dependencies: Containerization 0.9.1, CZ 0.8.0, Builder shim 0.6.1
+
+### Migration Checklist (0.4.x to 0.5.0)
+
+1. Replace `container images` with `container image list` in scripts
+2. Update system property commands to use `container system property`
+3. Re-login to registries (keychain ID changed)
+4. Review scripts for removed aliases
+5. Test build workflows (builder shim updated to 0.6.1)
+
+See `templates/0.4.1/commands.md` and `templates/0.5.0/commands.md` for version-specific details.
+
+## Scripts
+
+This skill includes focused Nushell scripts for container management:
+
+### container-system.nu
+
+System service management with health checks:
+
+```bash
+# Start system service
+nu scripts/container-system.nu start
+
+# Check status
+nu scripts/container-system.nu status
+
+# Full health check (status + disk + container count)
+nu scripts/container-system.nu health
+
+# View disk usage
+nu scripts/container-system.nu df
+
+# Show version
+nu scripts/container-system.nu version
+```
+
+### container-images.nu
+
+Image lifecycle operations:
+
+```bash
+# List images
+nu scripts/container-images.nu list
+
+# Pull an image
+nu scripts/container-images.nu pull ubuntu:latest
+
+# Build from Dockerfile
+nu scripts/container-images.nu build -t myimage:latest .
+
+# Prune unused images
+nu scripts/container-images.nu prune
+```
+
+### container-lifecycle.nu
+
+Container run/stop/exec/logs:
+
+```bash
+# List running containers
+nu scripts/container-lifecycle.nu ps
+
+# Run a container
+nu scripts/container-lifecycle.nu run ubuntu:latest
+
+# View logs
+nu scripts/container-lifecycle.nu logs mycontainer
+
+# Execute command
+nu scripts/container-lifecycle.nu exec mycontainer /bin/bash
+```
+
+### container-cleanup.nu
+
+Prune and disk usage:
+
+```bash
+# Prune everything unused
+nu scripts/container-cleanup.nu prune-all
+
+# Prune only containers
+nu scripts/container-cleanup.nu prune-containers
+
+# Show disk usage
+nu scripts/container-cleanup.nu df
+```
+
+## Mise Tasks
+
+Copy `templates/mise.toml` to add container management tasks to any project:
+
+```bash
+mise container:start      # Start system service
+mise container:stop       # Stop system service
+mise container:status     # Show formatted status
+mise container:run        # Run container (accepts image arg)
+mise container:ps         # List running containers
+mise container:images     # List images
+mise container:build      # Build from Dockerfile/Containerfile
+mise container:prune      # Clean up unused resources
+mise container:health     # System status + disk + container count
+mise container:df         # Disk usage
+mise container:version    # CLI version
+```
+
+## Common Workflows
+
+### Quick Start
+
+```bash
+# Start the system
+container system start
+
+# Pull and run an image
+container run -it --rm ubuntu:latest /bin/bash
+
+# Check what's running
+container ls
+```
+
+### Build and Run
+
+```bash
+# Build your image
+container build -t myapp:latest .
+
+# Run it
+container run -d --name myapp -p 8080:80 myapp:latest
+
+# Check logs
+container logs --follow myapp
+```
+
+### Multi-Container with Networking
+
+```bash
+# Create network
+container network create mynet
+
+# Start database
+container run -d --name postgres --network mynet \
+  -e POSTGRES_PASSWORD=secret \
+  -v pgdata:/var/lib/postgresql/data \
+  postgres:16
+
+# Start application
+container run -d --name app --network mynet \
+  -p 3000:3000 \
+  -e DATABASE_URL=postgres://postgres:secret@postgres:5432/mydb \
+  myapp:latest
+```
+
+### Persistent Data with Volumes
+
+```bash
+# Create a volume
+container volume create appdata
+
+# Run with volume
+container run -d --name db -v appdata:/var/lib/data mydb:latest
+
+# Volume persists after container removal
+container rm db
+container run -d --name db2 -v appdata:/var/lib/data mydb:latest
+```
+
+## Troubleshooting
+
+### System Not Started
+
+```bash
+# Check status
+container system status
+
+# Start if not running
+container system start
+
+# View logs for errors
+container system logs
+```
+
+### Image Pull Failures
+
+```bash
+# Check system is running
+container system status
+
+# Try with explicit platform
+container image pull --platform linux/arm64 <image>
+
+# Check registry authentication
+container registry login <registry>
+```
+
+### Volume Permission Issues
+
+```bash
+# Check volume exists
+container volume list
+
+# Inspect volume for mount details
+container volume inspect <name>
+
+# Run container with specific user
+container run -u 1000:1000 -v myvol:/data myimage:latest
+```
+
+### Builder Issues
+
+```bash
+# Check builder status
+container builder status
+
+# Restart builder
+container builder stop
+container builder start
+
+# Delete and recreate if stuck
+container builder delete
+container builder start
+```
+
+## Key Principles
+
+- **Pre-1.0 software**: Breaking changes expected between minor versions
+- **Apple silicon only**: No Intel Mac support
+- **macOS 26+ required**: Not available on earlier macOS versions
+- **OCI-compatible**: Standard container images work as expected
+- **Lightweight VMs**: Each container is an isolated lightweight VM
+- **System service**: Start the system service before running containers

--- a/core/skills/container/references/command-reference.md
+++ b/core/skills/container/references/command-reference.md
@@ -1,0 +1,553 @@
+# Apple Container CLI - Command Reference
+
+Exhaustive reference for all Apple Container CLI commands and their flags/options.
+
+## Container Lifecycle
+
+### `container run`
+
+Create and start a container from an image.
+
+```
+container run [FLAGS] IMAGE [COMMAND] [ARGS...]
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--interactive` | `-i` | Keep STDIN open |
+| `--tty` | `-t` | Allocate a pseudo-TTY |
+| `--detach` | `-d` | Run in background |
+| `--name` | | Assign a name to the container |
+| `--rm` | | Automatically remove container when it exits |
+| `--publish` | `-p` | Publish port(s) `host:container` |
+| `--volume` | `-v` | Bind mount a volume `host:container[:ro]` |
+| `--env` | `-e` | Set environment variable `KEY=VALUE` |
+| `--network` | | Connect to a network |
+| `--platform` | | Target platform (e.g., `linux/arm64`) |
+| `--user` | `-u` | Run as user `UID[:GID]` |
+| `--workdir` | `-w` | Working directory inside the container |
+| `--entrypoint` | | Override default entrypoint |
+| `--hostname` | `-h` | Container hostname |
+| `--restart` | | Restart policy (`no`, `always`, `on-failure`) |
+
+Common combinations:
+- `-it` - Interactive terminal session
+- `-d --name` - Named background service
+- `-d -p -v -e --name --rm` - Full service with ports, volumes, env vars
+
+### `container create`
+
+Create a container without starting it.
+
+```
+container create [FLAGS] IMAGE [COMMAND] [ARGS...]
+```
+
+Accepts all the same flags as `container run` except `--detach`.
+
+### `container start`
+
+Start one or more stopped containers.
+
+```
+container start CONTAINER [CONTAINER...]
+```
+
+### `container stop`
+
+Stop one or more running containers.
+
+```
+container stop CONTAINER [CONTAINER...]
+```
+
+### `container kill`
+
+Force stop one or more running containers.
+
+```
+container kill CONTAINER [CONTAINER...]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--signal` | Signal to send (default: SIGKILL) |
+
+### `container delete` / `container rm`
+
+Remove one or more containers.
+
+```
+container delete CONTAINER [CONTAINER...]
+container rm CONTAINER [CONTAINER...]
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--force` | `-f` | Force removal of running container |
+
+### `container exec`
+
+Execute a command in a running container.
+
+```
+container exec [FLAGS] CONTAINER COMMAND [ARGS...]
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--interactive` | `-i` | Keep STDIN open |
+| `--tty` | `-t` | Allocate a pseudo-TTY |
+| `--env` | `-e` | Set environment variable |
+| `--workdir` | `-w` | Working directory |
+| `--user` | `-u` | Run as user |
+
+### `container logs`
+
+Fetch logs of a container.
+
+```
+container logs [FLAGS] CONTAINER
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--follow` | `-f` | Follow log output |
+| `--tail` | `-n` | Number of lines from end |
+| `--timestamps` | `-t` | Show timestamps |
+
+### `container inspect`
+
+Show detailed information about a container.
+
+```
+container inspect CONTAINER
+```
+
+### `container stats`
+
+Display resource usage statistics for running containers.
+
+```
+container stats [CONTAINER...]
+```
+
+### `container prune`
+
+Remove all stopped containers.
+
+```
+container prune
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--force` | `-f` | Skip confirmation |
+
+### `container list` / `container ls`
+
+List containers.
+
+```
+container list [FLAGS]
+container ls [FLAGS]
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--all` | `-a` | Show all containers (including stopped) |
+| `--quiet` | `-q` | Only show container IDs |
+| `--format` | | Output format |
+
+## Image Management
+
+### `container image pull`
+
+Pull an image from a registry.
+
+```
+container image pull [FLAGS] IMAGE
+```
+
+| Flag | Description |
+|------|-------------|
+| `--platform` | Target platform (e.g., `linux/arm64`) |
+| `--arch` | Target architecture |
+| `--os` | Target OS |
+| `--scheme` | Image scheme (e.g., `oci`) |
+
+### `container image push`
+
+Push an image to a registry.
+
+```
+container image push IMAGE
+```
+
+### `container image save`
+
+Save one or more images to a tar archive.
+
+```
+container image save [FLAGS] IMAGE [IMAGE...]
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--output` | `-o` | Output file path |
+
+**Note**: Multi-image save added in 0.5.0.
+
+### `container image load`
+
+Load an image from a tar archive.
+
+```
+container image load [FLAGS]
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--input` | `-i` | Input file path |
+
+### `container image tag`
+
+Create a new tag for an image.
+
+```
+container image tag SOURCE TARGET
+```
+
+### `container image delete`
+
+Remove one or more images.
+
+```
+container image delete IMAGE [IMAGE...]
+```
+
+### `container image inspect`
+
+Show detailed information about an image.
+
+```
+container image inspect IMAGE
+```
+
+### `container image prune`
+
+Remove unused images.
+
+```
+container image prune
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--force` | `-f` | Skip confirmation |
+
+### `container image list` / `container image ls`
+
+List images.
+
+```
+container image list [FLAGS]
+container image ls [FLAGS]
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--quiet` | `-q` | Only show image IDs |
+| `--format` | | Output format |
+
+## Build
+
+### `container build`
+
+Build an image from a Dockerfile or Containerfile.
+
+```
+container build [FLAGS] PATH
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--tag` | `-t` | Name and optionally tag (`name:tag`) |
+| `--file` | `-f` | Path to Dockerfile/Containerfile |
+| `--build-arg` | | Set build-time variable `KEY=VALUE` |
+| `--no-cache` | | Do not use cache |
+| `--target` | | Set target build stage |
+| `--platform` | | Target platform |
+| `--output` | `-o` | Output destination (`type=local,dest=path`) |
+| `--progress` | | Progress output type (`auto`, `plain`, `tty`) |
+
+### `container builder start`
+
+Start the builder process.
+
+```
+container builder start
+```
+
+### `container builder stop`
+
+Stop the builder process.
+
+```
+container builder stop
+```
+
+### `container builder delete`
+
+Delete the builder.
+
+```
+container builder delete
+```
+
+### `container builder status`
+
+Check builder status.
+
+```
+container builder status
+```
+
+## Network Management
+
+### `container network create`
+
+Create a network.
+
+```
+container network create [FLAGS] NAME
+```
+
+| Flag | Description |
+|------|-------------|
+| `--subnet` | Subnet in CIDR format (e.g., `10.0.0.0/24`) |
+| `--labels` | Labels for the network (0.5.0+) |
+
+### `container network delete`
+
+Remove a network.
+
+```
+container network delete NETWORK
+```
+
+### `container network list`
+
+List networks.
+
+```
+container network list
+```
+
+### `container network inspect`
+
+Show detailed information about a network.
+
+```
+container network inspect NETWORK
+```
+
+### `container network prune`
+
+Remove unused networks.
+
+```
+container network prune
+```
+
+## Volume Management
+
+### `container volume create`
+
+Create a volume.
+
+```
+container volume create [FLAGS] [NAME]
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--size` | `-s` | Size limit (e.g., `10G`) |
+| `--label` | | Label for the volume |
+| `--opt` | | Driver-specific options (e.g., `type=tmpfs`) |
+
+### `container volume delete`
+
+Remove a volume.
+
+```
+container volume delete VOLUME
+```
+
+### `container volume list`
+
+List volumes.
+
+```
+container volume list
+```
+
+### `container volume inspect`
+
+Show detailed information about a volume.
+
+```
+container volume inspect VOLUME
+```
+
+### `container volume prune`
+
+Remove unused volumes.
+
+```
+container volume prune
+```
+
+## Registry
+
+### `container registry login`
+
+Log in to a container registry.
+
+```
+container registry login REGISTRY
+```
+
+Prompts for username and password. Credentials stored in macOS Keychain.
+
+**Keychain ID**:
+- 0.4.x: `com.apple.container`
+- 0.5.0+: `com.apple.container.registry`
+
+### `container registry logout`
+
+Log out from a container registry.
+
+```
+container registry logout REGISTRY
+```
+
+## System Management
+
+### `container system start`
+
+Start the container system service.
+
+```
+container system start
+```
+
+### `container system stop`
+
+Stop the container system service.
+
+```
+container system stop
+```
+
+### `container system status`
+
+Check if the system service is running.
+
+```
+container system status
+```
+
+Exit code 0 if running, non-zero if not.
+
+### `container system version`
+
+Show the CLI version.
+
+```
+container system version
+```
+
+### `container system logs`
+
+View system service logs.
+
+```
+container system logs
+```
+
+### `container system df`
+
+Show disk usage of container resources.
+
+```
+container system df
+```
+
+### `container system property list`
+
+List all system properties. (0.5.0+ consolidated)
+
+```
+container system property list
+```
+
+### `container system property get`
+
+Get a system property value.
+
+```
+container system property get KEY
+```
+
+### `container system property set`
+
+Set a system property value.
+
+```
+container system property set KEY VALUE
+```
+
+### `container system property clear`
+
+Clear a system property.
+
+```
+container system property clear KEY
+```
+
+### `container system dns create`
+
+Create a DNS entry.
+
+```
+container system dns create NAME IP
+```
+
+### `container system dns delete`
+
+Delete a DNS entry.
+
+```
+container system dns delete NAME
+```
+
+### `container system dns list`
+
+List DNS entries.
+
+```
+container system dns list
+```
+
+### `container system kernel set`
+
+Set a custom Linux kernel.
+
+```
+container system kernel set [FLAGS] PATH
+```
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Force set (0.5.0+ only) |

--- a/core/skills/container/scripts/container-cleanup.nu
+++ b/core/skills/container/scripts/container-cleanup.nu
@@ -1,0 +1,133 @@
+#!/usr/bin/env nu
+
+# Apple Container cleanup and resource management
+# Supports: prune-all, prune-containers, prune-images, prune-volumes, prune-networks, df
+
+def main [
+    command: string  # Subcommand: prune-all, prune-containers, prune-images, prune-volumes, prune-networks, df
+] {
+    match $command {
+        "prune-all" => { cmd-prune-all }
+        "prune-containers" => { cmd-prune-containers }
+        "prune-images" => { cmd-prune-images }
+        "prune-volumes" => { cmd-prune-volumes }
+        "prune-networks" => { cmd-prune-networks }
+        "df" => { cmd-df }
+        _ => {
+            print $"(ansi red)Error:(ansi reset) Unknown command '($command)'"
+            print "Available: prune-all, prune-containers, prune-images, prune-volumes, prune-networks, df"
+            exit 1
+        }
+    }
+}
+
+def ensure-running [] {
+    if (which container | is-empty) {
+        print $"(ansi red)Error:(ansi reset) Apple Container CLI not found"
+        exit 1
+    }
+    let status = (do { ^container system status } | complete)
+    if $status.exit_code != 0 {
+        print $"(ansi yellow)Starting Apple Container...(ansi reset)"
+        let start_result = (do { ^container system start } | complete)
+        if $start_result.exit_code != 0 {
+            print $"(ansi red)Error:(ansi reset) Failed to start Apple Container"
+            print $start_result.stderr
+            exit 1
+        }
+        print $"(ansi green)Apple Container started(ansi reset)"
+    }
+}
+
+def cmd-prune-all [] {
+    ensure-running
+    print $"(ansi cyan)Pruning all unused resources...(ansi reset)"
+    print ""
+
+    print $"(ansi yellow)Pruning stopped containers...(ansi reset)"
+    let c = (do { ^container prune } | complete)
+    if $c.exit_code == 0 { print $c.stdout }
+
+    print $"(ansi yellow)Pruning unused images...(ansi reset)"
+    let i = (do { ^container image prune } | complete)
+    if $i.exit_code == 0 { print $i.stdout }
+
+    print $"(ansi yellow)Pruning unused volumes...(ansi reset)"
+    let v = (do { ^container volume prune } | complete)
+    if $v.exit_code == 0 { print $v.stdout }
+
+    print $"(ansi yellow)Pruning unused networks...(ansi reset)"
+    let n = (do { ^container network prune } | complete)
+    if $n.exit_code == 0 { print $n.stdout }
+
+    print ""
+    print $"(ansi green)Cleanup complete(ansi reset)"
+
+    # Show disk usage after cleanup
+    print ""
+    cmd-df
+}
+
+def cmd-prune-containers [] {
+    ensure-running
+    print $"(ansi yellow)Pruning stopped containers...(ansi reset)"
+    let result = (do { ^container prune } | complete)
+    if $result.exit_code == 0 {
+        print $result.stdout
+        print $"(ansi green)Container prune complete(ansi reset)"
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}
+
+def cmd-prune-images [] {
+    ensure-running
+    print $"(ansi yellow)Pruning unused images...(ansi reset)"
+    let result = (do { ^container image prune } | complete)
+    if $result.exit_code == 0 {
+        print $result.stdout
+        print $"(ansi green)Image prune complete(ansi reset)"
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}
+
+def cmd-prune-volumes [] {
+    ensure-running
+    print $"(ansi yellow)Pruning unused volumes...(ansi reset)"
+    let result = (do { ^container volume prune } | complete)
+    if $result.exit_code == 0 {
+        print $result.stdout
+        print $"(ansi green)Volume prune complete(ansi reset)"
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}
+
+def cmd-prune-networks [] {
+    ensure-running
+    print $"(ansi yellow)Pruning unused networks...(ansi reset)"
+    let result = (do { ^container network prune } | complete)
+    if $result.exit_code == 0 {
+        print $result.stdout
+        print $"(ansi green)Network prune complete(ansi reset)"
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}
+
+def cmd-df [] {
+    ensure-running
+    print $"(ansi cyan)Disk Usage:(ansi reset)"
+    let result = (do { ^container system df } | complete)
+    if $result.exit_code == 0 {
+        print $result.stdout
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}

--- a/core/skills/container/scripts/container-images.nu
+++ b/core/skills/container/scripts/container-images.nu
@@ -1,0 +1,189 @@
+#!/usr/bin/env nu
+
+# Apple Container image management
+# Supports: list, pull, push, build, save, load, tag, prune, inspect
+
+def main [
+    command: string   # Subcommand: list, pull, push, build, save, load, tag, prune, inspect
+    ...args: string   # Additional arguments passed to the command
+] {
+    match $command {
+        "list" => { cmd-list }
+        "pull" => { cmd-pull $args }
+        "push" => { cmd-push $args }
+        "build" => { cmd-build $args }
+        "save" => { cmd-save $args }
+        "load" => { cmd-load $args }
+        "tag" => { cmd-tag $args }
+        "prune" => { cmd-prune }
+        "inspect" => { cmd-inspect $args }
+        _ => {
+            print $"(ansi red)Error:(ansi reset) Unknown command '($command)'"
+            print "Available: list, pull, push, build, save, load, tag, prune, inspect"
+            exit 1
+        }
+    }
+}
+
+def ensure-running [] {
+    if (which container | is-empty) {
+        print $"(ansi red)Error:(ansi reset) Apple Container CLI not found"
+        exit 1
+    }
+    let status = (do { ^container system status } | complete)
+    if $status.exit_code != 0 {
+        print $"(ansi yellow)Starting Apple Container...(ansi reset)"
+        let start_result = (do { ^container system start } | complete)
+        if $start_result.exit_code != 0 {
+            print $"(ansi red)Error:(ansi reset) Failed to start Apple Container"
+            print $start_result.stderr
+            exit 1
+        }
+        print $"(ansi green)Apple Container started(ansi reset)"
+    }
+}
+
+def cmd-list [] {
+    ensure-running
+    print $"(ansi cyan)Images:(ansi reset)"
+    let result = (do { ^container image list } | complete)
+    if $result.exit_code == 0 {
+        print $result.stdout
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}
+
+def cmd-pull [args: list<string>] {
+    ensure-running
+    if ($args | is-empty) {
+        print $"(ansi red)Error:(ansi reset) Image name required"
+        print "Usage: container-images.nu pull <image>"
+        exit 1
+    }
+    let image = ($args | first)
+    print $"(ansi cyan)Pulling:(ansi reset) ($image)"
+    let result = (do { ^container image pull $image } | complete)
+    if $result.exit_code == 0 {
+        print $"(ansi green)Pulled:(ansi reset) ($image)"
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}
+
+def cmd-push [args: list<string>] {
+    ensure-running
+    if ($args | is-empty) {
+        print $"(ansi red)Error:(ansi reset) Image name required"
+        exit 1
+    }
+    let image = ($args | first)
+    print $"(ansi cyan)Pushing:(ansi reset) ($image)"
+    let result = (do { ^container image push $image } | complete)
+    if $result.exit_code == 0 {
+        print $"(ansi green)Pushed:(ansi reset) ($image)"
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}
+
+def cmd-build [args: list<string>] {
+    ensure-running
+    if ($args | is-empty) {
+        print $"(ansi red)Error:(ansi reset) Build context required"
+        print "Usage: container-images.nu build [-t tag] [-f file] [path]"
+        exit 1
+    }
+    print $"(ansi cyan)Building image...(ansi reset)"
+    let result = (do { ^container build ...$args } | complete)
+    if $result.exit_code == 0 {
+        print $result.stdout
+        print $"(ansi green)Build complete(ansi reset)"
+    } else {
+        print $"(ansi red)Build failed:(ansi reset)"
+        print $result.stderr
+        exit 1
+    }
+}
+
+def cmd-save [args: list<string>] {
+    ensure-running
+    if ($args | is-empty) {
+        print $"(ansi red)Error:(ansi reset) Image name and output required"
+        print "Usage: container-images.nu save <image> -o <file>"
+        exit 1
+    }
+    let result = (do { ^container image save ...$args } | complete)
+    if $result.exit_code == 0 {
+        print $"(ansi green)Image saved(ansi reset)"
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}
+
+def cmd-load [args: list<string>] {
+    ensure-running
+    if ($args | is-empty) {
+        print $"(ansi red)Error:(ansi reset) Input file required"
+        print "Usage: container-images.nu load -i <file>"
+        exit 1
+    }
+    let result = (do { ^container image load ...$args } | complete)
+    if $result.exit_code == 0 {
+        print $"(ansi green)Image loaded(ansi reset)"
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}
+
+def cmd-tag [args: list<string>] {
+    ensure-running
+    if ($args | length) < 2 {
+        print $"(ansi red)Error:(ansi reset) Source and target required"
+        print "Usage: container-images.nu tag <source> <target>"
+        exit 1
+    }
+    let source = ($args | first)
+    let target = ($args | get 1)
+    let result = (do { ^container image tag $source $target } | complete)
+    if $result.exit_code == 0 {
+        print $"(ansi green)Tagged:(ansi reset) ($source) -> ($target)"
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}
+
+def cmd-prune [] {
+    ensure-running
+    print $"(ansi yellow)Pruning unused images...(ansi reset)"
+    let result = (do { ^container image prune } | complete)
+    if $result.exit_code == 0 {
+        print $result.stdout
+        print $"(ansi green)Image prune complete(ansi reset)"
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}
+
+def cmd-inspect [args: list<string>] {
+    ensure-running
+    if ($args | is-empty) {
+        print $"(ansi red)Error:(ansi reset) Image name required"
+        exit 1
+    }
+    let image = ($args | first)
+    let result = (do { ^container image inspect $image } | complete)
+    if $result.exit_code == 0 {
+        print $result.stdout
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}

--- a/core/skills/container/scripts/container-lifecycle.nu
+++ b/core/skills/container/scripts/container-lifecycle.nu
@@ -1,0 +1,195 @@
+#!/usr/bin/env nu
+
+# Apple Container lifecycle management
+# Supports: run, ps, start, stop, kill, rm, exec, logs, inspect, stats
+
+def main [
+    command: string   # Subcommand: run, ps, start, stop, kill, rm, exec, logs, inspect, stats
+    ...args: string   # Additional arguments passed to the command
+] {
+    match $command {
+        "run" => { cmd-run $args }
+        "ps" => { cmd-ps $args }
+        "start" => { cmd-start $args }
+        "stop" => { cmd-stop $args }
+        "kill" => { cmd-kill $args }
+        "rm" => { cmd-rm $args }
+        "exec" => { cmd-exec $args }
+        "logs" => { cmd-logs $args }
+        "inspect" => { cmd-inspect $args }
+        "stats" => { cmd-stats }
+        _ => {
+            print $"(ansi red)Error:(ansi reset) Unknown command '($command)'"
+            print "Available: run, ps, start, stop, kill, rm, exec, logs, inspect, stats"
+            exit 1
+        }
+    }
+}
+
+def ensure-running [] {
+    if (which container | is-empty) {
+        print $"(ansi red)Error:(ansi reset) Apple Container CLI not found"
+        exit 1
+    }
+    let status = (do { ^container system status } | complete)
+    if $status.exit_code != 0 {
+        print $"(ansi yellow)Starting Apple Container...(ansi reset)"
+        let start_result = (do { ^container system start } | complete)
+        if $start_result.exit_code != 0 {
+            print $"(ansi red)Error:(ansi reset) Failed to start Apple Container"
+            print $start_result.stderr
+            exit 1
+        }
+        print $"(ansi green)Apple Container started(ansi reset)"
+    }
+}
+
+def cmd-run [args: list<string>] {
+    ensure-running
+    if ($args | is-empty) {
+        print $"(ansi red)Error:(ansi reset) Image name required"
+        print "Usage: container-lifecycle.nu run [flags] <image> [command]"
+        exit 1
+    }
+    let result = (do { ^container run ...$args } | complete)
+    print $result.stdout
+    if $result.exit_code != 0 {
+        print $result.stderr
+        exit $result.exit_code
+    }
+}
+
+def cmd-ps [args: list<string>] {
+    ensure-running
+    print $"(ansi cyan)Containers:(ansi reset)"
+    let result = if ($args | is-empty) {
+        (do { ^container list } | complete)
+    } else {
+        (do { ^container list ...$args } | complete)
+    }
+    if $result.exit_code == 0 {
+        print $result.stdout
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}
+
+def cmd-start [args: list<string>] {
+    ensure-running
+    if ($args | is-empty) {
+        print $"(ansi red)Error:(ansi reset) Container name or ID required"
+        exit 1
+    }
+    let name = ($args | first)
+    let result = (do { ^container start $name } | complete)
+    if $result.exit_code == 0 {
+        print $"(ansi green)Started:(ansi reset) ($name)"
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}
+
+def cmd-stop [args: list<string>] {
+    ensure-running
+    if ($args | is-empty) {
+        print $"(ansi red)Error:(ansi reset) Container name or ID required"
+        exit 1
+    }
+    let name = ($args | first)
+    let result = (do { ^container stop $name } | complete)
+    if $result.exit_code == 0 {
+        print $"(ansi green)Stopped:(ansi reset) ($name)"
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}
+
+def cmd-kill [args: list<string>] {
+    ensure-running
+    if ($args | is-empty) {
+        print $"(ansi red)Error:(ansi reset) Container name or ID required"
+        exit 1
+    }
+    let name = ($args | first)
+    let result = (do { ^container kill $name } | complete)
+    if $result.exit_code == 0 {
+        print $"(ansi green)Killed:(ansi reset) ($name)"
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}
+
+def cmd-rm [args: list<string>] {
+    ensure-running
+    if ($args | is-empty) {
+        print $"(ansi red)Error:(ansi reset) Container name or ID required"
+        exit 1
+    }
+    let result = (do { ^container rm ...$args } | complete)
+    if $result.exit_code == 0 {
+        print $"(ansi green)Removed(ansi reset)"
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}
+
+def cmd-exec [args: list<string>] {
+    ensure-running
+    if ($args | length) < 2 {
+        print $"(ansi red)Error:(ansi reset) Container name and command required"
+        print "Usage: container-lifecycle.nu exec <container> <command>"
+        exit 1
+    }
+    let result = (do { ^container exec ...$args } | complete)
+    print $result.stdout
+    if $result.exit_code != 0 {
+        print $result.stderr
+        exit $result.exit_code
+    }
+}
+
+def cmd-logs [args: list<string>] {
+    ensure-running
+    if ($args | is-empty) {
+        print $"(ansi red)Error:(ansi reset) Container name or ID required"
+        exit 1
+    }
+    let result = (do { ^container logs ...$args } | complete)
+    print $result.stdout
+    if $result.exit_code != 0 {
+        print $result.stderr
+        exit $result.exit_code
+    }
+}
+
+def cmd-inspect [args: list<string>] {
+    ensure-running
+    if ($args | is-empty) {
+        print $"(ansi red)Error:(ansi reset) Container name or ID required"
+        exit 1
+    }
+    let name = ($args | first)
+    let result = (do { ^container inspect $name } | complete)
+    if $result.exit_code == 0 {
+        print $result.stdout
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}
+
+def cmd-stats [] {
+    ensure-running
+    let result = (do { ^container stats } | complete)
+    if $result.exit_code == 0 {
+        print $result.stdout
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit 1
+    }
+}

--- a/core/skills/container/scripts/container-system.nu
+++ b/core/skills/container/scripts/container-system.nu
@@ -1,0 +1,143 @@
+#!/usr/bin/env nu
+
+# Apple Container system service management
+# Supports: start, stop, status, version, logs, df, health
+
+def main [
+    command: string  # Subcommand: start, stop, status, version, logs, df, health
+] {
+    match $command {
+        "start" => { cmd-start }
+        "stop" => { cmd-stop }
+        "status" => { cmd-status }
+        "version" => { cmd-version }
+        "logs" => { cmd-logs }
+        "df" => { cmd-df }
+        "health" => { cmd-health }
+        _ => {
+            print $"(ansi red)Error:(ansi reset) Unknown command '($command)'"
+            print "Available: start, stop, status, version, logs, df, health"
+            exit 1
+        }
+    }
+}
+
+def check-prerequisites [] {
+    if (which container | is-empty) {
+        print $"(ansi red)Error:(ansi reset) Apple Container CLI not found"
+        print "Install from: https://github.com/apple/container/releases"
+        exit 1
+    }
+}
+
+def ensure-running [] {
+    check-prerequisites
+    let status = (do { ^container system status } | complete)
+    if $status.exit_code != 0 {
+        print $"(ansi yellow)Starting Apple Container...(ansi reset)"
+        let start_result = (do { ^container system start } | complete)
+        if $start_result.exit_code != 0 {
+            print $"(ansi red)Error:(ansi reset) Failed to start Apple Container"
+            print $start_result.stderr
+            exit 1
+        }
+        print $"(ansi green)Apple Container started(ansi reset)"
+    }
+}
+
+def cmd-start [] {
+    check-prerequisites
+    let status = (do { ^container system status } | complete)
+    if $status.exit_code == 0 {
+        print $"(ansi green)Apple Container is already running(ansi reset)"
+        return
+    }
+    print $"(ansi yellow)Starting Apple Container...(ansi reset)"
+    let result = (do { ^container system start } | complete)
+    if $result.exit_code != 0 {
+        print $"(ansi red)Error:(ansi reset) Failed to start"
+        print $result.stderr
+        exit 1
+    }
+    print $"(ansi green)Apple Container started(ansi reset)"
+}
+
+def cmd-stop [] {
+    check-prerequisites
+    let status = (do { ^container system status } | complete)
+    if $status.exit_code != 0 {
+        print $"(ansi green)Apple Container is not running(ansi reset)"
+        return
+    }
+    print $"(ansi yellow)Stopping Apple Container...(ansi reset)"
+    let result = (do { ^container system stop } | complete)
+    if $result.exit_code != 0 {
+        print $"(ansi red)Error:(ansi reset) Failed to stop"
+        print $result.stderr
+        exit 1
+    }
+    print $"(ansi green)Apple Container stopped(ansi reset)"
+}
+
+def cmd-status [] {
+    check-prerequisites
+    let result = (do { ^container system status } | complete)
+    if $result.exit_code == 0 {
+        print $"(ansi green)Running(ansi reset)"
+        print $result.stdout
+    } else {
+        print $"(ansi red)Not running(ansi reset)"
+    }
+}
+
+def cmd-version [] {
+    check-prerequisites
+    let result = (do { ^container system version } | complete)
+    print $result.stdout
+}
+
+def cmd-logs [] {
+    check-prerequisites
+    let result = (do { ^container system logs } | complete)
+    print $result.stdout
+}
+
+def cmd-df [] {
+    ensure-running
+    let result = (do { ^container system df } | complete)
+    print $result.stdout
+}
+
+def cmd-health [] {
+    check-prerequisites
+    print $"(ansi cyan)Apple Container Health Check(ansi reset)"
+    print ""
+
+    # System status
+    let status = (do { ^container system status } | complete)
+    if $status.exit_code == 0 {
+        print $"  System:     (ansi green)Running(ansi reset)"
+    } else {
+        print $"  System:     (ansi red)Not running(ansi reset)"
+        return
+    }
+
+    # Version
+    let version = (do { ^container system version } | complete)
+    print $"  Version:    ($version.stdout | str trim)"
+
+    # Disk usage
+    let df = (do { ^container system df } | complete)
+    if $df.exit_code == 0 {
+        print $"  Disk usage:"
+        print $df.stdout
+    }
+
+    # Running containers
+    let containers = (do { ^container list } | complete)
+    if $containers.exit_code == 0 {
+        let lines = ($containers.stdout | str trim | lines)
+        let count = if ($lines | length) > 1 { ($lines | length) - 1 } else { 0 }
+        print $"  Containers: ($count) running"
+    }
+}

--- a/core/skills/container/templates/0.4.1/commands.md
+++ b/core/skills/container/templates/0.4.1/commands.md
@@ -1,0 +1,99 @@
+# Apple Container CLI - Version 0.4.1 Commands
+
+Last stable release in the 0.4.x series.
+
+## Container Lifecycle
+
+| Command | Description |
+|---------|-------------|
+| `container run` | Create and start a container |
+| `container create` | Create a container without starting |
+| `container start` | Start a stopped container |
+| `container stop` | Stop a running container |
+| `container kill` | Force stop a container |
+| `container delete` / `rm` | Remove a container |
+| `container exec` | Execute a command in a running container |
+| `container logs` | View container logs |
+| `container inspect` | Show container details |
+| `container stats` | Show container resource usage |
+| `container prune` | Remove all stopped containers |
+| `container list` / `ls` | List containers |
+
+## Image Management
+
+| Command | Description |
+|---------|-------------|
+| `container image pull` | Pull an image from a registry |
+| `container image push` | Push an image to a registry |
+| `container image save` | Save an image to an archive |
+| `container image load` | Load an image from an archive |
+| `container image tag` | Tag an image |
+| `container image delete` | Remove an image |
+| `container image inspect` | Show image metadata |
+| `container image prune` | Remove unused images |
+| `container image list` / `ls` | List images |
+| `container images` | **Alias for `image list`** (removed in 0.5.0) |
+
+## Build
+
+| Command | Description |
+|---------|-------------|
+| `container build` | Build an image from a Dockerfile/Containerfile |
+| `container builder start` | Start the builder process |
+| `container builder stop` | Stop the builder process |
+| `container builder delete` | Delete the builder |
+| `container builder status` | Check builder status |
+
+## Volume Management
+
+| Command | Description |
+|---------|-------------|
+| `container volume create` | Create a volume |
+| `container volume delete` | Remove a volume |
+| `container volume list` | List volumes |
+| `container volume inspect` | Show volume details |
+| `container volume prune` | Remove unused volumes |
+
+## System Management
+
+| Command | Description |
+|---------|-------------|
+| `container system start` | Start the system service |
+| `container system stop` | Stop the system service |
+| `container system status` | Check service status |
+| `container system version` | Show CLI version |
+| `container system logs` | View system logs |
+| `container system df` | Show disk usage |
+
+### System Properties (Pre-Consolidation)
+
+In 0.4.1, system properties are accessed via scattered subcommands. In 0.5.0, these are consolidated under `container system property`.
+
+### System DNS
+
+| Command | Description |
+|---------|-------------|
+| `container system dns create` | Create a DNS entry |
+| `container system dns delete` | Delete a DNS entry |
+| `container system dns list` | List DNS entries |
+
+### System Kernel
+
+| Command | Description |
+|---------|-------------|
+| `container system kernel set` | Set a custom kernel (no `--force` flag) |
+
+## Registry
+
+| Command | Description |
+|---------|-------------|
+| `container registry login` | Log in to a registry |
+| `container registry logout` | Log out from a registry |
+
+**Keychain ID**: `com.apple.container` (changed in 0.5.0)
+
+## Known Issues Fixed in 0.5.0
+
+- Relative bind mount regression
+- Symlink handling in volume mounts
+- Platform filtering when pulling multi-arch images

--- a/core/skills/container/templates/0.5.0/commands.md
+++ b/core/skills/container/templates/0.5.0/commands.md
@@ -1,0 +1,133 @@
+# Apple Container CLI - Version 0.5.0 Commands
+
+Current release with breaking changes from 0.4.x.
+
+## Breaking Changes from 0.4.1
+
+| Change | 0.4.1 | 0.5.0 |
+|--------|-------|-------|
+| Image listing alias | `container images` available | `container images` **removed** - use `container image list` |
+| System properties | Scattered subcommands | Consolidated to `container system property` subcommands |
+| Registry keychain ID | `com.apple.container` | `com.apple.container.registry` (re-login required) |
+
+## Container Lifecycle
+
+| Command | Description |
+|---------|-------------|
+| `container run` | Create and start a container |
+| `container create` | Create a container without starting |
+| `container start` | Start a stopped container |
+| `container stop` | Stop a running container |
+| `container kill` | Force stop a container |
+| `container delete` / `rm` | Remove a container |
+| `container exec` | Execute a command in a running container |
+| `container logs` | View container logs |
+| `container inspect` | Show container details |
+| `container stats` | Show container resource usage |
+| `container prune` | Remove all stopped containers |
+| `container list` / `ls` | List containers |
+
+## Image Management
+
+| Command | Description |
+|---------|-------------|
+| `container image pull` | Pull an image from a registry |
+| `container image push` | Push an image to a registry |
+| `container image save` | Save image(s) to an archive (**multi-image support added**) |
+| `container image load` | Load an image from an archive |
+| `container image tag` | Tag an image |
+| `container image delete` | Remove an image |
+| `container image inspect` | Show image metadata |
+| `container image prune` | Remove unused images |
+| `container image list` / `ls` | List images |
+
+**Removed**: `container images` alias no longer available.
+
+## Build
+
+| Command | Description |
+|---------|-------------|
+| `container build` | Build an image from a Dockerfile/Containerfile |
+| `container builder start` | Start the builder process |
+| `container builder stop` | Stop the builder process |
+| `container builder delete` | Delete the builder |
+| `container builder status` | Check builder status |
+
+## Network Management
+
+| Command | Description |
+|---------|-------------|
+| `container network create` | Create a network (**`--labels` flag added**) |
+| `container network delete` | Remove a network |
+| `container network list` | List networks |
+| `container network inspect` | Show network details |
+| `container network prune` | Remove unused networks |
+
+## Volume Management
+
+| Command | Description |
+|---------|-------------|
+| `container volume create` | Create a volume |
+| `container volume delete` | Remove a volume |
+| `container volume list` | List volumes |
+| `container volume inspect` | Show volume details |
+| `container volume prune` | Remove unused volumes |
+
+## System Management
+
+| Command | Description |
+|---------|-------------|
+| `container system start` | Start the system service |
+| `container system stop` | Stop the system service |
+| `container system status` | Check service status |
+| `container system version` | Show CLI version |
+| `container system logs` | View system logs |
+| `container system df` | Show disk usage |
+
+### System Properties (Consolidated)
+
+| Command | Description |
+|---------|-------------|
+| `container system property list` | List all properties |
+| `container system property get` | Get a property value |
+| `container system property set` | Set a property value |
+| `container system property clear` | Clear a property |
+
+### System DNS
+
+| Command | Description |
+|---------|-------------|
+| `container system dns create` | Create a DNS entry |
+| `container system dns delete` | Delete a DNS entry |
+| `container system dns list` | List DNS entries |
+
+### System Kernel
+
+| Command | Description |
+|---------|-------------|
+| `container system kernel set` | Set a custom kernel (**`--force` flag added**) |
+
+## Registry
+
+| Command | Description |
+|---------|-------------|
+| `container registry login` | Log in to a registry |
+| `container registry logout` | Log out from a registry |
+
+**Keychain ID**: `com.apple.container.registry` (changed from `com.apple.container`)
+
+## New Features in 0.5.0
+
+- **Multi-image save**: `container image save img1 img2 -o archive.tar`
+- **Network labels**: `container network create --labels env=dev mynet`
+- **Kernel force set**: `container system kernel set --force <path>`
+- **CVE-2026-20613 fix**: Security vulnerability patched
+- **Relative bind mount fix**: Regression from 0.4.x resolved
+- **Symlink handling**: Fixed in volume mounts
+- **Platform filtering**: Fixed for multi-arch image pulls
+
+## Dependencies
+
+- Containerization 0.9.1
+- CZ 0.8.0
+- Builder shim 0.6.1

--- a/core/skills/container/templates/mise.toml
+++ b/core/skills/container/templates/mise.toml
@@ -1,0 +1,313 @@
+# Apple Container CLI Tasks
+# Copy these tasks to your project's mise.toml
+#
+# Prerequisites:
+# - macOS 26+ on Apple silicon
+# - Apple Container CLI installed from GitHub releases
+#
+# Usage:
+#   mise container:start     # Start system service
+#   mise container:stop      # Stop system service
+#   mise container:status    # Show formatted status
+#   mise container:run       # Run container (accepts image arg)
+#   mise container:ps        # List running containers
+#   mise container:images    # List images
+#   mise container:build     # Build from Dockerfile/Containerfile
+#   mise container:prune     # Clean up unused resources
+#   mise container:health    # System status + disk + container count
+#   mise container:df        # Disk usage
+#   mise container:version   # CLI version
+
+[tasks."container:start"]
+description = "Start Apple Container system service"
+run = """
+#!/usr/bin/env nu
+
+if (which container | is-empty) {
+    print "❌ Apple Container CLI not found"
+    exit 1
+}
+
+let status = (do { ^container system status } | complete)
+if $status.exit_code == 0 {
+    print "✅ Apple Container is already running"
+    exit 0
+}
+
+print "🚀 Starting Apple Container..."
+let result = (do { ^container system start } | complete)
+if $result.exit_code != 0 {
+    print $"❌ Failed to start: ($result.stderr)"
+    exit 1
+}
+print "✅ Apple Container started"
+"""
+
+[tasks."container:stop"]
+description = "Stop Apple Container system service"
+run = """
+#!/usr/bin/env nu
+
+if (which container | is-empty) {
+    print "⚠️  Apple Container CLI not found"
+    exit 0
+}
+
+let status = (do { ^container system status } | complete)
+if $status.exit_code != 0 {
+    print "✅ Apple Container is not running"
+    exit 0
+}
+
+print "🛑 Stopping Apple Container..."
+let result = (do { ^container system stop } | complete)
+if $result.exit_code != 0 {
+    print $"❌ Failed to stop: ($result.stderr)"
+    exit 1
+}
+print "✅ Apple Container stopped"
+"""
+
+[tasks."container:status"]
+description = "Show Apple Container system status"
+run = """
+#!/usr/bin/env nu
+
+if (which container | is-empty) {
+    print "❌ Apple Container CLI not found"
+    exit 1
+}
+
+let status = (do { ^container system status } | complete)
+if $status.exit_code == 0 {
+    print "✅ Apple Container is running"
+    print $status.stdout
+} else {
+    print "🔴 Apple Container is not running"
+}
+"""
+
+[tasks."container:run"]
+description = "Run a container (pass image and flags as arguments)"
+run = """
+#!/usr/bin/env nu
+
+def main [...args: string] {
+    if ($args | is-empty) {
+        print "Usage: mise container:run <image> [flags...]"
+        print "Example: mise container:run -- -it --rm ubuntu:latest /bin/bash"
+        exit 1
+    }
+
+    if (which container | is-empty) {
+        print "❌ Apple Container CLI not found"
+        exit 1
+    }
+
+    # Ensure system is running
+    let status = (do { ^container system status } | complete)
+    if $status.exit_code != 0 {
+        print "🚀 Starting Apple Container..."
+        do { ^container system start } | complete
+    }
+
+    let result = (do { ^container run ...$args } | complete)
+    print $result.stdout
+    if $result.exit_code != 0 {
+        print $result.stderr
+        exit $result.exit_code
+    }
+}
+"""
+
+[tasks."container:ps"]
+description = "List running containers"
+run = """
+#!/usr/bin/env nu
+
+if (which container | is-empty) {
+    print "❌ Apple Container CLI not found"
+    exit 1
+}
+
+let status = (do { ^container system status } | complete)
+if $status.exit_code != 0 {
+    print "🔴 Apple Container is not running"
+    exit 1
+}
+
+print "📋 Running containers:"
+let result = (do { ^container list } | complete)
+print $result.stdout
+"""
+
+[tasks."container:images"]
+description = "List container images"
+run = """
+#!/usr/bin/env nu
+
+if (which container | is-empty) {
+    print "❌ Apple Container CLI not found"
+    exit 1
+}
+
+let status = (do { ^container system status } | complete)
+if $status.exit_code != 0 {
+    print "🔴 Apple Container is not running. Run: mise container:start"
+    exit 1
+}
+
+print "📋 Images:"
+let result = (do { ^container image list } | complete)
+print $result.stdout
+"""
+
+[tasks."container:build"]
+description = "Build image from Dockerfile/Containerfile (pass flags as arguments)"
+run = """
+#!/usr/bin/env nu
+
+def main [...args: string] {
+    if ($args | is-empty) {
+        print "Usage: mise container:build -- -t <tag> [path]"
+        print "Example: mise container:build -- -t myapp:latest ."
+        exit 1
+    }
+
+    if (which container | is-empty) {
+        print "❌ Apple Container CLI not found"
+        exit 1
+    }
+
+    # Ensure system is running
+    let status = (do { ^container system status } | complete)
+    if $status.exit_code != 0 {
+        print "🚀 Starting Apple Container..."
+        do { ^container system start } | complete
+    }
+
+    print "🔨 Building image..."
+    let result = (do { ^container build ...$args } | complete)
+    print $result.stdout
+    if $result.exit_code != 0 {
+        print $"❌ Build failed: ($result.stderr)"
+        exit 1
+    }
+    print "✅ Build complete"
+}
+"""
+
+[tasks."container:prune"]
+description = "Clean up all unused container resources"
+run = """
+#!/usr/bin/env nu
+
+if (which container | is-empty) {
+    print "❌ Apple Container CLI not found"
+    exit 1
+}
+
+let status = (do { ^container system status } | complete)
+if $status.exit_code != 0 {
+    print "🔴 Apple Container is not running"
+    exit 1
+}
+
+print "🧹 Pruning unused resources..."
+
+print "  Pruning stopped containers..."
+do { ^container prune } | complete
+
+print "  Pruning unused images..."
+do { ^container image prune } | complete
+
+print "  Pruning unused volumes..."
+do { ^container volume prune } | complete
+
+print "  Pruning unused networks..."
+do { ^container network prune } | complete
+
+print "✅ Cleanup complete"
+
+print ""
+print "📊 Disk usage:"
+let df = (do { ^container system df } | complete)
+print $df.stdout
+"""
+
+[tasks."container:health"]
+description = "Apple Container health check (status + disk + containers)"
+run = """
+#!/usr/bin/env nu
+
+if (which container | is-empty) {
+    print "❌ Apple Container CLI not found"
+    exit 1
+}
+
+print "🏥 Apple Container Health Check"
+print ""
+
+# System status
+let status = (do { ^container system status } | complete)
+if $status.exit_code == 0 {
+    print "  System:     ✅ Running"
+} else {
+    print "  System:     🔴 Not running"
+    exit 0
+}
+
+# Version
+let version = (do { ^container system version } | complete)
+print $"  Version:    ($version.stdout | str trim)"
+
+# Disk usage
+let df = (do { ^container system df } | complete)
+if $df.exit_code == 0 {
+    print "  Disk usage:"
+    print $df.stdout
+}
+
+# Running containers
+let containers = (do { ^container list } | complete)
+if $containers.exit_code == 0 {
+    let lines = ($containers.stdout | str trim | lines)
+    let count = if ($lines | length) > 1 { ($lines | length) - 1 } else { 0 }
+    print $"  Containers: ($count) running"
+}
+"""
+
+[tasks."container:df"]
+description = "Show Apple Container disk usage"
+run = """
+#!/usr/bin/env nu
+
+if (which container | is-empty) {
+    print "❌ Apple Container CLI not found"
+    exit 1
+}
+
+let status = (do { ^container system status } | complete)
+if $status.exit_code != 0 {
+    print "🔴 Apple Container is not running"
+    exit 1
+}
+
+print "📊 Disk usage:"
+let result = (do { ^container system df } | complete)
+print $result.stdout
+"""
+
+[tasks."container:version"]
+description = "Show Apple Container CLI version"
+run = """
+#!/usr/bin/env nu
+
+if (which container | is-empty) {
+    print "❌ Apple Container CLI not found"
+    exit 1
+}
+
+let result = (do { ^container system version } | complete)
+print $result.stdout
+"""

--- a/core/skills/sources.md
+++ b/core/skills/sources.md
@@ -155,10 +155,29 @@ This file documents the sources used to create the core plugin skills.
 - Three sync modes: full, stealth (local-only), contributor (pull-only)
 - VS Code extensions for visual task management and IDE integration
 
+## Container Skill
+
+### Apple Container CLI
+- **URL**: https://github.com/apple/container
+- **Purpose**: macOS-native tool for running Linux containers as lightweight VMs on Apple silicon
+- **Date Accessed**: 2026-02-08
+- **Key Topics**: OCI containers, Virtualization.framework, Apple silicon, container lifecycle, image management, networking, volumes
+
+### Apple Container Command Reference
+- **URL**: https://github.com/apple/container/blob/main/docs/command-reference.md
+- **Purpose**: CLI command documentation for all container subcommands and flags
+- **Key Topics**: Container run/stop/exec, image pull/push/build, network/volume management, system service
+
+### Apple Container Releases
+- **URL**: https://github.com/apple/container/releases
+- **Purpose**: Version tracking, breaking changes between releases, installation packages
+- **Date Accessed**: 2026-02-08
+- **Key Topics**: Version 0.4.1 to 0.5.0 migration, breaking changes, new features, CVE fixes
+
 ## Plugin Information
 
 - **Name**: core
-- **Version**: 0.1.4
+- **Version**: 0.1.9
 - **Description**: Essential development skills: Git, documentation, code review, accessibility, security
-- **Skills**: 11 skills covering fundamental development tools and best practices
+- **Skills**: 12 skills covering fundamental development tools and best practices
 - **Created**: 2025-11-15


### PR DESCRIPTION
 - Add container skill to core plugin with SKILL.md covering system management, container lifecycle, image management, build, network, volume, and registry
  operations                                                                                                                                                     
  - Add 4 Nushell scripts: container-system.nu, container-images.nu, container-lifecycle.nu, container-cleanup.nu
  - Add 11 mise task definitions in templates/mise.toml
  - Add version-specific command references for 0.4.1 and 0.5.0 with breaking changes and migration checklist
  - Add exhaustive CLI command reference as Level 3 deep context
  - Register skill in core plugin.json, marketplace.json, and all-skills meta-plugin
  - Bump core version 0.1.8 -> 0.1.9, all-skills version 0.3.1 -> 0.3.2
  - Update sources.md with Apple Container CLI references