### PR TITLE
feat(wasm): add wasmtime skill and wasm-inspector agent

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -80,6 +80,16 @@
       "version": "0.1.1",
       "category": "frontend",
       "keywords": ["ui", "daisyui", "tailwind"]
+    },
+    {
+      "name": "wasm",
+      "source": "./wasm",
+      "strict": true,
+      "description": "WebAssembly skills: wasmtime runtime, component model, guest compilation, and host embedding",
+      "version": "0.1.1",
+      "category": "language",
+      "keywords": ["wasm", "webassembly", "wasmtime", "wasi", "component-model"],
+      "license": "MIT"
     },
     {
       "name": "claudio",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -13,6 +13,7 @@
     "development",
     "elixir",
     "rust",
+    "wasm",
     "complete"
   ],
   "skills": [
@@ -46,6 +47,7 @@
     "./github/skills/workflows",
     "./github/skills/act",
     "./rust/skills",
-    "./ui/skills/daisyui"
+    "./ui/skills/daisyui",
+    "./wasm/skills/wasmtime"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Add the marketplace and install plugins:
 /plugin install core@vinnie357        # Git, documentation, code review, accessibility
 /plugin install elixir@vinnie357      # Elixir, Phoenix, OTP, testing
 /plugin install rust@vinnie357        # Rust language features
+/plugin install wasm@vinnie357        # WebAssembly and Wasmtime
 /plugin install dagu@vinnie357        # Workflow orchestration
 /plugin install ui@vinnie357          # daisyUI, accessibility, Material Design
 /plugin install claude-code@vinnie357 # Plugin marketplace management tools
@@ -76,6 +77,15 @@ Rust language features and best practices.
 - **rust** - Ownership, borrowing, lifetimes, error handling, async programming
 
 **Keywords**: rust, systems-programming, memory-safety
+
+### `wasm` - WebAssembly Development
+
+WebAssembly runtime, compilation, and embedding skills.
+
+**Skills:**
+- **wasmtime** - Wasmtime runtime, Component Model, WIT, WASI, guest compilation (Rust, Zig), host embedding (Rust, Elixir)
+
+**Keywords**: wasm, webassembly, wasmtime, wasi, component-model
 
 ### `dagu` - Workflow Orchestration
 
@@ -144,6 +154,13 @@ Skills are automatically activated by Claude based on task context once plugins 
 "Review this code for Rust best practices"
 ```
 
+**WebAssembly Development:**
+```
+"Help me compile this Rust library to wasm"
+"Embed a wasm plugin system using Wasmtime in Rust"
+"Set up Wasmex to run wasm modules in Elixir"
+```
+
 **Workflow Orchestration:**
 ```
 "Create a Dagu workflow for this ETL pipeline"
@@ -171,7 +188,8 @@ claude-skills/
 ├── dagu/                   # Workflow orchestration
 ├── elixir/                 # Elixir development
 ├── rust/                   # Rust programming
-└── ui/                     # UI frameworks
+├── ui/                     # UI frameworks
+└── wasm/                   # WebAssembly development
 ```
 
 Each plugin contains:
@@ -203,6 +221,11 @@ Install only the plugins you need:
 
 # Rust developer
 /plugin install core@vinnie357
+/plugin install rust@vinnie357
+
+# WebAssembly developer
+/plugin install core@vinnie357
+/plugin install wasm@vinnie357
 /plugin install rust@vinnie357
 
 # DevOps/Platform engineer
@@ -288,7 +311,7 @@ Install it to build your own Claude Code plugins:
 
 ## Testing
 
-The repository includes automated validation tests for the marketplace and all 8 plugins (including the all-skills meta-plugin).
+The repository includes automated validation tests for the marketplace and all 9 plugins (including the all-skills meta-plugin).
 
 ### Requirements
 
@@ -301,7 +324,7 @@ The repository includes automated validation tests for the marketplace and all 8
 # Install mise (if not already installed)
 curl https://mise.run | sh
 
-# Run all tests (validates marketplace + all 7 plugins)
+# Run all tests (validates marketplace + all 8 plugins)
 mise test
 
 # Test specific plugin
@@ -318,7 +341,7 @@ mise test:plugins
 ### What Gets Tested
 
 - **Marketplace validation**: Required fields, plugin entries, JSON structure
-- **Plugin validation** (all 8 plugins including all-skills):
+- **Plugin validation** (all 9 plugins including all-skills):
   - Name matches directory (or root for all-skills)
   - No invalid marketplace-only fields
   - Kebab-case naming
@@ -366,7 +389,7 @@ The repository includes automated CI/CD via GitHub Actions that runs on:
 
 **What gets tested:**
 - Validates marketplace.json schema
-- Validates all plugin.json files (8 plugins)
+- Validates all plugin.json files (9 plugins)
 - Checks skill paths exist
 - Verifies naming conventions
 
@@ -405,6 +428,7 @@ Primary sources include:
 - **Rust**: [The Rust Programming Language](https://doc.rust-lang.org/stable/)
 - **mise**: [mise Documentation](https://mise.jdx.dev/)
 - **Nushell**: [Nushell Book](https://www.nushell.sh/book/)
+- **Wasmtime**: [Wasmtime Documentation](https://docs.wasmtime.dev/)
 - **Dagu**: [Dagu Documentation](https://docs.dagu.cloud/)
 - **Claude Code**: [Official Plugins Documentation](https://code.claude.com/docs/en/plugins)
 
@@ -448,6 +472,6 @@ MIT License - see [LICENSE](LICENSE) file for details.
 
 ### 1.0.0 (Current)
 - Tiered marketplace architecture with selective plugin installation
-- 8 plugins: all-skills (meta), claude-code, core, dagu, elixir, github, rust, ui
+- 9 plugins: all-skills (meta), claude-code, core, dagu, elixir, github, rust, ui, wasm
 - 25+ skills covering multiple programming languages and development tools
 - Comprehensive plugin development tools with Nushell validation scripts

--- a/wasm/.claude-plugin/plugin.json
+++ b/wasm/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "wasm",
+  "version": "0.1.1",
+  "description": "WebAssembly skills: wasmtime runtime, component model, guest compilation, and host embedding",
+  "author": {
+    "name": "vinnie357"
+  },
+  "repository": "https://github.com/vinnie357/claude-skills",
+  "license": "MIT",
+  "keywords": ["wasm", "webassembly", "wasmtime", "wasi", "component-model"],
+  "skills": [
+    "./skills/wasmtime"
+  ],
+  "agents": [
+    "./agents/wasm-inspector.md"
+  ]
+}

--- a/wasm/agents/wasm-inspector.md
+++ b/wasm/agents/wasm-inspector.md
@@ -1,0 +1,51 @@
+---
+name: wasm-inspector
+description: "Inspect WebAssembly binaries for validity, structure, imports, exports, WIT interfaces, and size."
+tools: Bash, Glob, Read
+model: haiku
+---
+
+You are a WebAssembly binary inspector. Your role is to analyze `.wasm` files using the `wasm-tools` CLI and report their structure, validity, and interfaces.
+
+## Workflow
+
+1. **Locate**: If no specific file is given, use Glob to find `.wasm` files in the project (pattern `**/*.wasm`)
+2. **Validate**: Run `wasm-tools validate <file>` to check binary validity
+3. **Identify type**: Run `wasm-tools dump --skeleton <file>` and check for a `component` section to determine if it is a core module or a component
+4. **Inspect structure**: Run `wasm-tools dump --skeleton <file>` to show the section layout
+5. **Extract interfaces**: For components, run `wasm-tools component wit <file>` to extract WIT interfaces
+6. **Report size**: Report the file size in bytes and human-readable form
+7. **Summarize**: Output a structured report
+
+## Guidelines
+
+- **Read-only**: Never modify, compile, or generate wasm binaries
+- **Tool-first**: Always use `wasm-tools` CLI output rather than guessing about binary contents
+- **Concise**: Report facts from tool output, not verbose explanations
+- **Graceful errors**: If `wasm-tools` is not installed, inform the user and suggest `cargo install wasm-tools`
+- **Multiple files**: When multiple `.wasm` files are found and no specific file was requested, list them and ask which to inspect
+
+## Output Format
+
+```
+## <filename>
+
+- **Valid**: yes/no (with error details if invalid)
+- **Type**: core module | component
+- **Size**: <bytes> (<human-readable>)
+- **Sections**: <list of sections from dump>
+- **Imports**: <list of imports, if any>
+- **Exports**: <list of exports, if any>
+- **WIT interfaces**: <extracted WIT, components only>
+```
+
+## Tool Selection
+
+| Need | Command |
+|------|---------|
+| Validate binary | `wasm-tools validate <file>` |
+| Section layout | `wasm-tools dump --skeleton <file>` |
+| Extract WIT | `wasm-tools component wit <file>` |
+| Print imports/exports | `wasm-tools dump --skeleton <file>` |
+| Find wasm files | Glob `**/*.wasm` |
+| Check file size | `ls -la <file>` |

--- a/wasm/commands/inspect.md
+++ b/wasm/commands/inspect.md
@@ -1,0 +1,5 @@
+---
+description: "Inspect a WebAssembly binary and report its structure, validity, and interfaces"
+---
+
+Use the wasm-inspector subagent to analyze WebAssembly binaries in the project

--- a/wasm/skills/sources.md
+++ b/wasm/skills/sources.md
@@ -1,0 +1,78 @@
+# Wasm Plugin Sources
+
+This file documents the sources used to create the wasm plugin skills.
+
+## Wasmtime Skill
+
+### Wasmtime Documentation
+- **URL**: https://docs.wasmtime.dev/
+- **Purpose**: Official Wasmtime runtime documentation
+- **Key Topics**: Engine, Store, Module, Instance, Linker, WASI, Component Model, resource limits, AOT compilation
+
+### Wasmtime API Reference (Rust)
+- **URL**: https://docs.rs/wasmtime/latest/wasmtime/
+- **Purpose**: Rust API reference for the wasmtime crate
+- **Key Topics**: Embedding API, host functions, memory access, async support, typed function calls
+
+### Bytecode Alliance
+- **URL**: https://bytecodealliance.org/
+- **Purpose**: Organization behind Wasmtime, WASI, and the Component Model
+- **Key Topics**: WebAssembly standards, runtime implementations, community governance
+
+### Component Model Documentation
+- **URL**: https://component-model.bytecodealliance.org/
+- **Purpose**: Component Model specification and guides
+- **Key Topics**: WIT syntax, worlds, interfaces, composition, canonical ABI
+
+### WASI Specification
+- **URL**: https://wasi.dev/
+- **Purpose**: WebAssembly System Interface specification
+- **Key Topics**: WASIp1, WASIp2, system interface design, capability-based security
+
+### cargo-component
+- **URL**: https://github.com/bytecodealliance/cargo-component
+- **Purpose**: Cargo subcommand for building WebAssembly components from Rust
+- **Key Topics**: Component builds, WIT integration, dependency management
+
+### wit-bindgen
+- **URL**: https://github.com/bytecodealliance/wit-bindgen
+- **Purpose**: Language binding generator for WIT interfaces
+- **Key Topics**: Rust bindings, guest code generation, type mapping
+
+### wasm-tools
+- **URL**: https://github.com/bytecodealliance/wasm-tools
+- **Purpose**: CLI and Rust libraries for wasm manipulation
+- **Key Topics**: Validation, composition, printing, component creation
+
+### Wasmex (Elixir)
+- **URL**: https://hexdocs.pm/wasmex/
+- **Purpose**: Elixir wrapper around Wasmtime via Rust NIFs
+- **Key Topics**: Module compilation, instance management, memory access, host callbacks, WASI support
+
+### Wasmex GitHub Repository
+- **URL**: https://github.com/tessi/wasmex
+- **Purpose**: Source code and examples for the Wasmex library
+- **Key Topics**: NIF implementation, store configuration, fuel metering
+
+### Zig WebAssembly Documentation
+- **URL**: https://ziglang.org/documentation/master/
+- **Purpose**: Official Zig language documentation
+- **Key Topics**: Wasm targets, build system, allocators, extern functions
+
+### Zig WASI Guide
+- **URL**: https://ziglang.org/documentation/master/#toc-WebAssembly-System-Interface-WASI
+- **Purpose**: Zig's WASI target documentation
+- **Key Topics**: wasm32-wasi target, std library WASI support, build configuration
+
+### Rust Wasm Working Group
+- **URL**: https://rustwasm.github.io/docs/book/
+- **Purpose**: Rust and WebAssembly integration guide
+- **Key Topics**: Wasm targets, wasm-pack, binary size optimization, debugging
+
+## Plugin Information
+
+- **Name**: wasm
+- **Version**: 0.1.0
+- **Description**: WebAssembly skills: wasmtime runtime, component model, guest compilation, and host embedding
+- **Skills**: 1 skill (wasmtime)
+- **Created**: 2026-02-21

--- a/wasm/skills/wasmtime/SKILL.md
+++ b/wasm/skills/wasmtime/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: wasmtime
+description: Guide for WebAssembly development with Wasmtime runtime. Use when compiling Rust or Zig to wasm, embedding Wasmtime in Rust or Elixir hosts, working with WASI, or using the Component Model.
+license: MIT
+---
+
+# Wasmtime Development
+
+Wasmtime is a standalone, fast, secure WebAssembly runtime from the Bytecode Alliance. It implements the WebAssembly standard and extensions including WASI (WebAssembly System Interface) and the Component Model.
+
+## When to Use This Skill
+
+Activate when:
+- Compiling Rust or Zig code to WebAssembly targets
+- Embedding a WebAssembly runtime in Rust or Elixir applications
+- Working with WASI for system interface access
+- Using the Component Model and WIT interfaces
+- Building plugin systems with WebAssembly sandboxing
+- Optimizing wasm module size or runtime performance
+
+## Core Concepts
+
+| Concept | Purpose |
+|---------|---------|
+| Engine | Shared compilation environment and configuration |
+| Store | Per-instance state container (fuel, epoch, host data) |
+| Module | Compiled `.wasm` binary (core module) |
+| Component | Compiled component with typed interfaces (WIT-based) |
+| Instance | Runtime instantiation of a module or component |
+| Linker | Resolves imports by name, defines host functions |
+| WIT | WebAssembly Interface Type language for component contracts |
+
+## Supported Languages
+
+### Guest Languages (compile TO wasm)
+
+| Language | Target | Tooling | Reference |
+|----------|--------|---------|-----------|
+| Rust | `wasm32-wasip1`, `wasm32-wasip2`, `wasm32-unknown-unknown` | `cargo-component`, `wit-bindgen` | [guest-rust.md](references/guest-rust.md) |
+| Zig | `wasm32-wasi`, `wasm32-freestanding` | `zig build`, `build.zig` | [guest-zig.md](references/guest-zig.md) |
+
+### Host Languages (embed wasmtime IN)
+
+| Language | Crate/Package | Async Support | Reference |
+|----------|---------------|---------------|-----------|
+| Rust | `wasmtime` crate | Yes (tokio) | [host-rust.md](references/host-rust.md) |
+| Elixir | `wasmex` hex package | Via GenServer | [host-elixir.md](references/host-elixir.md) |
+
+## WASI Versions
+
+| Version | Status | Key Differences |
+|---------|--------|-----------------|
+| WASIp1 (Preview 1) | Stable, widely supported | POSIX-like, `fd_*` functions, linear memory I/O |
+| WASIp2 (Preview 2) | Current standard | Component Model-based, typed streams, async-ready |
+
+Use WASIp2 for new projects. WASIp1 remains supported for existing code. See [overview.md](references/overview.md) for migration details.
+
+## Reference Index
+
+| Reference | Contents |
+|-----------|----------|
+| [overview.md](references/overview.md) | Installation, core concepts detail, Component Model, WIT syntax, WASI deep dive, resource limits, AOT compilation, debugging |
+| [guest-rust.md](references/guest-rust.md) | Rust wasm targets, cargo-component, wit-bindgen, binary size optimization, testing strategies |
+| [guest-zig.md](references/guest-zig.md) | Zig wasm targets, build.zig configuration, allocator patterns, WASI imports, exports |
+| [host-rust.md](references/host-rust.md) | Wasmtime Rust API, WASI context setup, Component Model bindgen!, async support, plugin system patterns |
+| [host-elixir.md](references/host-elixir.md) | Wasmex API, GenServer integration, memory access, host callbacks, supervision patterns |
+
+## Common Pitfalls
+
+- **Wrong target triple**: Use `wasm32-wasip2` for Component Model, `wasm32-wasip1` for legacy WASI, `wasm32-unknown-unknown` for bare modules
+- **Missing WASI context**: Host must add WASI to the linker before instantiating WASI-dependent modules
+- **Store lifetime**: Each `Store` owns instance state — do not share stores across threads without synchronization
+- **Fuel exhaustion**: Enable fuel metering for untrusted code and handle `OutOfFuel` traps
+- **Component vs Module**: Components use WIT-typed interfaces; core modules use raw numeric imports/exports — do not mix APIs
+- **Linear memory bounds**: Always validate pointer+length pairs when passing data through linear memory

--- a/wasm/skills/wasmtime/references/guest-rust.md
+++ b/wasm/skills/wasmtime/references/guest-rust.md
@@ -1,0 +1,382 @@
+# Guest Language: Rust
+
+Compile Rust code to WebAssembly for execution in Wasmtime.
+
+## Wasm Targets
+
+| Target | Use Case | WASI | Component Model |
+|--------|----------|------|-----------------|
+| `wasm32-wasip1` | Legacy WASI modules | WASIp1 | No (core module) |
+| `wasm32-wasip2` | Component Model components | WASIp2 | Yes |
+| `wasm32-unknown-unknown` | Bare wasm, no system interface | No | No |
+
+### Adding Targets
+
+```bash
+rustup target add wasm32-wasip1
+rustup target add wasm32-wasip2
+rustup target add wasm32-unknown-unknown
+```
+
+## Core Module (wasm32-wasip1)
+
+### Basic Setup
+
+```bash
+cargo new --lib my-wasm-lib
+cd my-wasm-lib
+```
+
+`Cargo.toml`:
+```toml
+[lib]
+crate-type = ["cdylib"]
+```
+
+`src/lib.rs`:
+```rust
+#[no_mangle]
+pub extern "C" fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+```
+
+Build:
+```bash
+cargo build --target wasm32-wasip1 --release
+# Output: target/wasm32-wasip1/release/my_wasm_lib.wasm
+```
+
+### WASI Command (main executable)
+
+```rust
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    println!("Hello from WASI! Args: {:?}", args);
+}
+```
+
+```bash
+cargo build --target wasm32-wasip1 --release
+wasmtime target/wasm32-wasip1/release/my_wasm_app.wasm -- arg1 arg2
+```
+
+## Component Model (wasm32-wasip2)
+
+### cargo-component
+
+The primary tool for building Rust components.
+
+```bash
+cargo install cargo-component
+```
+
+#### Create a New Component
+
+```bash
+cargo component new my-component
+cd my-component
+```
+
+This generates:
+- `Cargo.toml` with `cargo-component-bindings` dependency
+- `wit/world.wit` defining the component interface
+- `src/lib.rs` with binding scaffolding
+
+#### Define WIT Interface
+
+`wit/world.wit`:
+```wit
+package my-org:my-component@0.1.0;
+
+world my-component {
+    export process: func(input: string) -> string;
+}
+```
+
+#### Implement the Component
+
+`src/lib.rs`:
+```rust
+#[allow(warnings)]
+mod bindings;
+
+use bindings::Guest;
+
+struct Component;
+
+impl Guest for Component {
+    fn process(input: String) -> String {
+        format!("processed: {input}")
+    }
+}
+
+bindings::export!(Component with_types_in bindings);
+```
+
+#### Build
+
+```bash
+cargo component build --release
+# Output: target/wasm32-wasip2/release/my_component.wasm
+```
+
+### wit-bindgen
+
+Generate Rust bindings from WIT files manually (without cargo-component).
+
+```toml
+[dependencies]
+wit-bindgen = "0.36"
+```
+
+```rust
+wit_bindgen::generate!({
+    world: "my-world",
+    path: "wit",
+});
+```
+
+### Using WASI Interfaces in Components
+
+Access WASI from within a component:
+
+`wit/world.wit`:
+```wit
+package my-org:my-app@0.1.0;
+
+world my-app {
+    include wasi:cli/imports@0.2.0;
+    export run: func() -> result<_, string>;
+}
+```
+
+```rust
+use bindings::wasi::filesystem::types::*;
+use bindings::wasi::io::streams::*;
+
+impl Guest for Component {
+    fn run() -> Result<(), String> {
+        // Use WASI interfaces through generated bindings
+        Ok(())
+    }
+}
+```
+
+### Importing Host Functions
+
+`wit/world.wit`:
+```wit
+package my-org:plugin@0.1.0;
+
+interface host-api {
+    log: func(level: log-level, msg: string);
+    get-config: func(key: string) -> option<string>;
+
+    enum log-level {
+        debug,
+        info,
+        warn,
+        error,
+    }
+}
+
+world plugin {
+    import host-api;
+    export run: func() -> result<string, string>;
+}
+```
+
+```rust
+use bindings::my_org::plugin::host_api;
+
+impl Guest for Component {
+    fn run() -> Result<String, String> {
+        host_api::log(host_api::LogLevel::Info, "plugin starting");
+        let val = host_api::get_config("key").unwrap_or_default();
+        Ok(val)
+    }
+}
+```
+
+## Binary Size Optimization
+
+Wasm binary size directly affects load time and memory usage.
+
+### Cargo.toml Profile
+
+```toml
+[profile.release]
+opt-level = "z"          # optimize for size
+lto = true               # link-time optimization
+codegen-units = 1        # single codegen unit for better optimization
+strip = true             # strip debug info
+panic = "abort"          # no unwinding overhead
+```
+
+### Additional Techniques
+
+| Technique | Savings | How |
+|-----------|---------|-----|
+| `wasm-opt` | 10-30% | `wasm-opt -Oz input.wasm -o output.wasm` |
+| `wasm-strip` | Debug info | `wasm-tools strip input.wasm -o output.wasm` |
+| Avoid `std` | Significant | `#![no_std]` with `wee_alloc` or custom allocator |
+| Avoid `format!` | ~20KB | Use fixed strings where possible |
+| Avoid panics | ~10KB | Use `Result` instead of `unwrap()` |
+
+### Install wasm-opt
+
+```bash
+# Via binaryen
+cargo install wasm-opt
+# or
+brew install binaryen
+```
+
+### Size Analysis
+
+```bash
+# Show section sizes
+wasm-tools strip -a input.wasm | wasm-tools dump | head -20
+
+# Detailed function-level analysis
+cargo install twiggy
+twiggy top target/wasm32-wasip2/release/my_component.wasm
+twiggy dominators target/wasm32-wasip2/release/my_component.wasm
+```
+
+## Testing
+
+### Unit Tests (native)
+
+Run tests on the host (not in wasm) for logic testing:
+
+```bash
+cargo test
+```
+
+### Integration Tests with Wasmtime
+
+Test compiled wasm in a host harness:
+
+```rust
+// tests/integration.rs (runs on host)
+use wasmtime::*;
+
+#[test]
+fn test_add() -> anyhow::Result<()> {
+    let engine = Engine::default();
+    let module = Module::from_file(&engine, "target/wasm32-wasip1/release/my_lib.wasm")?;
+    let mut store = Store::new(&engine, ());
+    let instance = Linker::new(&engine).instantiate(&mut store, &module)?;
+
+    let add = instance.get_typed_func::<(i32, i32), i32>(&mut store, "add")?;
+    assert_eq!(add.call(&mut store, (2, 3))?, 5);
+    Ok(())
+}
+```
+
+### Testing with WASI
+
+```rust
+#[test]
+fn test_wasi_command() -> anyhow::Result<()> {
+    let engine = Engine::default();
+    let module = Module::from_file(&engine, "target/wasm32-wasip1/release/my_app.wasm")?;
+
+    let mut linker = Linker::new(&engine);
+    wasmtime_wasi::preview1::add_to_linker_sync(&mut linker, |s| s)?;
+
+    let wasi = wasmtime_wasi::preview1::WasiCtxBuilder::new()
+        .inherit_stdio()
+        .build();
+
+    let mut store = Store::new(&engine, wasi);
+    linker.module(&mut store, "", &module)?;
+
+    let func = linker.get_default(&mut store, "")?
+        .typed::<(), ()>(&store)?;
+    func.call(&mut store, ())?;
+    Ok(())
+}
+```
+
+### Component Testing
+
+```rust
+use wasmtime::component::*;
+
+bindgen!({
+    world: "my-component",
+    path: "wit",
+});
+
+#[test]
+fn test_component() -> anyhow::Result<()> {
+    let engine = Engine::default();
+    let component = Component::from_file(&engine, "target/wasm32-wasip2/release/my_component.wasm")?;
+
+    let mut linker = Linker::new(&engine);
+    let mut store = Store::new(&engine, ());
+
+    let instance = MyComponent::instantiate(&mut store, &component, &linker)?;
+    let result = instance.call_process(&mut store, "hello")?;
+    assert_eq!(result, "processed: hello");
+    Ok(())
+}
+```
+
+## Common Patterns
+
+### Reactor vs Command
+
+- **Command**: Has `fn main()`, runs once, used for CLI tools
+- **Reactor**: Has `#[no_mangle]` exports, stays loaded, used for libraries and plugins
+
+For reactors with WASIp1:
+```toml
+[lib]
+crate-type = ["cdylib"]
+```
+
+For components, `cargo-component` handles this automatically.
+
+### Error Handling Across the Boundary
+
+Use `result<T, E>` in WIT for fallible exports:
+
+```wit
+export parse: func(input: string) -> result<parsed-data, parse-error>;
+```
+
+Map to Rust `Result`:
+```rust
+impl Guest for Component {
+    fn parse(input: String) -> Result<ParsedData, ParseError> {
+        // errors cross the boundary cleanly
+        serde_json::from_str(&input).map_err(|e| ParseError { message: e.to_string() })
+    }
+}
+```
+
+### State Across Calls (Reactor Pattern)
+
+Use `thread_local!` or `static` for persistent state in reactor-style components:
+
+```rust
+use std::cell::RefCell;
+
+thread_local! {
+    static STATE: RefCell<Vec<String>> = RefCell::new(Vec::new());
+}
+
+impl Guest for Component {
+    fn add_item(item: String) {
+        STATE.with(|s| s.borrow_mut().push(item));
+    }
+
+    fn get_items() -> Vec<String> {
+        STATE.with(|s| s.borrow().clone())
+    }
+}
+```

