### PR TITLE
feat(beads): add two-tier skill discovery with runtime awareness

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -32,7 +32,7 @@
       "source": "./core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "category": "development",
       "keywords": ["git", "documentation", "code-review", "tools", "beads", "container"]
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/core/.claude-plugin/plugin.json
+++ b/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/core/skills/beads/SKILL.md
+++ b/core/skills/beads/SKILL.md
@@ -522,6 +522,7 @@ type:bug, type:feature, type:chore
 priority:high, priority:medium, priority:low
 status:wip, status:blocked, status:review
 sprint:42, epic:auth
+skill:git, skill:security, skill:rust    # Suggested skills for task execution
 ```
 
 ### Dependency Best Practices
@@ -537,6 +538,36 @@ sprint:42, epic:auth
 - Poll `bd ready` for task queue
 - Close tasks atomically after completion
 - Sync frequently in multi-agent scenarios
+
+### Skills-Aware Task Creation
+
+When creating tasks, analyze the task domain and suggest relevant marketplace skills using `skill:` labels. This helps the beads-worker agent (and humans) know which skills to activate during execution.
+
+**How to suggest skills:**
+
+1. Identify the task domain from its title, description, and labels
+2. Consult `references/skill-catalog.md` for the keyword-to-skill mapping (Tier 1: static catalog)
+3. Check available skills in the current session for additional matches beyond the catalog (Tier 2: runtime discovery)
+4. Add 1-3 `skill:` labels for the most relevant skills from either tier
+
+**Matching priority:** explicit `skill:` labels > static catalog keyword match > runtime skill description match.
+
+**Note:** `skill:` labels work with any installed skill, not just those in the static catalog. If a user has third-party skills loaded, those can be suggested and activated by the worker.
+
+**Example with skill suggestions:**
+
+```bash
+bd create "Add pre-commit gitleaks scanning" \
+  --labels "type:feature,skill:security,skill:git" \
+  --description "## Task
+Integrate gitleaks pre-commit hook for secret detection.
+
+## Suggested Skills
+- security: gitleaks configuration and scanning patterns
+- git: pre-commit hook setup and git workflow integration"
+```
+
+Include a `## Suggested Skills` block in the description when skills need context beyond the label name. This tells the worker *why* each skill is relevant.
 
 ## IDE Integration
 
@@ -621,6 +652,10 @@ bd show abc1234  # Instead of abc1
 # Full IDs are always unique
 bd show abc12345678
 ```
+
+## References
+
+- `references/skill-catalog.md`: Skill catalog with keyword triggers for task matching
 
 ## Key Principles
 

--- a/core/skills/beads/agents/beads-worker.md
+++ b/core/skills/beads/agents/beads-worker.md
@@ -84,6 +84,22 @@ bd show <task_id> --json
 
 Extract: `title`, `description`, `labels`, `comments`.
 
+#### 2b. Extract Skill Suggestions
+
+From the task JSON, extract any `skill:*` labels:
+
+```bash
+bd show <task_id> --json | jq -r '.labels[] | select(startswith("skill:")) | ltrimstr("skill:")'
+```
+
+Note the suggested skills for activation during execution. When resolving skills:
+
+1. **Explicit `skill:` labels** - Use directly (highest priority). These may reference any installed skill, not just those in the static catalog.
+2. **Static catalog** - If no `skill:` labels are present, consult `references/skill-catalog.md` to match task keywords to relevant skills.
+3. **Runtime discovery** - Also check available skills in the current session. Any loaded skill whose name or description matches the task domain is a valid candidate, even if it does not appear in the static catalog.
+
+Activate any valid skill from the available skills list during execution, regardless of whether it appears in the static catalog.
+
 #### 3. Execute Work
 
 (Same as below)
@@ -111,6 +127,8 @@ Continue until `bd ready --json` returns empty.
 ---
 
 ## Execute Work
+
+Before dispatching work, activate any suggested skills from the `skill:` labels. Load the corresponding skill context so domain-specific knowledge is available during execution.
 
 Match task pattern to action:
 
@@ -154,7 +172,7 @@ Continue to next task.
 ```
 ## Beads Worker Summary
 
