### PR TITLE
feat(container): update skill for apple container 0.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -32,7 +32,7 @@
       "source": "./core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "category": "development",
       "keywords": ["git", "documentation", "code-review", "tools", "beads", "container"]
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/core/.claude-plugin/plugin.json
+++ b/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/core/skills/container/references/command-reference.md
+++ b/core/skills/container/references/command-reference.md
@@ -29,6 +29,28 @@ container run [FLAGS] IMAGE [COMMAND] [ARGS...]
 | `--entrypoint` | | Override default entrypoint |
 | `--hostname` | `-h` | Container hostname |
 | `--restart` | | Restart policy (`no`, `always`, `on-failure`) |
+| `--cpus` | | CPU limit (0.9.0+) |
+| `--memory` | | Memory limit, e.g., `4g` (0.9.0+) |
+| `--read-only` | | Read-only rootfs (0.8.0+) |
+| `--rosetta` | | Enable Rosetta x86_64 emulation (0.7.0+) |
+| `--mac-address` | | Custom MAC address (0.7.0+) |
+| `--dns` | | DNS server address |
+| `--dns-domain` | | DNS domain |
+| `--dns-option` | | DNS option |
+| `--dns-search` | | DNS search domain |
+| `--no-dns` | | Disable DNS |
+| `--mount` | | Mount specification |
+| `--tmpfs` | | Mount a tmpfs filesystem |
+| `--cidfile` | | Write container ID to file |
+| `--publish-socket` | | Publish a socket |
+| `--init-image` | | Init image for VM |
+| `--kernel` | | Custom kernel for VM |
+| `--virtualization` | | Virtualization backend |
+| `--runtime` | | Container runtime |
+| `--scheme` | | Image scheme |
+| `--progress` | | Progress output (`none`, `ansi`) (0.7.0+) |
+| `--gid` | | Group ID |
+| `--uid` | | User ID |
 
 Common combinations:
 - `-it` - Interactive terminal session
@@ -43,7 +65,7 @@ Create a container without starting it.
 container create [FLAGS] IMAGE [COMMAND] [ARGS...]
 ```
 
-Accepts all the same flags as `container run` except `--detach`.
+Accepts all the same flags as `container run` except `--detach`. Includes `--read-only` (0.8.0+), `--cpus`/`--memory` (0.9.0+), and all DNS flags.
 
 ### `container start`
 
@@ -98,6 +120,7 @@ container exec [FLAGS] CONTAINER COMMAND [ARGS...]
 |------|-------|-------------|
 | `--interactive` | `-i` | Keep STDIN open |
 | `--tty` | `-t` | Allocate a pseudo-TTY |
+| `--detach` | `-d` | Run in background (0.7.0+) |
 | `--env` | `-e` | Set environment variable |
 | `--workdir` | `-w` | Working directory |
 | `--user` | `-u` | Run as user |
@@ -196,7 +219,7 @@ container image save [FLAGS] IMAGE [IMAGE...]
 |------|-------|-------------|
 | `--output` | `-o` | Output file path |
 
-**Note**: Multi-image save added in 0.5.0.
+**Notes**: Multi-image save added in 0.5.0. Stdio support added in 0.7.0+ (pipe to/from stdout/stdin).
 
 ### `container image load`
 
@@ -226,9 +249,11 @@ Remove one or more images.
 container image delete IMAGE [IMAGE...]
 ```
 
+**Note**: `--force` flag available in 0.9.0+ (verify syntax with `container image delete --help`).
+
 ### `container image inspect`
 
-Show detailed information about an image.
+Show detailed information about an image. Enhanced output in 0.9.0+.
 
 ```
 container image inspect IMAGE
@@ -244,11 +269,12 @@ container image prune
 
 | Flag | Short | Description |
 |------|-------|-------------|
+| `--all` | `-a` | Remove all unused images, not just dangling (0.7.0+) |
 | `--force` | `-f` | Skip confirmation |
 
 ### `container image list` / `container image ls`
 
-List images.
+List images. Full size included in JSON output (0.9.0+).
 
 ```
 container image list [FLAGS]