--- a/wasm/skills/wasmtime/references/guest-zig.md
+++ b/wasm/skills/wasmtime/references/guest-zig.md
@@ -1,0 +1,392 @@
+# Guest Language: Zig
+
+Compile Zig code to WebAssembly for execution in Wasmtime.
+
+## Wasm Targets
+
+| Target | Use Case | WASI |
+|--------|----------|------|
+| `wasm32-wasi` | WASI modules (WASIp1) | Yes |
+| `wasm32-freestanding` | Bare wasm, no system interface | No |
+
+## Basic Setup
+
+### Freestanding Module (No WASI)
+
+`src/main.zig`:
+```zig
+export fn add(a: i32, b: i32) i32 {
+    return a + b;
+}
+```
+
+Build:
+```bash
+zig build-lib src/main.zig -target wasm32-freestanding -dynamic -O ReleaseSmall
+# Output: main.wasm
+```
+
+### With build.zig
+
+`build.zig`:
+```zig
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.resolveTargetQuery(.{
+        .cpu_arch = .wasm32,
+        .os_tag = .freestanding,
+    });
+
+    const optimize = b.standardOptimizeOption(.{});
+
+    const lib = b.addSharedLibrary(.{
+        .name = "my_lib",
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // Export specific symbols
+    lib.rdynamic = true;
+
+    b.installArtifact(lib);
+}
+```
+
+```bash
+zig build -Doptimize=ReleaseSmall
+# Output: zig-out/lib/my_lib.wasm
+```
+
+### WASI Module
+
+`build.zig`:
+```zig
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.resolveTargetQuery(.{
+        .cpu_arch = .wasm32,
+        .os_tag = .wasi,
+    });
+
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "my_app",
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    b.installArtifact(exe);
+}
+```
+
+`src/main.zig`:
+```zig
+const std = @import("std");
+
+pub fn main() !void {
+    const stdout = std.io.getStdOut().writer();
+    try stdout.print("Hello from Zig WASI!\n", .{});
+}
+```
+
+```bash
+zig build -Doptimize=ReleaseSmall
+wasmtime zig-out/bin/my_app.wasm
+```
+
+## Exporting Functions
+
+### Basic Exports
+
+```zig
+// Functions marked `export` are visible to the host
+export fn multiply(a: i32, b: i32) i32 {
+    return a * b;
+}
+
+// Export with a different name
+comptime {
+    @export(internalName, .{ .name = "external_name" });
+}
+
+fn internalName(x: i32) i32 {
+    return x * 2;
+}
+```
+
+### Exporting Memory
+
+```zig
+// The host needs access to the module's linear memory
+// Zig automatically exports memory as "memory" for wasm targets
+```
+
+### Passing Strings and Buffers
+
+Wasm only supports numeric types at the boundary. Pass strings as pointer + length.
+
+```zig
+// Allocate buffer in wasm memory for the host to write into
+var buffer: [1024]u8 = undefined;
+
+export fn get_buffer_ptr() [*]u8 {
+    return &buffer;
+}
+
+export fn get_buffer_len() usize {
+    return buffer.len;
+}
+
+// Process data the host wrote into the buffer
+export fn process_buffer(len: usize) i32 {
+    const data = buffer[0..len];
+    // process data...
+    return @intCast(data.len);
+}
+```
+
+### Returning Strings to Host
+
+```zig
+const std = @import("std");
+
+var result_buf: [4096]u8 = undefined;
+var result_len: usize = 0;
+
+export fn get_result_ptr() [*]const u8 {
+    return &result_buf;
+}
+
+export fn get_result_len() usize {
+    return result_len;
+}
+
+export fn greet(name_ptr: [*]const u8, name_len: usize) void {
+    const name = name_ptr[0..name_len];
+    const greeting = std.fmt.bufPrint(&result_buf, "Hello, {s}!", .{name}) catch return;
+    result_len = greeting.len;
+}
+```
+
+## Allocator Patterns
+
+### No Allocator (Stack/Static Only)
+
+For simple modules, avoid heap allocation entirely:
+
+```zig
+var static_buffer: [65536]u8 = undefined;
+var fba = std.heap.FixedBufferAllocator.init(&static_buffer);
+
+export fn process(ptr: [*]const u8, len: usize) i32 {
+    const allocator = fba.allocator();
+    defer fba.reset();
+    // use allocator...
+    return 0;
+}
+```
+
+### Page Allocator
+
+Use Zig's page allocator backed by `memory.grow`:
+
+```zig
+const allocator = std.heap.page_allocator;
+
+export fn allocate(size: usize) ?[*]u8 {
+    const slice = allocator.alloc(u8, size) catch return null;
+    return slice.ptr;
+}
+
+export fn deallocate(ptr: [*]u8, size: usize) void {
+    allocator.free(ptr[0..size]);
+}
+```
+
+### General Purpose Allocator
+
+For complex allocation patterns:
+
+```zig
+var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+const allocator = gpa.allocator();
+```
+
+Note: The GPA has more overhead. Prefer fixed-buffer or page allocator for wasm when possible.
+
+## Importing Host Functions
+
+### WASI Imports
+
+WASI functions are automatically available through `std` when targeting `wasm32-wasi`:
+
+```zig
+const std = @import("std");
+
+pub fn main() !void {
+    // File I/O (through WASI)
+    const file = try std.fs.cwd().openFile("data.txt", .{});
+    defer file.close();
+
+    // Environment variables
+    var env = try std.process.getEnvMap(std.heap.page_allocator);
+    defer env.deinit();
+
+    // Clock
+    const timestamp = std.time.timestamp();
+    _ = timestamp;
+}
+```
+
+### Custom Host Imports
+
+Declare external functions the host must provide:
+
+```zig
+// Declare imports from the "env" module
+extern "env" fn host_log(ptr: [*]const u8, len: usize) void;
+extern "env" fn host_random() u32;
+extern "env" fn host_get_time() i64;
+
+export fn run() void {
+    const msg = "Hello from guest";
+    host_log(msg.ptr, msg.len);
+
+    const rand = host_random();
+    _ = rand;
+}
+```
+
+The host must provide matching function definitions when instantiating the module.
+
+## Build Configuration
+
+### Optimization Levels
+
+| Flag | Size | Speed | Debug |
+|------|------|-------|-------|
+| `Debug` | Large | Slow | Full debug info |
+| `ReleaseSafe` | Medium | Fast | Safety checks |
+| `ReleaseFast` | Medium | Fastest | No safety checks |
+| `ReleaseSmall` | Smallest | Fast | No safety checks |
+
+Use `ReleaseSmall` for production wasm to minimize binary size.
+
+### Stripping
+
+```zig
+// In build.zig
+lib.root_module.strip = true;  // strip debug info for smaller binary
+```
+
+### Stack Size
+
+```zig
+// In build.zig
+exe.stack_size = 64 * 1024;  // 64KB stack (default is larger)
+```
+
+## Common Patterns
+
+### Error Handling Across the Boundary
+
+Zig errors cannot cross the wasm boundary. Convert to numeric codes:
+
+```zig
+const ErrorCode = enum(i32) {
+    ok = 0,
+    invalid_input = -1,
+    out_of_memory = -2,
+    io_error = -3,
+};
+
+export fn process(ptr: [*]const u8, len: usize) i32 {
+    return processInner(ptr, len) catch |err| switch (err) {
+        error.InvalidInput => @intFromEnum(ErrorCode.invalid_input),
+        error.OutOfMemory => @intFromEnum(ErrorCode.out_of_memory),
+        else => @intFromEnum(ErrorCode.io_error),
+    };
+}
+
+fn processInner(ptr: [*]const u8, len: usize) !i32 {
+    // actual implementation with proper error handling
+    const data = ptr[0..len];
+    if (data.len == 0) return error.InvalidInput;
+    return @intCast(data.len);
+}
+```
+
+### Multi-Value Returns
+
+Wasm supports single return values. Return structs through memory:
+
+```zig
+const Result = extern struct {
+    x: f32,
+    y: f32,
+    status: i32,
+};
+
+var last_result: Result = .{ .x = 0, .y = 0, .status = 0 };
+
+export fn compute() *const Result {
+    last_result = .{
+        .x = 1.5,
+        .y = 2.5,
+        .status = 0,
+    };
+    return &last_result;
+}
+```
+
+### Limiting Memory Usage
+
+Control the initial and maximum memory:
+
+```zig
+// In build.zig
+lib.root_module.initial_memory = 65536 * 2;  // 2 pages (128KB)
+lib.root_module.max_memory = 65536 * 16;     // 16 pages (1MB)
+```
+
+## Testing
+
+### Native Tests
+
+Test logic natively (not as wasm):
+
+```bash
+zig build test
+```
+
+### Wasm Integration Tests
+
+Build and run with Wasmtime:
+
+```bash
+zig build -Doptimize=ReleaseSmall
+wasmtime zig-out/bin/my_app.wasm
+```
+
+For automated testing, use a host-side test harness (Rust or other) that loads the Zig-compiled wasm and validates exports.
+
+## Binary Size Tips
+
+| Technique | Impact |
+|-----------|--------|
+| `ReleaseSmall` | Baseline optimization |
+| `strip = true` | Remove debug symbols |
+| Avoid `std.fmt` | `std.fmt` adds significant code |
+| Avoid `std.json` | Large parser, use manual parsing |
+| Fixed buffers over heap | Eliminate allocator code |
+| `wasm-opt -Oz` | Post-build optimization (10-30%) |
+
+```bash
+# Post-process with wasm-opt (from binaryen)
+wasm-opt -Oz zig-out/lib/my_lib.wasm -o my_lib.opt.wasm
+```