-Completed: [id] title - summary
+Completed: [id] title - summary (skills: skill1, skill2)
 Failed: [id] title - reason
 Remaining: N tasks
 ```

--- a/core/skills/beads/references/skill-catalog.md
+++ b/core/skills/beads/references/skill-catalog.md
@@ -1,0 +1,128 @@
+# Skill Catalog for Task Matching
+
+This reference maps marketplace skills to trigger keywords for suggesting relevant skills when creating beads tasks.
+
+## Matching Rules (Two-Tier Discovery)
+
+When creating a task, match skills to the task using this priority:
+
+1. **Explicit `skill:` labels** - Author specified skills directly (highest priority)
+2. **Tier 1 - Static catalog keyword match** - Task labels or description match trigger keywords in the tables below
+3. **Tier 2 - Runtime skill discovery** - Check available skills in the current session for additional matches beyond the catalog
+4. **Description keyword match** - Task title/description contains trigger keywords from either tier
+
+Suggest **1-3 skills** per task. Prefer fewer, more relevant skills over many loosely related ones.
+
+### Tier 1: Static Catalog (Known Skills)
+
+The keyword mapping tables below cover known marketplace skills with curated trigger keywords. These provide reliable keyword-based matching for skills in this repository.
+
+### Tier 2: Runtime Discovery (All Loaded Skills)
+
+The static catalog does not cover every possible skill. Users may have skills installed from other marketplaces or plugins. To discover these:
+
+1. Check the available skills listing in the current session (visible in the system prompt as loaded skill names and descriptions)
+2. For any loaded skill **not** in the static catalog, analyze its name and description against the task domain
+3. If a runtime-discovered skill is relevant, suggest it with a `skill:` label just like catalog skills
+
+Runtime discovery ensures that third-party or user-created skills can be suggested even without curated keyword mappings.
+
+## Skill-to-Keyword Mapping
+
+### claude-code Plugin
+
+| Skill | Trigger Keywords |
+|-------|-----------------|
+| `plugin-marketplace` | marketplace, plugin registry, marketplace.json, plugin distribution |
+| `claude-plugins` | plugin.json, plugin schema, plugin validation, plugin creation |
+| `claude-commands` | slash command, custom command, command argument |
+| `claude-agents` | custom agent, agent tools, specialized agent, subagent |
+| `claude-skills` | skill creation, SKILL.md, progressive disclosure, skill structure |
+| `claude-hooks` | hooks, event-driven, lifecycle event, tool call automation |
+
+### core Plugin
+
+| Skill | Trigger Keywords |
+|-------|-----------------|
+| `git` | git, commit, branch, rebase, merge, conflict, version control |
+| `mise` | mise, tool version, runtime, environment variable, project task |
+| `nushell` | nushell, nu script, structured data, pipeline, cross-platform script |
+| `documentation` | documentation, README, API docs, guide, technical writing |
+| `code-review` | code review, pull request review, audit, code quality, feedback |
+| `accessibility` | accessibility, WCAG, a11y, screen reader, WAI, ARIA |
+| `material-design` | material design, material you, android theme, dynamic color |
+| `twelve-factor` | twelve-factor, 12-factor, microservice, cloud-native, kubernetes |
+| `anti-fabrication` | validation, claims verification, factual accuracy, metrics |
+| `security` | security, secret detection, gitleaks, credential scan, API key leak |
+| `beads` | beads, task management, dependency tracking, issue tracker |
+| `container` | container, OCI, linux container, apple container, macOS container |
+
+### dagu Plugin
+
+| Skill | Trigger Keywords |
+|-------|-----------------|
+| `dagu-workflows` | dagu, workflow definition, DAG, YAML workflow, scheduling |
+| `dagu-webui` | dagu UI, workflow monitoring, DAG browser |
+| `dagu-rest-api` | dagu API, workflow API, execution status API |
+
+### elixir Plugin
+
+| Skill | Trigger Keywords |
+|-------|-----------------|
+| `elixir-anti-patterns` | elixir anti-pattern, elixir smell, elixir refactor |
+| `phoenix` | phoenix, liveview, phoenix context, phoenix channel |
+| `otp` | OTP, genserver, supervision tree, fault-tolerant, BEAM |
+| `testing` | elixir test, ExUnit, property-based test, elixir mock |
+| `config` | elixir config, runtime.exs, config.exs, Application.get_env |
+
+### github Plugin
+
+| Skill | Trigger Keywords |
+|-------|-----------------|
+| `actions` | github action, custom action, action runner, action marketplace |
+| `workflows` | github workflow, CI/CD pipeline, workflow trigger, workflow artifact |
+| `act` | act, local action test, workflow debug local |
+
+### rust Plugin
+
+| Skill | Trigger Keywords |
+|-------|-----------------|
+| `rust` | rust, ownership, borrowing, cargo, async rust, lifetime |
+
+### ui Plugin
+
+| Skill | Trigger Keywords |
+|-------|-----------------|
+| `daisyui` | daisyUI, tailwind component, UI theme, responsive design |
+
+## Matching Examples
+
+### Example 1: Explicit labels
+
+Task: `bd create "Add pre-commit secret scanning" --labels "type:feature,skill:security,skill:git"`
+
+Skills come directly from labels: `security`, `git`.
+
+### Example 2: Label keyword match
+
+Task: `bd create "Fix Phoenix LiveView crash" --labels "type:bug,elixir"`
+
+Label `elixir` matches the elixir plugin. Title contains "Phoenix" and "LiveView" which trigger `phoenix`. Suggested: `skill:phoenix`.
+
+### Example 3: Description keyword match
+
+Task: `bd create "Set up CI/CD pipeline" --description "Create GitHub Actions workflow for running tests and deploying"`
+
+Description contains "GitHub Actions" and "workflow" which trigger `workflows` and `actions`. Suggested: `skill:workflows`, `skill:actions`.
+
+### Example 4: Cross-plugin match
+
+Task: `bd create "Containerize Elixir app" --labels "type:feature"`
+
+Title contains "Container" (triggers `container`) and "Elixir" (triggers elixir skills). Description analysis needed to narrow elixir skills. Suggested: `skill:container`, `skill:twelve-factor`.
+
+### Example 5: Runtime discovery (third-party skill)
+
+Task: `bd create "Add type hints to data pipeline" --labels "type:feature"`
+
+Title contains "type hints" and "data pipeline". No static catalog match. However, a `python` skill from another marketplace is loaded in the current session with description "Python development patterns and type system." The skill name and description match the task domain. Suggested: `skill:python`.


### PR DESCRIPTION
- Add skill-catalog.md with keyword-to-skill mapping for 31 marketplace skills
- Add two-tier discovery: static catalog (Tier 1) + runtime session skills (Tier 2)
- Update SKILL.md with skills-aware task creation instructions and runtime discovery step
- Extend beads-worker agent to resolve skills from both catalog and runtime-available skills
- Bump core plugin to 0.1.11 and all-skills to 0.3.4