@@ -279,7 +305,14 @@ container build [FLAGS] PATH
 | `--target` | | Set target build stage |
 | `--platform` | | Target platform |
 | `--output` | `-o` | Output destination (`type=local,dest=path`) |
-| `--progress` | | Progress output type (`auto`, `plain`, `tty`) |
+| `--progress` | | Progress output (`none`, `ansi`) (0.7.0+, replaces `--disable-progress-updates`) |
+| `--network` | | Network mode, e.g., `none` (0.6.0+) |
+| `--pull` | | Pull policy |
+| `--quiet` | `-q` | Suppress build output |
+| `--cpus` | | CPU limit for build |
+| `--memory` | | Memory limit for build |
+| `--vsock-port` | | Vsock port for builder |
+| `--dns` | | DNS server for build (0.9.0+) |
 
 ### `container builder start`
 
@@ -325,8 +358,10 @@ container network create [FLAGS] NAME
 
 | Flag | Description |
 |------|-------------|
-| `--subnet` | Subnet in CIDR format (e.g., `10.0.0.0/24`) |
+| `--subnet` | Subnet in CIDR format (e.g., `10.0.0.0/24`) (0.6.0+) |
 | `--labels` | Labels for the network (0.5.0+) |
+
+**Note**: Full IPv6 support in 0.8.0+. Host-only and isolated network capabilities in 0.9.0+ (verify flag syntax with `container network create --help`).
 
 ### `container network delete`
 

--- a/core/skills/container/templates/0.6.0/commands.md
+++ b/core/skills/container/templates/0.6.0/commands.md
@@ -1,0 +1,58 @@
+# Apple Container CLI - Version 0.6.0 Commands
+
+Changes from 0.5.0.
+
+## Breaking Changes from 0.5.0
+
+| Change | 0.5.0 | 0.6.0 |
+|--------|-------|-------|
+| Image store directory | `.build` | `builder` |
+
+## New Features in 0.6.0
+
+- Multiple `--tag` flags on build (`container build -t img:latest -t img:v1 .`)
+- `--network none` for builds (isolated builds)
+- `container network create --subnet` for custom subnets
+- Anonymous volumes support
+- `container volume prune` to remove unused volumes
+- Containerfile fallback (builder uses Containerfile when no Dockerfile found)
+- DNS list `--format`/`--quiet` flags (`container system dns list --format json`)
+
+## Container Lifecycle
+
+No changes from 0.5.0.
+
+## Image Management
+
+No changes from 0.5.0.
+
+## Build
+
+| Command | Description |
+|---------|-------------|
+| `container build` | **Multiple `--tag` flags; `--network none`; Containerfile fallback** |
+
+## Network Management
+
+| Command | Description |
+|---------|-------------|
+| `container network create` | **`--subnet` flag added** |
+
+## Volume Management
+
+| Command | Description |
+|---------|-------------|
+| `container volume create` | **Anonymous volumes supported** |
+| `container volume prune` | **New command** |
+
+## System Management
+
+### System DNS
+
+| Command | Description |
+|---------|-------------|
+| `container system dns list` | **`--format`/`--quiet` flags added** |
+
+## Dependencies
+
+- Containerization 0.12.1