--- a/wasm/skills/wasmtime/references/host-elixir.md
+++ b/wasm/skills/wasmtime/references/host-elixir.md
@@ -1,0 +1,381 @@
+# Host Language: Elixir (Wasmex)
+
+Embed WebAssembly in Elixir applications using Wasmex, which wraps the Wasmtime runtime via Rust NIFs.
+
+## Setup
+
+### Dependencies
+
+```elixir
+# mix.exs
+defp deps do
+  [
+    {:wasmex, "~> 0.9"}
+  ]
+end
+```
+
+Wasmex ships pre-compiled Wasmtime NIFs for major platforms (macOS, Linux). Rust toolchain is not required for installation.
+
+```bash
+mix deps.get
+```
+
+## Basic Usage
+
+### Loading and Calling a Module
+
+```elixir
+# Load from file
+{:ok, bytes} = File.read("module.wasm")
+{:ok, module} = Wasmex.Module.compile(store, bytes)
+
+# Or load from binary
+{:ok, store} = Wasmex.Store.new()
+{:ok, module} = Wasmex.Module.compile(store, wasm_bytes)
+{:ok, instance} = Wasmex.Instance.new(store, module, %{})
+
+# Call an exported function
+{:ok, [result]} = Wasmex.Instance.call_function(store, instance, "add", [2, 3])
+# result => 5
+```
+
+### Using Wasmex Convenience API
+
+```elixir
+{:ok, pid} = Wasmex.start_link(%{bytes: wasm_bytes})
+
+# Call exported functions
+{:ok, [result]} = Wasmex.call_function(pid, "add", [2, 3])
+```
+
+## Store Configuration
+
+```elixir
+# Basic store
+{:ok, store} = Wasmex.Store.new()
+
+# Store with fuel metering
+{:ok, store} = Wasmex.Store.new(%{fuel: 100_000})
+
+# WASI-enabled store
+{:ok, store} = Wasmex.Store.new_wasi(%Wasmex.Wasi.WasiOptions{
+  args: ["app", "--verbose"],
+  env: %{"KEY" => "VALUE"},
+  preopen: [%Wasmex.Wasi.PreopenOptions{
+    path: "/sandbox",
+    alias: "data"
+  }]
+})
+```
+
+## Host Callbacks (Imported Functions)
+
+Define Elixir functions callable from wasm:
+
+```elixir
+imports = %{
+  "env" => %{
+    "host_log" =>
+      {:fn, [:i32, :i32], [], fn context ->
+        # Read string from guest memory
+        {:ok, memory} = Wasmex.Instance.memory(context.store, context.instance, "memory")
+        {:ok, data} = Wasmex.Memory.read_binary(context.store, memory, context.params |> List.first(), context.params |> List.last())
+        IO.puts("Guest says: #{data}")
+        []
+      end},
+
+    "host_random" =>
+      {:fn, [], [:i32], fn _context ->
+        [:rand.uniform(1_000_000)]
+      end}
+  }
+}
+
+{:ok, instance} = Wasmex.Instance.new(store, module, imports)
+```
+
+### Callback Signature Format
+
+```elixir
+{:fn, param_types, return_types, callback_fn}
+```
+
+Types: `:i32`, `:i64`, `:f32`, `:f64`
+
+## Memory Access
+
+### Reading from Guest Memory
+
+```elixir
+{:ok, memory} = Wasmex.Instance.memory(store, instance, "memory")
+
+# Read binary data
+{:ok, binary} = Wasmex.Memory.read_binary(store, memory, offset, length)
+
+# Read string
+{:ok, binary} = Wasmex.Memory.read_binary(store, memory, offset, length)
+string = binary |> :binary.bin_to_list() |> to_string()
+```
+
+### Writing to Guest Memory
+
+```elixir
+{:ok, memory} = Wasmex.Instance.memory(store, instance, "memory")
+
+# Write binary data
+:ok = Wasmex.Memory.write_binary(store, memory, offset, binary_data)
+
+# Write a string
+:ok = Wasmex.Memory.write_binary(store, memory, offset, "hello")
+```
+
+### Memory Size
+
+```elixir
+{:ok, memory} = Wasmex.Instance.memory(store, instance, "memory")
+
+# Get size in bytes
+size = Wasmex.Memory.size(store, memory)
+
+# Grow memory (in pages, 1 page = 64KB)
+:ok = Wasmex.Memory.grow(store, memory, 1)
+```
+
+## String Passing Pattern
+
+Wasm only supports numeric types at the boundary. Use a shared memory protocol:
+
+```elixir
+defmodule WasmStringHelper do
+  @doc """
+  Write a string to guest memory and return {pointer, length}.
+  Requires the guest to export an `allocate(size) -> ptr` function.
+  """
+  def write_string(store, instance, string) do
+    binary = string |> :binary.bin_to_list()
+    length = byte_size(string)
+
+    # Ask guest to allocate memory
+    {:ok, [ptr]} = Wasmex.Instance.call_function(store, instance, "allocate", [length])
+
+    # Write string into allocated memory
+    {:ok, memory} = Wasmex.Instance.memory(store, instance, "memory")
+    :ok = Wasmex.Memory.write_binary(store, memory, ptr, string)
+
+    {ptr, length}
+  end
+
+  @doc """
+  Read a string from guest memory at the given pointer and length.
+  """
+  def read_string(store, instance, ptr, length) do
+    {:ok, memory} = Wasmex.Instance.memory(store, instance, "memory")
+    {:ok, binary} = Wasmex.Memory.read_binary(store, memory, ptr, length)
+    binary
+  end
+end
+```
+
+## GenServer Integration
+
+### Wasm Worker
+
+```elixir
+defmodule MyApp.WasmWorker do
+  use GenServer
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: opts[:name])
+  end
+
+  def call_function(pid, func_name, params) do
+    GenServer.call(pid, {:call, func_name, params})
+  end
+
+  @impl true
+  def init(opts) do
+    wasm_bytes = File.read!(opts[:wasm_path])
+    {:ok, store} = Wasmex.Store.new()
+    {:ok, module} = Wasmex.Module.compile(store, wasm_bytes)
+    {:ok, instance} = Wasmex.Instance.new(store, module, opts[:imports] || %{})
+
+    {:ok, %{store: store, instance: instance}}
+  end
+
+  @impl true
+  def handle_call({:call, func_name, params}, _from, state) do
+    result = Wasmex.Instance.call_function(state.store, state.instance, func_name, params)
+    {:reply, result, state}
+  end
+end
+```
+
+### Supervised Wasm Pool
+
+```elixir
+defmodule MyApp.WasmSupervisor do
+  use Supervisor
+
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_init_arg) do
+    children = [
+      {MyApp.WasmWorker, name: :wasm_worker_1, wasm_path: "priv/wasm/plugin.wasm"},
+      {MyApp.WasmWorker, name: :wasm_worker_2, wasm_path: "priv/wasm/plugin.wasm"},
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end
+```
+
+### Poolboy Integration
+
+For high-throughput scenarios, use a worker pool:
+
+```elixir
+# In application supervisor
+children = [
+  :poolboy.child_spec(:wasm_pool, [
+    name: {:local, :wasm_pool},
+    worker_module: MyApp.WasmWorker,
+    size: System.schedulers_online(),
+    max_overflow: 2
+  ], [wasm_path: "priv/wasm/plugin.wasm"])
+]
+```
+
+```elixir
+# Usage
+:poolboy.transaction(:wasm_pool, fn pid ->
+  MyApp.WasmWorker.call_function(pid, "process", [input])
+end, :timer.seconds(5))
+```
+
+## WASI Support
+
+```elixir
+# Create WASI-enabled store
+{:ok, store} = Wasmex.Store.new_wasi(%Wasmex.Wasi.WasiOptions{
+  args: ["my-app", "--config", "/data/config.toml"],
+  env: %{
+    "LOG_LEVEL" => "info",
+    "APP_ENV" => "production"
+  },
+  preopen: [
+    %Wasmex.Wasi.PreopenOptions{path: "./data", alias: "data"},
+    %Wasmex.Wasi.PreopenOptions{path: "./tmp", alias: "tmp"}
+  ]
+})
+
+{:ok, module} = Wasmex.Module.compile(store, wasm_bytes)
+{:ok, instance} = Wasmex.Instance.new(store, module, %{})
+
+# Call WASI _start for command modules
+{:ok, _} = Wasmex.Instance.call_function(store, instance, "_start", [])
+```
+
+## Error Handling
+
+```elixir
+case Wasmex.Instance.call_function(store, instance, "process", [ptr, len]) do
+  {:ok, [result]} ->
+    {:ok, result}
+
+  {:error, "unreachable" <> _} ->
+    {:error, :wasm_trap}
+
+  {:error, "out of bounds memory access" <> _} ->
+    {:error, :memory_violation}
+
+  {:error, "all fuel consumed" <> _} ->
+    {:error, :fuel_exhausted}
+
+  {:error, reason} ->
+    {:error, {:wasm_error, reason}}
+end
+```
+
+## Fuel Metering
+
+```elixir
+# Create store with fuel
+{:ok, store} = Wasmex.Store.new(%{fuel: 1_000_000})
+
+# Execute with fuel limit
+case Wasmex.Instance.call_function(store, instance, "expensive_op", []) do
+  {:ok, result} -> {:ok, result}
+  {:error, "all fuel consumed" <> _} -> {:error, :timeout}
+end
+```
+
+## Phoenix Integration
+
+### LiveView with Wasm Processing
+
+```elixir
+defmodule MyAppWeb.ProcessorLive do
+  use MyAppWeb, :live_view
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, result: nil, processing: false)}
+  end
+
+  @impl true
+  def handle_event("process", %{"input" => input}, socket) do
+    socket = assign(socket, processing: true)
+
+    # Offload to wasm worker
+    task = Task.async(fn ->
+      MyApp.WasmWorker.call_function(:wasm_worker, "process", [input])
+    end)
+
+    {:noreply, assign(socket, task: task)}
+  end
+
+  @impl true
+  def handle_info({ref, {:ok, [result]}}, socket) when is_reference(ref) do
+    Process.demonitor(ref, [:flush])
+    {:noreply, assign(socket, result: result, processing: false)}
+  end
+end
+```
+
+## Common Patterns
+
+### Module Preloading at Application Start
+
+```elixir
+defmodule MyApp.Application do
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    # Preload wasm modules into ETS for fast access
+    :ets.new(:wasm_modules, [:named_table, :public, read_concurrency: true])
+
+    wasm_bytes = File.read!(Application.app_dir(:my_app, "priv/wasm/plugin.wasm"))
+    :ets.insert(:wasm_modules, {"plugin", wasm_bytes})
+
+    children = [
+      MyApp.WasmSupervisor
+    ]
+
+    Supervisor.start_link(children, strategy: :one_for_one)
+  end
+end
+```
+
+### Loading Wasm from Priv Directory
+
+```elixir
+wasm_path = Application.app_dir(:my_app, "priv/wasm/module.wasm")
+wasm_bytes = File.read!(wasm_path)
+```
+
+Place `.wasm` files in `priv/wasm/` so they are included in releases.

