### PR TITLE
feat(phoenix): add tidewave MCP dev tools integration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,8 +49,8 @@
       "name": "elixir",
       "source": "./elixir",
       "strict": true,
-      "description": "Elixir development skills: Phoenix, OTP, testing, configuration",
-      "version": "0.1.1",
+      "description": "Elixir development skills: Phoenix, OTP, Tidewave MCP, testing, configuration",
+      "version": "0.1.2",
       "category": "language",
       "keywords": ["elixir", "phoenix", "otp", "beam"]
     },

--- a/elixir/.claude-plugin/plugin.json
+++ b/elixir/.claude-plugin/plugin.json
@@ -1,13 +1,16 @@
 {
   "name": "elixir",
-  "version": "0.1.1",
-  "description": "Elixir development skills: Phoenix, OTP, testing, configuration, and anti-patterns",
+  "version": "0.1.2",
+  "description": "Elixir development skills: Phoenix, OTP, Tidewave MCP, testing, configuration, and anti-patterns",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
   "keywords": ["elixir", "phoenix", "otp", "beam", "erlang"],
+  "agents": [
+    "./agents/tidewave.md"
+  ],
   "skills": [
     "./skills/anti-patterns",
     "./skills/phoenix",

--- a/elixir/agents/tidewave.md
+++ b/elixir/agents/tidewave.md
@@ -1,0 +1,41 @@
+---
+name: tidewave
+description: Introspect and debug a running Phoenix application using Tidewave MCP tools
+tools: Read, Glob, Grep, mcp__tidewave__project_eval, mcp__tidewave__execute_sql_query, mcp__tidewave__get_ecto_schemas, mcp__tidewave__get_ash_resources, mcp__tidewave__get_docs, mcp__tidewave__search_package_docs, mcp__tidewave__get_source_location, mcp__tidewave__get_models, mcp__tidewave__get_logs
+model: sonnet
+---
+
+You are a Phoenix runtime introspection agent. Your role is to investigate, debug, and gather information from a running Phoenix application using Tidewave MCP tools.
+
+## Workflow
+
+1. **Discover**: Use `get_ecto_schemas` or `get_models` to understand application structure
+2. **Locate**: Use `get_source_location` to find module/function source paths
+3. **Inspect**: Use `get_docs` or `search_package_docs` for documentation lookup
+4. **Evaluate**: Use `project_eval` to execute Elixir code in the running app
+5. **Query**: Use `execute_sql_query` to inspect database state
+6. **Debug**: Use `get_logs` to review server output
+7. **Cross-reference**: Use Read, Glob, Grep to examine source code alongside runtime state
+
+## Guidelines
+
+- **Runtime-first**: Prefer Tidewave tools over static code analysis when the app is running
+- **Non-destructive**: Use read-only queries and safe evaluations by default
+- **Contextual**: Combine runtime introspection with source code reading for full picture
+- **Specific**: Report exact module names, schema fields, and query results
+- **Concise**: Summarize findings with relevant data, not verbose explanations
+
+## Tool Selection
+
+| Need | Tool |
+|------|------|
+| List schemas and fields | `get_ecto_schemas` |
+| List Ash resources | `get_ash_resources` |
+| Find module source file | `get_source_location` |
+| List all modules | `get_models` |
+| Read module/function docs | `get_docs` |
+| Search hex dependency docs | `search_package_docs` |
+| Run Elixir code in app | `project_eval` |
+| Run SQL against database | `execute_sql_query` |
+| Check server logs | `get_logs` |
+| Read source files | Read, Glob, Grep |

--- a/elixir/skills/phoenix/SKILL.md
+++ b/elixir/skills/phoenix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phoenix-framework
-description: Guide for Phoenix web applications. Use when building Phoenix apps, implementing LiveView, designing contexts, or setting up channels.
+description: Guide for Phoenix web applications. Use when building Phoenix apps, implementing LiveView, designing contexts, setting up channels, or integrating Tidewave MCP dev tools.
 ---
 
 # Phoenix Framework Development
@@ -490,6 +490,56 @@ end
 - Validate file uploads (type, size, content)
 - Use prepared statements (Ecto does this automatically)
 - Implement proper authentication and authorization
+
+## Tidewave MCP Dev Tools
+
+Tidewave connects AI coding assistants to running Phoenix applications via MCP, exposing runtime introspection tools (Ecto schemas, code execution, docs, logs, SQL queries).
+
+### When to Use Tidewave
+
+- Introspecting a running Phoenix app (schemas, modules, logs)
+- Executing Elixir code or SQL queries against a live dev server
+- Looking up documentation for project dependencies at runtime
+- Debugging LiveView components with source annotations
+
+### Quick Setup
+
+1. Add dependency to `mix.exs`:
+
+```elixir
+{:tidewave, "~> 0.5", only: :dev}
+```
+
+2. Add plug to `endpoint.ex` (before `code_reloading?`):
+
+```elixir
+if Mix.env() == :dev do
+  plug Tidewave
+end
+```
+
+3. Connect Claude Code to the MCP server:
+
+```bash
+claude mcp add --transport http tidewave http://localhost:4000/tidewave/mcp
+```
+
+### Key MCP Tools
+
+| Tool | Purpose |
+|------|---------|
+| `project_eval` | Execute Elixir code in the running app |
+| `execute_sql_query` | Run SQL queries against the database |
+| `get_ecto_schemas` | List schemas with fields and associations |
+| `get_docs` | Retrieve module/function documentation |
+| `get_source_location` | Find source file paths and line numbers |
+| `get_logs` | Access server logs |
+
+### Security
+
+Tidewave is dev-only. Always guard with `Mix.env() == :dev` and never deploy to production. It only accepts localhost requests by default.
+
+For full setup details, configuration options, LiveView debug annotations, and troubleshooting, see `references/tidewave.md`.
 
 ## Key Principles
 

--- a/elixir/skills/phoenix/references/tidewave.md
+++ b/elixir/skills/phoenix/references/tidewave.md
@@ -1,0 +1,181 @@
+# Tidewave MCP Dev Tools for Phoenix
+
+Tidewave is a dev tool by Dashbit that connects AI coding assistants to running Phoenix applications via the Model Context Protocol (MCP). It exposes runtime introspection tools that make AI assistants aware of live application state — Ecto schemas, code execution, documentation lookup, log inspection, and SQL queries.
+
+## Installation
+
+### New Projects (via Igniter)
+
+```bash
+mix archive.install hex igniter_new
+mix igniter.install tidewave
+```
+
+### Existing Projects (Manual)
+
+1. Add the dependency to `mix.exs`:
+
+```elixir
+defp deps do
+  [
+    {:tidewave, "~> 0.5", only: :dev}
+  ]
+end
+```
+
+2. Add the plug to `lib/my_app_web/endpoint.ex` before the `code_reloading?` block:
+
+```elixir
+if Mix.env() == :dev do
+  plug Tidewave
+end
+
+if code_reloading? do
+  # ...existing code reload plugs...
+end
+```
+
+3. Fetch dependencies:
+
+```bash
+mix deps.get
+```
+
+### Umbrella Projects
+
+Apply manual steps to the application defining your Phoenix endpoint (typically `apps/your_app_web`).
+
+### Non-Phoenix Elixir Projects
+
+Combine Bandit with Tidewave using a mix alias for standalone MCP server functionality.
+
+## MCP Server Configuration
+
+Tidewave exposes an MCP server at `/tidewave/mcp` on your Phoenix app's port. The transport type is HTTP (streamable).
+
+Default URL: `http://localhost:4000/tidewave/mcp`
+
+### Claude Code Setup
+
+Add the Tidewave MCP server to Claude Code:
+
+```bash
+claude mcp add --transport http tidewave http://localhost:4000/tidewave/mcp
+```
+
+Replace `4000` with your application's port if different.
+
+Add rules to `CLAUDE.md` to encourage MCP tool usage:
+
+```markdown
+Always use Tidewave's tools for evaluating code, querying the database, etc.
+Use `get_docs` to access documentation and the `get_source_location` tool
+to find module/function definitions.
+```
+
+### Other Editors
+
+For other MCP-compatible editors, point to the same HTTP endpoint:
+
+| Editor | Config File | URL Key |
+|--------|-------------|---------|
+| Cursor | `.cursor/mcp.json` | `mcpServers.tidewave.url` |
+| VS Code | `.vscode/mcp.json` | `servers.tidewave.url` |
+| Zed | Zed `settings.json` | `context_servers.tidewave.settings.url` |
+
+All use the same URL: `http://localhost:4000/tidewave/mcp`
+
+## MCP Tools Reference
+
+| Tool | Description |
+|------|-------------|
+| `project_eval` | Execute Elixir code within the running application runtime |
+| `execute_sql_query` | Run SQL queries against the application database |
+| `get_ecto_schemas` | List all Ecto schema modules with their fields and associations |
+| `get_ash_resources` | List all Ash resources (when using the Ash framework) |
+| `get_docs` | Retrieve documentation for modules/functions using exact project versions |
+| `search_package_docs` | Query hexdocs.pm filtered to project dependencies |
+| `get_source_location` | Find module/function source code file paths and line numbers |
+| `get_models` | List all application modules with their file locations |
+| `get_logs` | Access server logs written during development |
+
+### Tool Usage Patterns
+
+**Introspect Ecto schemas before writing queries:**
+```
+Use get_ecto_schemas to discover available schemas, then execute_sql_query to run queries.
+```
+
+**Look up documentation for project dependencies:**
+```
+Use get_docs for specific modules, search_package_docs for broader searches across hex dependencies.
+```
+
+**Execute and test code in the running app:**
+```
+Use project_eval to run Elixir expressions against the live application state.
+```
+
+## Plug Configuration Options
+
+Configure via plug options in `endpoint.ex`:
+
+```elixir
+if Mix.env() == :dev do
+  plug Tidewave,
+    allow_remote_access: false,
+    inspect_opts: [pretty: true, limit: 50]
+end
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `allow_remote_access` | `false` | Allow connections from non-localhost. Keep `false` in development. |
+| `inspect_opts` | `[]` | Options passed to `Kernel.inspect/2` for formatting tool output |
+| `team` | `nil` | Team configuration (e.g., `[id: "my-company"]`) |
+
+## LiveView Debug Annotations
+
+For LiveView-heavy applications, enable debug annotations in `config/dev.exs`:
+
+```elixir
+config :phoenix_live_view,
+  debug_heex_annotations: true
+
+config :phoenix,
+  debug_attributes: true
+```
+
+These annotations help Tidewave (and other dev tools) map rendered HTML back to source HEEx templates and components. Requires Phoenix LiveView v1.1+.
+
+## Security Considerations
+
+- **Dev-only**: Always guard with `Mix.env() == :dev` or `only: :dev` in deps
+- **Localhost-only**: Tidewave only accepts localhost requests by default, even if the server listens on other interfaces
+- **No production use**: Tidewave exposes code execution and database access — never deploy to production
+- **Docker/remote dev**: If developing in containers, configure `allow_remote_access: true` only when the network is trusted
+- **Content Security Policy**: Tidewave injects `unsafe-eval` in `script-src` directives for browser testing and disables `frame-ancestors` restrictions
+
+## Troubleshooting
+
+### MCP connection fails
+
+- Verify the Phoenix server is running: `mix phx.server`
+- Check the port matches your configuration (default 4000)
+- Try `http://127.0.0.1:4000/tidewave/mcp` if IPv6 causes issues
+
+### Tools not appearing
+
+- Confirm `plug Tidewave` is placed before `if code_reloading?` in `endpoint.ex`
+- Restart the Phoenix server after adding the plug
+- Verify the dependency is installed: `mix deps.get`
+
+### Claude Code authentication error
+
+- Run `claude` in your terminal and confirm authentication
+- Verify CLI availability: `which claude`
+
+### Umbrella project issues
+
+- Add the plug only in the endpoint of the web application, not in other umbrella apps
+- Ensure `:tidewave` dependency is added to the correct `mix.exs` in the umbrella

--- a/elixir/skills/sources.md
+++ b/elixir/skills/sources.md
@@ -42,6 +42,32 @@ This file documents the sources used to create the elixir plugin skills.
 - **Purpose**: Comprehensive guides for building Phoenix applications
 - **Key Topics**: Routing, controllers, views, templates, contexts, testing
 
+## Tidewave MCP Dev Tools (Phoenix Skill Extension)
+
+### Tidewave Hex Package
+- **URL**: https://hex.pm/packages/tidewave
+- **Purpose**: Package listing and version information for Tidewave
+- **Date Accessed**: 2026-02-21
+- **Key Topics**: Version history, installation, license (Apache 2.0)
+
+### Tidewave Documentation
+- **URL**: https://hexdocs.pm/tidewave
+- **Purpose**: Official Tidewave documentation for MCP dev tools integration
+- **Date Accessed**: 2026-02-21
+- **Key Topics**:
+  - Installation (Igniter and manual)
+  - MCP server setup and client configuration
+  - Available MCP tools (project_eval, execute_sql_query, get_ecto_schemas, get_docs, etc.)
+  - Plug configuration options
+  - LiveView debug annotations
+  - Security considerations
+
+### Tidewave GitHub Repository
+- **URL**: https://github.com/tidewave-ai/tidewave_phoenix
+- **Purpose**: Source code, README, and community documentation
+- **Date Accessed**: 2026-02-21
+- **Key Topics**: Installation walkthrough, editor-specific MCP setup, troubleshooting
+
 ## OTP Skill
 
 ### Elixir OTP Documentation


### PR DESCRIPTION
- Add Tidewave section to Phoenix SKILL.md with quick setup and MCP tools table
- Create references/tidewave.md with full installation, Claude Code MCP setup, tools reference, configuration, and troubleshooting
- Add tidewave agent for runtime introspection via MCP tools
- Add Tidewave source attribution to elixir/skills/sources.md
- Update plugin descriptions to mention Tidewave MCP
- Bump elixir plugin version 0.1.1 to 0.1.2