--- a/core/skills/container/templates/0.7.0/commands.md
+++ b/core/skills/container/templates/0.7.0/commands.md
@@ -1,0 +1,64 @@
+# Apple Container CLI - Version 0.7.0 Commands
+
+Changes from 0.6.0.
+
+## Breaking Changes from 0.6.0
+
+| Change | 0.6.0 | 0.7.0 |
+|--------|-------|-------|
+| Progress flag | `--disable-progress-updates` | `--progress none\|ansi` |
+
+## New Features in 0.7.0
+
+- `--rosetta` flag for x86_64 emulation via Rosetta on Apple silicon
+- `--progress none|ansi` replaces `--disable-progress-updates`
+- Image download progress display
+- Stdio support for `container image save` and `container image load` (pipe to/from stdout/stdin)
+- Dockerfile from stdin (`container build -t img:latest -f - .`)
+- `container stats` for resource usage monitoring
+- Port range publishing (`-p 8000-8010:8000-8010`)
+- `--mac-address` flag on `container run`
+- `container system df` for disk usage reporting
+- `container image prune -a` to prune all unused images (not just dangling)
+- `container exec -d` for detached command execution
+- Network `creationDate` field in network inspect output
+
+## Container Lifecycle
+
+| Command | Description |
+|---------|-------------|
+| `container run` | **`--rosetta`, `--mac-address`, `--progress none\|ansi` flags added; port range publishing** |
+| `container exec` | **`-d` (detach) flag added** |
+| `container stats` | **New command** |
+
+## Image Management
+
+| Command | Description |
+|---------|-------------|
+| `container image pull` | **Download progress display** |
+| `container image save` | **Stdio support (pipe to stdout)** |
+| `container image load` | **Stdio support (pipe from stdin)** |
+| `container image prune` | **`-a` flag to prune all unused images** |
+
+## Build
+
+| Command | Description |
+|---------|-------------|
+| `container build` | **Dockerfile from stdin (`-f -`); `--progress` flag** |
+
+## Network Management
+
+| Command | Description |
+|---------|-------------|
+| `container network list` | **`creationDate` field added** |
+
+## System Management
+
+| Command | Description |
+|---------|-------------|
+| `container system df` | **New command** |
+
+## Dependencies
+
+- Containerization 0.16.0
+- Builder Shim 0.7.0

--- a/core/skills/container/templates/0.8.0/commands.md
+++ b/core/skills/container/templates/0.8.0/commands.md
@@ -1,0 +1,56 @@
+# Apple Container CLI - Version 0.8.0 Commands
+
+Changes from 0.7.0.
+
+## Breaking Changes from 0.7.0
+
+| Change | 0.7.0 | 0.8.0 |
+|--------|-------|-------|
+| Client API | Previous layout | Reorganized |
+| Subnet allocation | Previous defaults | Changed defaults |
+
+## New Features in 0.8.0
+
+- `--read-only` flag for `container run` and `container create` (read-only rootfs)
+- Architecture aliases: `amd64` = `x86_64`, `arm64` = `aarch64`
+- `container network prune` to remove unused networks
+- Full IPv6 support for container networking
+- Volume relative paths (bind mounts accept relative paths)
+- Environment variables from named pipes
+- CVE-2026-20613 security fix
+
+## Container Lifecycle
+
+| Command | Description |
+|---------|-------------|
+| `container run` | **`--read-only` flag added** |
+| `container create` | **`--read-only` flag added** |
+
+## Image Management
+
+| Command | Description |
+|---------|-------------|
+| `container image pull` | **Architecture aliases: `amd64`/`arm64`/`x86_64`/`aarch64`** |
+
+## Build
+
+| Command | Description |
+|---------|-------------|
+| `container build` | **Architecture aliases supported in `--platform`** |
+
+## Network Management
+
+| Command | Description |
+|---------|-------------|
+| `container network create` | **Full IPv6 support** |
+| `container network prune` | **New command** |
+
+## Volume Management
+
+| Command | Description |
+|---------|-------------|
+| `container volume create` | **Relative paths for bind mounts** |
+
+## Dependencies
+
+- Containerization 0.21.1