--- a/wasm/skills/wasmtime/references/host-rust.md
+++ b/wasm/skills/wasmtime/references/host-rust.md
@@ -1,0 +1,548 @@
+# Host Language: Rust
+
+Embed the Wasmtime runtime in Rust applications.
+
+## Dependencies
+
+```toml
+[dependencies]
+wasmtime = "29"
+wasmtime-wasi = "29"       # for WASI support
+anyhow = "1"
+
+# For async support
+tokio = { version = "1", features = ["full"] }
+
+# For Component Model
+wit-bindgen = "0.36"       # (guest-side, if also building components)
+```
+
+## Core Module Embedding
+
+### Minimal Example
+
+```rust
+use wasmtime::*;
+
+fn main() -> anyhow::Result<()> {
+    let engine = Engine::default();
+    let module = Module::from_file(&engine, "module.wasm")?;
+    let mut store = Store::new(&engine, ());
+    let instance = Linker::new(&engine).instantiate(&mut store, &module)?;
+
+    let func = instance.get_typed_func::<(i32, i32), i32>(&mut store, "add")?;
+    let result = func.call(&mut store, (2, 3))?;
+    println!("2 + 3 = {result}");
+    Ok(())
+}
+```
+
+### Host Functions
+
+Define functions the wasm module can call:
+
+```rust
+use wasmtime::*;
+
+struct HostState {
+    log_buffer: Vec<String>,
+}
+
+fn main() -> anyhow::Result<()> {
+    let engine = Engine::default();
+    let module = Module::from_file(&engine, "module.wasm")?;
+
+    let mut linker = Linker::new(&engine);
+
+    // Simple host function
+    linker.func_wrap("env", "host_random", || -> u32 {
+        rand::random()
+    })?;
+
+    // Host function with Caller access (for reading guest memory)
+    linker.func_wrap("env", "host_log", |mut caller: Caller<'_, HostState>, ptr: i32, len: i32| {
+        let memory = caller.get_export("memory")
+            .and_then(|e| e.into_memory())
+            .expect("missing memory export");
+
+        let data = memory.data(&caller);
+        let msg = std::str::from_utf8(&data[ptr as usize..(ptr + len) as usize])
+            .unwrap_or("<invalid utf8>");
+
+        caller.data_mut().log_buffer.push(msg.to_string());
+    })?;
+
+    let state = HostState { log_buffer: Vec::new() };
+    let mut store = Store::new(&engine, state);
+    let instance = linker.instantiate(&mut store, &module)?;
+
+    let run = instance.get_typed_func::<(), ()>(&mut store, "run")?;
+    run.call(&mut store, ())?;
+
+    println!("Logs: {:?}", store.data().log_buffer);
+    Ok(())
+}
+```
+
+### Memory Access
+
+Read and write guest linear memory from the host:
+
+```rust
+let memory = instance.get_memory(&mut store, "memory")
+    .expect("missing memory export");
+
+// Read bytes from guest memory
+let data = memory.data(&store);
+let value = &data[offset..offset + length];
+
+// Write bytes to guest memory
+let data_mut = memory.data_mut(&mut store);
+data_mut[offset..offset + length].copy_from_slice(&bytes);
+
+// Grow memory
+memory.grow(&mut store, 1)?;  // grow by 1 page (64KB)
+
+// Current size
+let pages = memory.size(&store);
+let bytes = memory.data_size(&store);
+```
+
+## WASI Integration
+
+### WASIp1 (Preview 1)
+
+```rust
+use wasmtime::*;
+use wasmtime_wasi::preview1::{self, WasiP1Ctx};
+
+fn main() -> anyhow::Result<()> {
+    let engine = Engine::default();
+    let module = Module::from_file(&engine, "wasi_app.wasm")?;
+
+    let mut linker: Linker<WasiP1Ctx> = Linker::new(&engine);
+    preview1::add_to_linker_sync(&mut linker, |ctx| ctx)?;
+
+    let wasi_ctx = preview1::WasiCtxBuilder::new()
+        .inherit_stdio()
+        .inherit_env()
+        .args(&["app", "--verbose"])
+        .preopened_dir("./data", "data", DirPerms::all(), FilePerms::all())?
+        .build();
+
+    let mut store = Store::new(&engine, wasi_ctx);
+    linker.module(&mut store, "", &module)?;
+
+    let func = linker.get_default(&mut store, "")?
+        .typed::<(), ()>(&store)?;
+    func.call(&mut store, ())?;
+    Ok(())
+}
+```
+
+### WASIp2 (Preview 2)
+
+```rust
+use wasmtime::*;
+use wasmtime::component::*;
+use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiView};
+
+struct ServerState {
+    wasi: WasiCtx,
+    table: ResourceTable,
+}
+
+impl WasiView for ServerState {
+    fn ctx(&mut self) -> &mut WasiCtx { &mut self.wasi }
+    fn table(&mut self) -> &mut ResourceTable { &mut self.table }
+}
+
+fn main() -> anyhow::Result<()> {
+    let mut config = Config::new();
+    config.wasm_component_model(true);
+
+    let engine = Engine::new(&config)?;
+    let component = Component::from_file(&engine, "component.wasm")?;
+
+    let mut linker = Linker::new(&engine);
+    wasmtime_wasi::add_to_linker_sync(&mut linker)?;
+
+    let wasi = WasiCtxBuilder::new()
+        .inherit_stdio()
+        .build();
+
+    let state = ServerState {
+        wasi,
+        table: ResourceTable::new(),
+    };
+    let mut store = Store::new(&engine, state);
+
+    // Instantiate and use component...
+    Ok(())
+}
+```
+
+### WASI Configuration
+
+```rust
+let wasi = WasiCtxBuilder::new()
+    // Stdio
+    .inherit_stdio()                    // inherit host stdio
+    .stdin(MemoryInputPipe::new(data))  // pipe data to stdin
+    .stdout(MemoryOutputPipe::new())    // capture stdout
+
+    // Environment
+    .inherit_env()                      // inherit host env vars
+    .env("KEY", "VALUE")               // set specific env var
+
+    // Arguments
+    .args(&["app", "--flag"])
+
+    // Filesystem
+    .preopened_dir(
+        "/host/path",                   // host path
+        "guest-alias",                  // guest mount point
+        DirPerms::READ,                 // directory permissions
+        FilePerms::READ,               // file permissions
+    )?
+
+    // Network (WASIp2)
+    .inherit_network()                  // allow network access
+
+    .build();
+```
+
+## Component Model Embedding
+
+### bindgen! Macro
+
+Generate Rust host bindings from WIT:
+
+```rust
+use wasmtime::component::*;
+use wasmtime::*;
+
+// Generate host-side bindings from WIT
+bindgen!({
+    world: "my-plugin",
+    path: "wit",
+    // async: true,                  // for async support
+    // with: { "wasi:io": wasmtime_wasi::bindings::io },
+});
+```
+
+Given this WIT:
+```wit
+package my-org:my-plugin@0.1.0;
+
+interface plugin-api {
+    record config {
+        name: string,
+        debug: bool,
+    }
+
+    process: func(input: string) -> result<string, string>;
+    get-version: func() -> string;
+}
+
+world my-plugin {
+    import log: func(msg: string);
+    export plugin-api;
+}
+```
+
+The `bindgen!` macro generates:
+- A `MyPlugin` struct for instantiation
+- Trait definitions for imports the host must satisfy
+- Typed accessors for exports
+
+### Implementing Host Imports
+
+```rust
+struct MyHost {
+    wasi: WasiCtx,
+    table: ResourceTable,
+}
+
+impl MyPluginImports for MyHost {
+    fn log(&mut self, msg: String) {
+        println!("[plugin] {msg}");
+    }
+}
+
+impl WasiView for MyHost {
+    fn ctx(&mut self) -> &mut WasiCtx { &mut self.wasi }
+    fn table(&mut self) -> &mut ResourceTable { &mut self.table }
+}
+```
+
+### Instantiating and Calling Components
+
+```rust
+fn main() -> anyhow::Result<()> {
+    let mut config = Config::new();
+    config.wasm_component_model(true);
+
+    let engine = Engine::new(&config)?;
+    let component = Component::from_file(&engine, "plugin.wasm")?;
+
+    let mut linker = Linker::new(&engine);
+    wasmtime_wasi::add_to_linker_sync(&mut linker)?;
+    MyPlugin::add_to_linker(&mut linker, |state: &mut MyHost| state)?;
+
+    let state = MyHost {
+        wasi: WasiCtxBuilder::new().build(),
+        table: ResourceTable::new(),
+    };
+    let mut store = Store::new(&engine, state);
+
+    let (plugin, _instance) = MyPlugin::instantiate(&mut store, &component, &linker)?;
+
+    // Call typed exports
+    let api = plugin.my_org_my_plugin_plugin_api();
+    let version = api.call_get_version(&mut store)?;
+    let result = api.call_process(&mut store, "input data")?;
+    match result {
+        Ok(output) => println!("Output: {output}"),
+        Err(e) => eprintln!("Plugin error: {e}"),
+    }
+
+    Ok(())
+}
+```
+
+## Async Support
+
+### Setup
+
+```rust
+let mut config = Config::new();
+config.async_support(true);
+config.wasm_component_model(true);
+
+let engine = Engine::new(&config)?;
+```
+
+### Async Host Functions
+
+```rust
+bindgen!({
+    world: "my-plugin",
+    path: "wit",
+    async: true,
+});
+
+#[async_trait::async_trait]
+impl MyPluginImports for MyHost {
+    async fn log(&mut self, msg: String) {
+        // Can do async I/O here
+        tokio::fs::write("log.txt", &msg).await.ok();
+    }
+}
+```
+
+### Async Instantiation
+
+```rust
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let engine = Engine::new(&config)?;
+    let component = Component::from_file(&engine, "plugin.wasm")?;
+
+    let mut linker = Linker::new(&engine);
+    wasmtime_wasi::add_to_linker_async(&mut linker)?;
+
+    let mut store = Store::new(&engine, state);
+
+    let (plugin, _) = MyPlugin::instantiate_async(&mut store, &component, &linker).await?;
+    let result = plugin.call_process(&mut store, "data").await?;
+    Ok(())
+}
+```
+
+### Epoch-Based Async Cancellation
+
+```rust
+let engine = Engine::new(&config)?;
+
+// Background thread increments epoch every 100ms
+let engine_clone = engine.clone();
+tokio::spawn(async move {
+    loop {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        engine_clone.increment_epoch();
+    }
+});
+
+let mut store = Store::new(&engine, state);
+store.set_epoch_deadline(10);  // 10 ticks = ~1 second
+store.epoch_deadline_async_yield_and_update(10);  // yield to async runtime on deadline
+```
+
+## Plugin System Patterns
+
+### Dynamic Plugin Loading
+
+```rust
+use std::path::Path;
+use wasmtime::component::*;
+
+struct PluginManager {
+    engine: Engine,
+    linker: Linker<PluginState>,
+}
+
+impl PluginManager {
+    fn new() -> anyhow::Result<Self> {
+        let mut config = Config::new();
+        config.wasm_component_model(true);
+
+        let engine = Engine::new(&config)?;
+        let mut linker = Linker::new(&engine);
+
+        wasmtime_wasi::add_to_linker_sync(&mut linker)?;
+
+        Ok(Self { engine, linker })
+    }
+
+    fn load_plugin(&self, path: &Path) -> anyhow::Result<LoadedPlugin> {
+        let component = Component::from_file(&self.engine, path)?;
+        let state = PluginState::new();
+        let mut store = Store::new(&self.engine, state);
+
+        let (instance, _) = MyPlugin::instantiate(&mut store, &component, &self.linker)?;
+
+        Ok(LoadedPlugin { store, instance })
+    }
+}
+```
+
+### Pre-Compilation Cache
+
+```rust
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+struct PluginCache {
+    engine: Engine,
+    compiled: HashMap<PathBuf, Vec<u8>>,
+}
+
+impl PluginCache {
+    fn get_or_compile(&mut self, path: &PathBuf) -> anyhow::Result<Component> {
+        if let Some(bytes) = self.compiled.get(path) {
+            return unsafe { Component::deserialize(&self.engine, bytes) };
+        }
+
+        let wasm = std::fs::read(path)?;
+        let compiled = self.engine.precompile_component(&wasm)?;
+        self.compiled.insert(path.clone(), compiled.clone());
+
+        unsafe { Component::deserialize(&self.engine, &compiled) }
+    }
+}
+```
+
+### Sandboxed Execution with Resource Limits
+
+```rust
+fn run_untrusted(wasm_bytes: &[u8]) -> anyhow::Result<String> {
+    let mut config = Config::new();
+    config.wasm_component_model(true);
+    config.consume_fuel(true);
+    config.epoch_interruption(true);
+
+    let engine = Engine::new(&config)?;
+    let component = Component::new(&engine, wasm_bytes)?;
+
+    let mut linker = Linker::new(&engine);
+    wasmtime_wasi::add_to_linker_sync(&mut linker)?;
+
+    let wasi = WasiCtxBuilder::new()
+        // No stdio, no env, no filesystem, no network
+        .build();
+
+    let state = SandboxState {
+        wasi,
+        table: ResourceTable::new(),
+    };
+    let mut store = Store::new(&engine, state);
+
+    // Limit fuel (execution steps)
+    store.set_fuel(1_000_000)?;
+
+    // Limit memory
+    store.limiter(|_| &mut StoreLimitsBuilder::new()
+        .memory_size(10 * 65536)  // 640KB
+        .instances(1)
+        .build());
+
+    let (plugin, _) = MyPlugin::instantiate(&mut store, &component, &linker)?;
+    let result = plugin.call_process(&mut store, "input")?;
+    result.map_err(|e| anyhow::anyhow!(e))
+}
+```
+
+## Error Handling
+
+### Trap Handling
+
+```rust
+use wasmtime::Trap;
+
+match func.call(&mut store, ()) {
+    Ok(result) => println!("Success: {result:?}"),
+    Err(e) => {
+        if let Some(trap) = e.downcast_ref::<Trap>() {
+            match trap {
+                Trap::StackOverflow => eprintln!("Stack overflow in wasm"),
+                Trap::MemoryOutOfBounds => eprintln!("Out of bounds memory access"),
+                Trap::UnreachableCodeReached => eprintln!("Hit unreachable instruction"),
+                Trap::OutOfFuel => eprintln!("Fuel exhausted"),
+                _ => eprintln!("Trap: {trap}"),
+            }
+        } else {
+            eprintln!("Error: {e}");
+        }
+    }
+}
+```
+
+### Backtraces
+
+```rust
+let mut config = Config::new();
+config.wasm_backtrace_details(WasmBacktraceDetails::Enable);
+
+// Errors will now include wasm stack traces
+// Requires debug info in the wasm module
+```
+
+## Multi-Module Linking
+
+Link multiple core modules together:
+
+```rust
+let mut linker = Linker::new(&engine);
+
+// First module provides exports
+let module_a = Module::from_file(&engine, "logger.wasm")?;
+let instance_a = linker.instantiate(&mut store, &module_a)?;
+linker.instance(&mut store, "logger", instance_a)?;
+
+// Second module imports from first
+let module_b = Module::from_file(&engine, "app.wasm")?;
+let instance_b = linker.instantiate(&mut store, &module_b)?;
+```
+
+## Performance Tips
+
+| Technique | When to Use |
+|-----------|-------------|
+| AOT compilation | Production deployments, fast startup |
+| Pooling allocator | High-throughput, many short-lived instances |
+| `cranelift_opt_level(Speed)` | CPU-bound workloads |
+| Module caching | Same module loaded multiple times |
+| Fuel over epochs | Fine-grained metering needed |
+| Epochs over fuel | Low-overhead periodic checks |
+| `Component::deserialize` | Cached pre-compiled components |

--- a/wasm/skills/wasmtime/references/overview.md
+++ b/wasm/skills/wasmtime/references/overview.md
@@ -1,0 +1,397 @@
+# Wasmtime Overview
+
+## Installation
+
+### Wasmtime CLI
+
+```bash
+# Install via installer script
+curl https://wasmtime.dev/install.sh -sSf | bash
+
+# Or via cargo
+cargo install wasmtime-cli
+
+# Verify
+wasmtime --version
+```
+
+### Essential Tools
+
+```bash
+# cargo-component: build Rust components targeting the Component Model
+cargo install cargo-component
+
+# wasm-tools: inspect, validate, compose wasm binaries
+cargo install wasm-tools
+
+# wit-bindgen: generate language bindings from WIT
+cargo install wit-bindgen-cli
+```
+
+## Core Concepts in Detail
+
+### Engine
+
+Global compilation configuration shared across all modules. Create once, reuse.
+
+```rust
+use wasmtime::*;
+
+let mut config = Config::new();
+config.cranelift_opt_level(OptLevel::Speed);
+config.wasm_component_model(true);  // enable Component Model
+config.async_support(true);          // enable async calls
+
+let engine = Engine::new(&config)?;
+```
+
+Key configuration options:
+- `cranelift_opt_level`: `None`, `Speed`, `SpeedAndSize`
+- `wasm_component_model(true)`: required for components
+- `async_support(true)`: required for async host functions
+- `epoch_interruption(true)`: enable epoch-based interruption
+- `consume_fuel(true)`: enable fuel metering
+
+### Store
+
+Owns all runtime state for instances. Carries user-defined host data.
+
+```rust
+struct HostState {
+    wasi: wasmtime_wasi::WasiCtx,
+    table: wasmtime::component::ResourceTable,
+}
+
+let mut store = Store::new(&engine, HostState { /* ... */ });
+
+// Set fuel limit
+store.set_fuel(10_000)?;
+
+// Set epoch deadline
+store.set_epoch_deadline(1);
+```
+
+### Module (Core WebAssembly)
+
+A compiled core wasm module. Use for legacy or non-component wasm.
+
+```rust
+// From file
+let module = Module::from_file(&engine, "path/to/module.wasm")?;
+
+// From bytes
+let module = Module::new(&engine, wasm_bytes)?;
+
+// Precompiled (AOT)
+let module = unsafe { Module::deserialize_file(&engine, "module.cwasm")? };
+```
+
+### Linker
+
+Resolves module imports to host functions or other module exports.
+
+```rust
+let mut linker = Linker::new(&engine);
+
+// Define a host function
+linker.func_wrap("env", "log", |caller: Caller<'_, HostState>, ptr: i32, len: i32| {
+    // read string from caller memory
+})?;
+
+// Add WASI
+wasmtime_wasi::add_to_linker_sync(&mut linker)?;
+
+// Instantiate
+let instance = linker.instantiate(&mut store, &module)?;
+```
+
+### Instance
+
+A runtime instantiation with its own memory and state.
+
+```rust
+let instance = linker.instantiate(&mut store, &module)?;
+
+// Call exported function
+let func = instance.get_typed_func::<(i32, i32), i32>(&mut store, "add")?;
+let result = func.call(&mut store, (2, 3))?;
+```
+
+## Component Model
+
+The Component Model adds typed, language-agnostic interfaces on top of core wasm.
+
+### Key Differences from Core Modules
+
+| Aspect | Core Module | Component |
+|--------|-------------|-----------|
+| Interface | Numeric types only (i32, i64, f32, f64) | Rich types (strings, records, variants, lists) |
+| Linking | By function name | By interface (package/name) |
+| Memory | Shared linear memory | Each component owns its memory |
+| Composition | Manual wiring | `wasm-tools compose` |
+| Standard | WebAssembly 1.0+ | Component Model proposal |
+
+### WIT (WebAssembly Interface Type)
+
+WIT defines typed contracts between components.
+
+#### Syntax
+
+```wit
+// Package declaration
+package my-org:my-package@1.0.0;
+
+// World: defines a component's full interface
+world my-world {
+    // Imports (what the component needs)
+    import log: func(msg: string);
+    import wasi:filesystem/types@0.2.0;
+
+    // Exports (what the component provides)
+    export process: func(input: list<u8>) -> result<list<u8>, string>;
+}
+
+// Interface: reusable group of types and functions
+interface types {
+    record point {
+        x: f64,
+        y: f64,
+    }
+
+    variant shape {
+        circle(f64),
+        rectangle(point),
+    }
+
+    enum color {
+        red,
+        green,
+        blue,
+    }
+
+    flags permissions {
+        read,
+        write,
+        execute,
+    }
+
+    resource file-handle {
+        constructor(path: string);
+        read: func(size: u32) -> list<u8>;
+        write: func(data: list<u8>);
+    }
+}
+```
+
+#### WIT Types
+
+| WIT Type | Description | Rust Mapping |
+|----------|-------------|--------------|
+| `bool` | Boolean | `bool` |
+| `u8`..`u64`, `s8`..`s64` | Integers | `u8`..`u64`, `i8`..`i64` |
+| `f32`, `f64` | Floats | `f32`, `f64` |
+| `char` | Unicode character | `char` |
+| `string` | UTF-8 string | `String` |
+| `list<T>` | Variable-length list | `Vec<T>` |
+| `option<T>` | Optional value | `Option<T>` |
+| `result<T, E>` | Success or error | `Result<T, E>` |
+| `tuple<T, U>` | Fixed tuple | `(T, U)` |
+| `record` | Named fields | `struct` |
+| `variant` | Tagged union | `enum` |
+| `enum` | Simple enumeration | `enum` (unit variants) |
+| `flags` | Bit flags | bitflags struct |
+| `resource` | Handle to host object | trait + handle |
+
+### Component Composition
+
+Combine multiple components into one using `wasm-tools compose`:
+
+```bash
+# Compose component A (needs interface X) with component B (provides interface X)
+wasm-tools compose -d b.wasm a.wasm -o composed.wasm
+```
+
+## WASI Deep Dive
+
+### WASIp1 (Preview 1)
+
+POSIX-inspired system interface using core wasm imports.
+
+```rust
+// Host setup for WASIp1
+use wasmtime_wasi::preview1;
+
+let wasi = preview1::WasiCtxBuilder::new()
+    .inherit_stdio()
+    .preopened_dir("/sandbox", ".", DirPerms::all(), FilePerms::all())?
+    .build();
+```
+
+Key WASIp1 modules:
+- `wasi_snapshot_preview1`: filesystem, clock, random, args, environ
+
+### WASIp2 (Preview 2)
+
+Component Model-based system interface with typed streams.
+
+```rust
+// Host setup for WASIp2
+use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiView};
+
+let wasi_ctx = WasiCtxBuilder::new()
+    .inherit_stdio()
+    .preopened_dir("/sandbox", "sandbox", DirPerms::all(), FilePerms::all())?
+    .build();
+```
+
+Key WASIp2 interfaces:
+- `wasi:cli/*` — args, environment, stdin/stdout/stderr
+- `wasi:filesystem/*` — files, directories, paths
+- `wasi:sockets/*` — TCP, UDP, name resolution
+- `wasi:clocks/*` — wall clock, monotonic clock
+- `wasi:random/*` — random number generation
+- `wasi:io/*` — streams, polling
+
+### Migration from WASIp1 to WASIp2
+
+1. Change target from `wasm32-wasip1` to `wasm32-wasip2`
+2. Replace `fd_*` calls with WIT-generated bindings
+3. Switch from `wasi_snapshot_preview1` imports to component imports
+4. Use `wasm-tools component new` to wrap existing p1 modules for p2 compatibility:
+   ```bash
+   wasm-tools component new module.wasm --adapt wasi_snapshot_preview1.reactor.wasm -o component.wasm
+   ```
+
+## Resource Limits
+
+### Fuel Metering
+
+Count execution cost per instruction.
+
+```rust
+let mut config = Config::new();
+config.consume_fuel(true);
+
+let mut store = Store::new(&engine, state);
+store.set_fuel(100_000)?;
+
+// Check remaining
+let remaining = store.get_fuel()?;
+
+// Handle exhaustion
+match func.call(&mut store, ()) {
+    Err(e) if e.downcast_ref::<wasmtime::Trap>() == Some(&Trap::OutOfFuel) => {
+        // refuel or terminate
+    }
+    other => other,
+}
+```
+
+### Epoch Interruption
+
+Coarse-grained cooperative interruption.
+
+```rust
+let mut config = Config::new();
+config.epoch_interruption(true);
+
+let mut store = Store::new(&engine, state);
+store.set_epoch_deadline(1);  // interrupt after 1 epoch tick
+
+// In another thread or timer:
+engine.increment_epoch();
+```
+
+### Memory Limits
+
+```rust
+// Limit memory per-instance
+let memory_type = MemoryType::new(1, Some(10));  // min 1 page, max 10 pages (640KB)
+
+// Or via Store limits
+let mut store = Store::new(&engine, state);
+store.limiter(|_| &mut StoreLimitsBuilder::new()
+    .memory_size(10 * 65536)  // 10 pages
+    .instances(10)
+    .tables(4)
+    .build());
+```
+
+### Pooling Allocator
+
+Pre-allocate resources for fast instantiation in high-throughput scenarios.
+
+```rust
+let mut pool = PoolingAllocationConfig::default();
+pool.total_memories(100);
+pool.total_tables(100);
+pool.max_memory_size(1 << 20);  // 1MB per memory
+
+let mut config = Config::new();
+config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
+```
+
+## AOT Compilation
+
+Pre-compile wasm to native code for faster startup.
+
+```bash
+# CLI
+wasmtime compile module.wasm -o module.cwasm
+
+# Cross-compile for different target
+wasmtime compile --target aarch64-unknown-linux-gnu module.wasm -o module.cwasm
+```
+
+```rust
+// Programmatic AOT
+let engine = Engine::default();
+let cwasm_bytes = engine.precompile_module(wasm_bytes)?;
+
+// Later, deserialize (unsafe: must trust the bytes)
+let module = unsafe { Module::deserialize(&engine, &cwasm_bytes)? };
+```
+
+AOT-compiled modules (`.cwasm`) are architecture-specific. The engine configuration at deserialization must match the configuration used during compilation.
+
+## Debugging and Profiling
+
+### DWARF Debug Info
+
+```rust
+let mut config = Config::new();
+config.debug_info(true);  // preserve DWARF in compiled code
+```
+
+### Profiling
+
+```rust
+let mut config = Config::new();
+config.profiler(ProfilingStrategy::JitDump);  // Linux perf
+// or
+config.profiler(ProfilingStrategy::VTune);    // Intel VTune
+```
+
+### Logging
+
+Enable wasmtime's tracing output:
+
+```bash
+WASMTIME_LOG=wasmtime=debug cargo run
+```
+
+### Inspecting Wasm Binaries
+
+```bash
+# Print module structure
+wasm-tools print module.wasm
+
+# Validate
+wasm-tools validate module.wasm
+
+# Show component interfaces
+wasm-tools component wit component.wasm
+
+# Module info
+wasm-tools dump module.wasm
+```


### PR DESCRIPTION
- Add wasm plugin with wasmtime skill covering component model, guest compilation (Rust/Zig), and host embedding (Rust/Elixir)
- Add reference docs for overview, guest-rust, guest-zig, host-rust, host-elixir
- Add wasm-inspector agent for analyzing .wasm binaries via wasm-tools CLI
- Add /wasm:inspect slash command delegating to the inspector agent
- Register wasm plugin in marketplace.json and all-skills plugin.json
- Add source attribution in skills/sources.md