--- a/core/skills/container/templates/0.9.0/commands.md
+++ b/core/skills/container/templates/0.9.0/commands.md
@@ -1,0 +1,56 @@
+# Apple Container CLI - Version 0.9.0 Commands
+
+Changes from 0.8.0.
+
+## New Features in 0.9.0
+
+- Resource limits: `--cpus` and `--memory` flags on `container run`/`container create`
+- `host.docker.internal` support for accessing host services from containers
+- Host-only and isolated network capabilities (verify flag syntax with `container network create --help`)
+- `--dns` flag on `container build`
+- `--force` on `container image delete` (verify flag syntax with `container image delete --help`)
+- zstd compression for image layers and kernels
+- Container prune improvements
+- Enhanced image inspection output
+- Full size in `container image list` JSON output
+- `container system stop` works across all launchd domains
+- Kata 3.26.0 kernel
+
+## Container Lifecycle
+
+| Command | Description |
+|---------|-------------|
+| `container run` | **`--cpus`, `--memory` flags added** |
+| `container create` | **`--cpus`, `--memory` flags added** |
+| `container prune` | **Improved behavior** |
+
+## Image Management
+
+| Command | Description |
+|---------|-------------|
+| `container image delete` | **`--force` flag added (verify with `--help`)** |
+| `container image inspect` | **Enhanced output** |
+| `container image list` / `ls` | **Full size in JSON output** |
+
+## Build
+
+| Command | Description |
+|---------|-------------|
+| `container build` | **`--dns` flag added** |
+
+## Network Management
+
+| Command | Description |
+|---------|-------------|
+| `container network create` | **Host-only and isolated network capabilities (verify flags with `--help`)** |
+
+## System Management
+
+| Command | Description |
+|---------|-------------|
+| `container system stop` | **Works across all launchd domains** |
+
+## Dependencies
+
+- Containerization 0.24.0
+- Kata kernel 3.26.0

--- a/core/skills/sources.md
+++ b/core/skills/sources.md
@@ -171,13 +171,33 @@ This file documents the sources used to create the core plugin skills.
 ### Apple Container Releases
 - **URL**: https://github.com/apple/container/releases
 - **Purpose**: Version tracking, breaking changes between releases, installation packages
-- **Date Accessed**: 2026-02-08
-- **Key Topics**: Version 0.4.1 to 0.5.0 migration, breaking changes, new features, CVE fixes
+- **Date Accessed**: 2026-02-21
+- **Key Topics**: Version migration (0.4.1 through 0.9.0), breaking changes, new features, CVE fixes
+
+### Apple Container Release 0.6.0
+- **URL**: https://github.com/apple/container/releases/tag/0.6.0
+- **Purpose**: Version 0.6.0 release notes
+- **Key Topics**: Image store directory change, multiple --tag on build, --network none, subnet support, anonymous volumes, volume prune, Containerfile fallback, DNS list flags
+
+### Apple Container Release 0.7.0
+- **URL**: https://github.com/apple/container/releases/tag/0.7.0
+- **Purpose**: Version 0.7.0 release notes
+- **Key Topics**: Rosetta flag, progress flag change, stdio save/load, stdin Dockerfile, container stats, port range publishing, mac-address, system df, image prune -a, exec -d, network creationDate
+
+### Apple Container Release 0.8.0
+- **URL**: https://github.com/apple/container/releases/tag/0.8.0
+- **Purpose**: Version 0.8.0 release notes
+- **Key Topics**: Read-only rootfs, architecture aliases, network prune, IPv6, volume relative paths, named pipe env vars, CVE-2026-20613, client API reorganization
+
+### Apple Container Release 0.9.0
+- **URL**: https://github.com/apple/container/releases/tag/0.9.0
+- **Purpose**: Version 0.9.0 release notes
+- **Key Topics**: Resource limits (--cpus/--memory), host.docker.internal, host-only/isolated networks, --dns on build, --force on image delete, zstd compression, Kata 3.26.0
 
 ## Plugin Information
 
 - **Name**: core
-- **Version**: 0.1.9
+- **Version**: 0.1.10
 - **Description**: Essential development skills: Git, documentation, code review, accessibility, security
 - **Skills**: 12 skills covering fundamental development tools and best practices
 - **Created**: 2025-11-15


### PR DESCRIPTION
- Add per-version templates for 0.6.0, 0.7.0, 0.8.0, and 0.9.0
- Update SKILL.md with new flag examples (--cpus, --memory, --read-only, --rosetta, --dns, --mac-address, host.docker.internal)
- Update command-reference.md with verified flags and version annotations
- Update version differences section with cumulative 0.5.0-0.9.0 breaking changes and migration checklist
- Add release source entries for 0.6.0-0.9.0 to sources.md
- Bump core plugin to 0.1.10, all-skills to 0.3.3