### PR TITLE
feat(core): add TDD skill for test-driven development methodology

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,9 +32,9 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "category": "development",
-      "keywords": ["git", "documentation", "code-review", "tools", "beads", "container"]
+      "keywords": ["git", "documentation", "code-review", "tools", "beads", "container", "tdd"]
     },
     {
       "name": "dagu",

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "core",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["git", "documentation", "code-review", "tools", "accessibility", "material-design", "twelve-factor-app", "security", "gitleaks", "beads", "container"],
+  "keywords": ["git", "documentation", "code-review", "tools", "accessibility", "material-design", "twelve-factor-app", "security", "gitleaks", "beads", "container", "tdd"],
   "skills": [
     "./skills/git",
     "./skills/mise",
@@ -20,7 +20,8 @@
     "./skills/anti-fabrication",
     "./skills/security",
     "./skills/beads",
-    "./skills/container"
+    "./skills/container",
+    "./skills/tdd"
   ],
   "agents": [
     "./skills/beads/agents/beads-worker.md"

--- a/plugins/core/skills/beads/references/skill-catalog.md
+++ b/plugins/core/skills/beads/references/skill-catalog.md
@@ -57,6 +57,7 @@ Runtime discovery ensures that third-party or user-created skills can be suggest
 | `security` | security, secret detection, gitleaks, credential scan, API key leak |
 | `beads` | beads, task management, dependency tracking, issue tracker |
 | `container` | container, OCI, linux container, apple container, macOS container |
+| `tdd` | TDD, test-driven, red green refactor, test first, test list, walking skeleton, outside-in, double loop |
 
 ### dagu Plugin
 

--- a/plugins/core/skills/sources.md
+++ b/plugins/core/skills/sources.md
@@ -194,6 +194,39 @@ This file documents the sources used to create the core plugin skills.
 - **Purpose**: Version 0.9.0 release notes
 - **Key Topics**: Resource limits (--cpus/--memory), host.docker.internal, host-only/isolated networks, --dns on build, --force on image delete, zstd compression, Kata 3.26.0
 
+## TDD Skill
+
+### Test-Driven Development by Example
+- **Author**: Kent Beck
+- **ISBN**: 978-0321146533
+- **Purpose**: Canonical TDD methodology — the test list, Fake It, Triangulation, Obvious Implementation
+- **Key Topics**: Red-Green-Refactor cycle, test sequencing, getting to green strategies, test isolation
+
+### Growing Object-Oriented Software, Guided by Tests
+- **Author**: Steve Freeman & Nat Pryce
+- **ISBN**: 978-0321503626
+- **Purpose**: Outside-in TDD, double-loop TDD, walking skeletons, ports and adapters
+- **Key Topics**: Acceptance-test-driven development, Tell Don't Ask, role-based interfaces, test doubles, design feedback from tests
+
+### The Three Laws of TDD
+- **Author**: Robert C. Martin
+- **URL**: https://www.butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd
+- **Purpose**: Concise formalization of Beck's TDD constraints into three strict laws
+
+### Software Craftsmanship Manifesto
+- **URL**: https://manifesto.softwarecraftsmanship.org/
+- **Purpose**: Professional framing for TDD as a craftsmanship discipline
+
+### Canon TDD
+- **Author**: Kent Beck
+- **URL**: https://tidyfirst.substack.com/p/canon-tdd
+- **Purpose**: Beck's 2023 restatement of canonical TDD, clarifying the five steps and their rationale
+
+### TDD (Martin Fowler's Bliki)
+- **Author**: Martin Fowler
+- **URL**: https://martinfowler.com/bliki/TestDrivenDevelopment.html
+- **Purpose**: Accessible overview of TDD practice and its relationship to software design
+
 ## Plugin Information
 
 - **Name**: core

--- a/plugins/core/skills/tdd/SKILL.md
+++ b/plugins/core/skills/tdd/SKILL.md
@@ -1,0 +1,340 @@
+---
+name: tdd
+description: Test-Driven Development methodology and discipline. Use when writing code test-first, practicing Red-Green-Refactor, building walking skeletons, applying outside-in development, or sequencing tests for incremental design.
+license: MIT
+---
+
+# Test-Driven Development
+
+A discipline for growing software guided by tests, one small step at a time.
+
+## When to Activate
+
+Use this skill when:
+- Writing code test-first for a new feature or module
+- Starting a greenfield project and need a walking skeleton
+- Applying outside-in development from acceptance tests to unit tests
+- Sequencing tests to drive incremental design
+- Creating a test list to plan implementation
+- Reviewing whether tests are giving good design feedback
+- Deciding between Fake It, Obvious Implementation, or Triangulation
+
+## The TDD Cycle
+
+### Five Steps
+
+1. **Write a test list** — brainstorm the tests you think you'll need
+2. **Write one failing test** — pick the next test from the list
+3. **Make it pass** — write the simplest code that makes the test green
+4. **Refactor** — remove duplication and improve design, keeping tests green
+5. **Repeat** — pick the next test, update the list as you learn
+
+### Red-Green-Refactor
+
+The micro-cycle is a three-state machine:
+
+```
+    ┌──────────────────────────────────────┐
+    │                                      │
+    ▼                                      │
+  [RED] ──── write minimal code ────► [GREEN] ──── refactor ────► [GREEN]
+    ▲                                                                │
+    │                                                                │
+    └──────────── write next failing test ◄──────────────────────────┘
+```
+
+**RED**: Write a test that fails. Confirm it fails for the *right reason* — the missing behavior, not a syntax error or wrong import.
+
+**GREEN**: Make the test pass with the simplest change possible. "Sinful" code is fine — hardcoded values, copy-paste, whatever gets green fastest.
+
+**REFACTOR**: Clean up while all tests stay green. Remove duplication between test and production code. Improve names. Extract methods. This is where design emerges.
+
+Rules:
+- Never write production code without a failing test
+- Never write more test code than needed to fail
+- Never write more production code than needed to pass
+
+### The Three Laws
+
+Uncle Bob's formalization of Beck's constraints:
+
+1. You shall not write production code unless you have a failing test
+2. You shall not write more of a test than is sufficient to fail (including compile failures)
+3. You shall not write more production code than is sufficient to pass the currently failing test
+
+These laws enforce the micro-cycle. They keep steps small and feedback immediate.
+
+## Test List
+
+A test list is a brainstorm of all the tests you think you'll need, written *before* you start coding. It is your roadmap.
+
+### How to Create One
+
+1. Think about the behavior you need to implement
+2. List the specific cases: happy path, edge cases, error cases
+3. Order them from simplest to most complex
+4. Start with a degenerate case if possible
+
+### Example: Stack
+
+```
+Test List:
+- [ ] new stack is empty
+- [ ] push one item, stack is not empty
+- [ ] push one item then pop, returns that item
+- [ ] push two items then pop, returns second item
+- [ ] pop empty stack raises error
+- [ ] push and pop multiple items (LIFO order)
+- [ ] peek returns top without removing
+```
+
+### When to Update
+
+The test list is alive. As you work:
+- Cross off completed tests
+- Add new tests you discover along the way
+- Remove tests that turn out to be redundant
+- Reorder if a different sequence makes more sense
+
+A test list can seed beads tasks — create one task per test with `skill:tdd` labels for tracking.
+
+## Strategies for Getting to Green
+
+Three strategies for making a failing test pass, in order of safety:
+
+### Fake It
+
+Return a hardcoded value that makes the test pass. Then write the next test to force generalization.
+
+```
+# Test: add(1, 2) returns 3
+# Fake It:
+def add(a, b):
+    return 3
+
+# Next test forces real implementation:
+# Test: add(3, 4) returns 7
+```
+
+**When to use**: When you're unsure how to implement the real thing. When the step to real code feels too big. When you want maximum safety.
+
+### Obvious Implementation
+
+Type the real implementation directly, because it's clear what the code should be.
+
+```
+# Test: add(1, 2) returns 3
+# Obvious Implementation:
+def add(a, b):
+    return a + b
+```
+
+**When to use**: When the implementation is trivially obvious. When you're confident. If you get an unexpected failure, *fall back to Fake It*.
+
+### Triangulation
+
+Use two or more test cases to force removal of hardcoded values and drive toward the general solution.
+
+```
+# Test 1: add(1, 2) returns 3
+def add(a, b):
+    return 3           # fake it
+
+# Test 2: add(3, 4) returns 7
+def add(a, b):
+    return a + b       # now forced to generalize
+```
+
+**When to use**: When you're uncertain about the abstraction. When two examples make the pattern clearer than one. When you need confidence before generalizing.
+
+## Test Sequencing
+
+> "As tests get more specific, code gets more generic." — Robert C. Martin
+
+Start with degenerate cases and progress toward forcing generalization:
+
+1. **Degenerate/boundary cases** — null, empty, zero, one element
+2. **Simple happy path** — the most basic successful case
+3. **Variations** — different inputs that exercise the same path
+4. **Edge cases** — boundaries, maximums, special values
+5. **Error cases** — invalid input, missing data, failure conditions
+
+Each new test should require a small, incremental change to the production code. If a test requires a large change, you skipped a step — find a simpler test to write first.
+
+### Sequencing Example: FizzBuzz
+
+```
+Test List (ordered):
+1. returns "1" for 1          → hardcode "1"
+2. returns "2" for 2          → return string of number
+3. returns "Fizz" for 3       → add modulo-3 check
+4. returns "Fizz" for 6       → confirms generalization
+5. returns "Buzz" for 5       → add modulo-5 check
+6. returns "Buzz" for 10      → confirms generalization
+7. returns "FizzBuzz" for 15  → add modulo-15 check
+8. returns "FizzBuzz" for 30  → confirms generalization
+```
+
+## Double-Loop TDD
+
+Freeman & Pryce's model from *Growing Object-Oriented Software, Guided by Tests*:
+
+```
+  Outer Loop (Acceptance Test)
+  ┌──────────────────────────────────────────────────┐
+  │                                                  │
+  │  Write failing          Acceptance test passes   │
+  │  acceptance test ──────────────────► Done         │
+  │       │                      ▲                   │
+  │       ▼                      │                   │
+  │   Inner Loop (Unit Tests)    │                   │
+  │   ┌────────────────────┐     │                   │
+  │   │ RED → GREEN →      │     │                   │
+  │   │ REFACTOR → repeat  │─────┘                   │
+  │   └────────────────────┘                         │
+  │                                                  │
+  └──────────────────────────────────────────────────┘
+```
+
+**Outer loop**: Write a failing end-to-end acceptance test that describes the feature from the user's perspective. This test stays red while you build the internals.
+
+**Inner loop**: Use the standard Red-Green-Refactor cycle to implement the components needed to make the acceptance test pass.
+
+### Walking Skeleton
+
+Start with the thinnest possible slice that exercises the full architecture:
+
+1. Write a failing acceptance test for the simplest end-to-end scenario
+2. Build just enough of each layer to make it pass — UI, service, persistence
+3. Deploy the skeleton to a production-like environment
+4. Every subsequent feature builds on this proven foundation
+
+The walking skeleton proves your architecture works before you invest in features. It's the first acceptance test in the outer loop.
+
+## Outside-In Development
+
+Start at the system boundary and work inward, discovering collaborators through tests.
+
+### The Process
+
+1. **Start at the boundary** — write a test for the entry point (HTTP handler, CLI command, message consumer)
+2. **Discover collaborators** — when the boundary object needs help, define an interface for the collaborator
+3. **Test the collaborator** — drop down one level and TDD the collaborator
+4. **Repeat inward** — each layer discovers the next through its tests
+5. **Integrate** — wire real implementations together; the acceptance test goes green
+
+### Tell, Don't Ask
+
+Prefer commands over queries. Tell objects what to do rather than asking for data and acting on it:
+
+```
+# Ask (fragile — coupled to internal structure):
+if order.status == "paid" and order.items_in_stock():
+    warehouse.ship(order.items)
+
+# Tell (robust — delegates to the object that knows):
+order.fulfill(warehouse)
+```
+
+### Ports and Adapters
+
+Separate domain logic from infrastructure for testability:
+
+```
+          ┌─────────────────────────┐
+ HTTP ───►│ Adapter                 │
+          │   └► Port (interface)   │
+          │        └► Domain Logic  │
+          │   ┌► Port (interface)   │
+          │ Adapter                 │◄─── Database
+          └─────────────────────────┘
+```
+
+- **Ports**: Interfaces defined by the domain (what it needs)
+- **Adapters**: Implementations that connect to infrastructure (how it's provided)
+- Tests can substitute adapters with test doubles, keeping tests fast and isolated
+
+## Listen to the Tests
+
+When tests are hard to write, they're telling you something about your design. Difficulty in testing is a symptom of a design problem.
+
+| Difficulty Signal | Probable Design Issue | Suggested Refactoring |
+|---|---|---|
+| Test needs many objects to set up | Class has too many dependencies | Extract class, introduce facade |
+| Test setup is deeply nested | Object graph is too complex | Flatten hierarchy, use composition |
+| Hard to name the test | Method does too many things | Extract method, single responsibility |
+| Test needs to access private state | Public interface is insufficient | Improve public API, add query method |
+| Many tests break for one change | High coupling between classes | Introduce interface, dependency inversion |
+| Slow tests (not integration) | Hidden I/O or expensive operations | Extract port/adapter, inject dependency |
+| Test requires complex mocking | Violation of Law of Demeter | Wrap and delegate, tell don't ask |
+| Test duplicates production logic | Missing abstraction | Extract shared concept |
+| Can't test in isolation | Static calls, global state, `new` | Inject dependencies, use factory |
+
+## Craftsmanship Principles
+
+From the Software Craftsmanship Manifesto, applied to TDD:
+
+- **Well-crafted software** — TDD produces code that works, is clean, and communicates intent
+- **Steadily adding value** — each green test is a verified increment of working software
+- **A community of professionals** — TDD is a shared discipline, not a personal preference
+- **Productive partnerships** — tests document behavior for the team; they're a communication tool
+
+TDD is a professional practice. Not every line of code requires it, but when you practice it, practice it with discipline. Half-hearted TDD (writing tests but skipping refactoring, or testing after the fact) delivers little of the benefit.
+
+## Language Testing Skills
+
+TDD teaches *when* and *why* to write tests. Language-specific skills teach *how* to use the testing framework. Load both when practicing TDD in a specific language.
+
+| TDD Concept | Elixir (`elixir-testing`) | Rust (`rust`) | Zig (`zig`) |
+|---|---|---|---|
+| Write a failing test | `test "name" do ... end` | `#[test] fn name()` | `test "name" = \|\| { ... }` |
+| Assertions | `assert`, `assert_receive` | `assert!`, `assert_eq!` | `try expect(...)` |
+| Test isolation | `async: true`, sandbox | Module-level isolation | Test allocator |
+| Test doubles | Mox for behaviours | Trait-based injection | Comptime interfaces |
+| Property tests | StreamData | proptest, quickcheck | N/A |
+| Test organization | `describe` blocks, tags | Module hierarchy, `#[cfg(test)]` | Nested test blocks |
+
+## Anti-Patterns
+
+### Test-After Development
+
+Writing code first, tests second. You lose the design feedback loop — tests conform to the code rather than driving it. Tests become verification scripts, not design tools.
+
+### Writing Too Many Tests Before Going Green
+
+Writing five tests at once, then trying to make them all pass. You lose the tight feedback cycle and can't triangulate. Write one test, make it pass, then write the next.
+
+### Skipping the Refactor Step
+
+Going from green straight to the next test. Duplication accumulates. Design degrades. The codebase becomes harder to change, and TDD feels slower than it should. Refactoring is where TDD pays for itself.
+
+### Testing Implementation Details
+
+Testing *how* code works rather than *what* it does. Brittle tests that break when you refactor internals. Test behavior through the public interface.
+
+### Gold-Plating (YAGNI)
+
+Adding behavior not driven by a test. Adding tests for scenarios nobody asked for. If it's not on the test list and not an edge case you discovered, you ain't gonna need it.
+
+### Ice Cream Cone
+
+Many end-to-end tests, few unit tests. Invert the pyramid — most tests should be fast unit tests. End-to-end tests verify integration, not logic.
+
+## References
+
+For deeper theory and worked examples:
+- `references/beck-tdd.md` — Kent Beck's canonical TDD: Fake It, Triangulation, test isolation
+- `references/goos-outside-in.md` — Freeman & Pryce's GOOS: double-loop TDD, walking skeleton, outside-in design
+
+## Key Principles
+
+- Write the test first — always
+- Keep steps small — if it feels like a leap, find a smaller step
+- Red-Green-Refactor is a discipline, not a suggestion — never skip refactor
+- The test list is your roadmap — update it as you learn
+- Listen to the tests — difficulty testing signals design problems
+- Fake It when unsure, Obvious Implementation when confident
+- As tests get more specific, code gets more generic
+- Walking skeleton first — prove the architecture before building features
+- Outside-in discovers interfaces — let tests drive the design inward
+- TDD is about design, not just verification

--- a/plugins/core/skills/tdd/references/beck-tdd.md
+++ b/plugins/core/skills/tdd/references/beck-tdd.md
@@ -1,0 +1,214 @@
+# Beck's Canonical TDD
+
+Deep-dive into Kent Beck's *Test-Driven Development by Example* — the foundational text on TDD practice.
+
+## The Test List in Depth
+
+The test list is the bridge between requirements and code. Before writing any code, brainstorm all the tests you can think of for the behavior you're about to implement.
+
+### From User Stories to Tests
+
+A user story describes *what* the user wants. The test list describes *how* you'll verify it:
+
+```
+User Story: "As a user, I can transfer money between accounts"
+
+Test List:
+- [ ] transfer $100 from account with $500, sender has $400
+- [ ] transfer $100 from account with $500, receiver gets $100 more
+- [ ] transfer full balance leaves sender at $0
+- [ ] transfer more than balance is rejected
+- [ ] transfer $0 is rejected
+- [ ] transfer negative amount is rejected
+- [ ] transfer between same account is rejected
+- [ ] transfer updates both accounts atomically
+```
+
+### Test List Heuristics
+
+- **Start with the simplest happy path** — the one that requires the least code
+- **Add boundary cases** — zero, one, empty, maximum
+- **Add error cases** — what should be rejected or fail
+- **Group related tests** — they often share setup
+- **Don't aim for completeness** — you'll discover more tests as you go
+
+## Fake It Till You Make It
+
+Fake It is the safest strategy for getting to green. Return a constant, then let the next test force generalization.
+
+### Worked Example: Currency Multiplication
+
+```
+# Test 1: 5 CHF * 2 = 10 CHF
+def test_multiplication():
+    five = Money(5, "CHF")
+    result = five.times(2)
+    assert result.amount == 10
+
+# Fake It:
+class Money:
+    def __init__(self, amount, currency):
+        self.amount = amount
+        self.currency = currency
+
+    def times(self, multiplier):
+        return Money(10, self.currency)    # hardcoded!
+```
+
+```
+# Test 2: 5 CHF * 3 = 15 CHF
+def test_multiplication_by_three():
+    five = Money(5, "CHF")
+    result = five.times(3)
+    assert result.amount == 15
+
+# Now we're forced to generalize:
+class Money:
+    def times(self, multiplier):
+        return Money(self.amount * multiplier, self.currency)
+```
+
+```
+# Test 3: 7 CHF * 3 = 21 CHF
+def test_different_amount():
+    seven = Money(7, "CHF")
+    result = seven.times(3)
+    assert result.amount == 21
+
+# Passes immediately — our generalization works
+# Cross off the test and move on
+```
+
+### Why Fake It Works
+
+1. **Guaranteed green** — you know the test will pass because you hardcoded the answer
+2. **Small steps** — each change is tiny and verifiable
+3. **Forces the next test** — you must write another test to remove the fake
+4. **Builds confidence** — each passing test is proof of progress
+
+## Triangulation in Practice
+
+Triangulation means writing two or more test cases before generalizing. When you have multiple specific examples, the general pattern becomes clear.
+
+### When to Use Triangulation
+
+- When you're unsure what the abstraction should be
+- When the generalization isn't obvious from one example
+- When you want extra confidence before generalizing
+
+### Example: Equality
+
+```
+# Test 1: same amount and currency are equal
+def test_equality():
+    assert Money(5, "CHF") == Money(5, "CHF")
+
+# Fake It:
+class Money:
+    def __eq__(self, other):
+        return True    # faked!
+```
+
+```
+# Test 2: different amounts are not equal
+def test_inequality_amount():
+    assert Money(5, "CHF") != Money(6, "CHF")
+
+# First triangulation point — need to check amount:
+class Money:
+    def __eq__(self, other):
+        return self.amount == other.amount    # partially generalized
+```
+
+```
+# Test 3: different currencies are not equal
+def test_inequality_currency():
+    assert Money(5, "CHF") != Money(5, "USD")
+
+# Second triangulation point — need to check currency too:
+class Money:
+    def __eq__(self, other):
+        return (self.amount == other.amount and
+                self.currency == other.currency)    # fully generalized
+```
+
+Each test forced a refinement. No single test was enough to drive the full implementation — that's the value of triangulation.
+
+## Obvious Implementation
+
+When the code is trivially clear, skip the fake and write the real implementation directly.
+
+```
+# Test: adding two positive numbers
+def test_add():
+    assert add(2, 3) == 5
+
+# Obvious Implementation (no need to fake this):
+def add(a, b):
+    return a + b
+```
+
+### Risk Assessment
+
+Obvious Implementation is faster but riskier:
+- **Use it when**: The code is trivial, you've written similar code many times, you're confident
+- **Fall back when**: You get an unexpected red, the implementation is longer than a few lines, or you're in unfamiliar territory
+- **The rule**: If Obvious Implementation gives you a red you didn't expect, *fall back to Fake It immediately*
+
+## The Milli-Cycle
+
+> "As tests get more specific, code gets more generic."
+
+This is Beck's key insight about the relationship between tests and production code. Each specific test case drives the code toward a more general solution:
+
+```
+Test: "1" → returns 1       Code: return 1
+Test: "2" → returns 2       Code: return int(input)
+Test: "1,2" → returns 3     Code: return sum(int(x) for x in input.split(","))
+Test: "" → returns 0        Code: if not input: return 0; ...
+Test: "1\n2,3" → returns 6  Code: return sum(int(x) for x in re.split("[,\n]", input))
+```
+
+Each test adds a specific constraint. The code responds by becoming more general.
+
+## The Three Laws — Detailed Rationale
+
+### Law 1: No production code without a failing test
+
+**Why**: Every line of production code exists because a test demanded it. No code exists "just in case" or "for completeness." This prevents gold-plating and YAGNI violations.
+
+### Law 2: No more test code than needed to fail
+
+**Why**: Keep the test small so the failure message is precise. A test that checks five things at once gives unclear feedback. A test that checks one thing tells you exactly what's broken.
+
+### Law 3: No more production code than needed to pass
+
+**Why**: Resist the urge to write the "full" implementation. Write only what the current test demands. The next test will demand more. This keeps you in the tight feedback loop.
+
+## Test Isolation and Independence
+
+Each test must:
+- **Set up its own state** — no reliance on other tests having run first
+- **Clean up after itself** — no side effects that affect other tests
+- **Be runnable in any order** — shuffling test order shouldn't break anything
+- **Be runnable alone** — extracting a single test to run should work
+
+### Shared Setup vs. Independence
+
+Shared setup (before-each, fixtures) is fine for reducing duplication, but every test must be understandable in isolation. If you need to read three other tests to understand what one test does, extract the setup into a descriptively-named helper.
+
+## When TDD Feels Wrong
+
+Sometimes TDD feels slow, painful, or forced. This is signal, not noise:
+
+| What Feels Wrong | What It Might Mean |
+|---|---|
+| "I can't figure out what test to write first" | The requirements are unclear — clarify before coding |
+| "Setting up the test is harder than writing the code" | Too many dependencies — simplify the design |
+| "I need to test a private method" | The class is doing too much — extract a collaborator |
+| "My tests break every time I refactor" | Tests are coupled to implementation — test behavior, not structure |
+| "TDD feels slow for this" | Maybe it's simple enough for Obvious Implementation — or maybe you're fighting the design |
+| "I wrote the code first and now I can't test it" | The code wasn't designed for testability — use outside-in next time |
+| "I need a database / network for every test" | Missing ports and adapters — inject dependencies |
+
+When TDD feels wrong, the answer is almost never "skip TDD." The answer is usually "change the design."

--- a/plugins/core/skills/tdd/references/goos-outside-in.md
+++ b/plugins/core/skills/tdd/references/goos-outside-in.md
@@ -1,0 +1,341 @@
+# Growing Object-Oriented Software, Guided by Tests
+
+Deep-dive into Freeman & Pryce's approach to TDD — outside-in development, walking skeletons, and using tests as a design tool.
+
+## Double-Loop TDD — Detailed
+
+The double loop separates *what* the system should do (outer) from *how* it does it (inner).
+
+```
+  Feature Request
+       │
+       ▼
+  ┌─────────────────────────────────────────────────────┐
+  │  OUTER LOOP: Acceptance Test                        │
+  │                                                     │
+  │  Write failing acceptance test                      │
+  │       │                                             │
+  │       ▼                                             │
+  │  ┌─────────────────────────────────────────────┐    │
+  │  │  INNER LOOP: Unit Tests                     │    │
+  │  │                                             │    │
+  │  │  ┌───► RED (write failing unit test)        │    │
+  │  │  │          │                               │    │
+  │  │  │          ▼                               │    │
+  │  │  │     GREEN (make it pass)                 │    │
+  │  │  │          │                               │    │
+  │  │  │          ▼                               │    │
+  │  │  │     REFACTOR (clean up)                  │    │
+  │  │  │          │                               │    │
+  │  │  │          ▼                               │    │
+  │  │  └──── more unit tests needed? ─── yes ─┘  │    │
+  │  │              │ no                           │    │
+  │  └──────────────┼──────────────────────────────┘    │
+  │                 ▼                                    │
+  │         Acceptance test passes?                     │
+  │              │ no ──► back to inner loop             │
+  │              │ yes                                   │
+  │              ▼                                       │
+  │         Feature complete                             │
+  └─────────────────────────────────────────────────────┘
+```
+
+### Outer Loop: Acceptance Tests
+
+- Written from the **user's perspective** — they describe behavior, not implementation
+- Exercise the **full system** — from entry point through to output
+- Stay **red** while you build — they're the goal, not the guide
+- Provide a **definition of done** — when the acceptance test goes green, the feature is complete
+
+### Inner Loop: Unit Tests
+
+- Written from the **developer's perspective** — they describe object responsibilities
+- Exercise **individual components** — fast, isolated, focused
+- Follow **Red-Green-Refactor** — the standard TDD micro-cycle
+- **Discover collaborators** — when a unit needs help, define an interface
+
+### Worked Example: Notification Service
+
+Outer loop (acceptance test):
+```
+test "user receives email when order ships":
+    place_order(user, item)
+    ship_order(order_id)
+    assert_email_received(user.email, subject: "Your order has shipped")
+```
+
+Inner loop iteration 1 — shipping service:
+```
+test "ship_order marks order as shipped":
+    order = create_order(status: "paid")
+    shipping_service.ship(order)
+    assert order.status == "shipped"
+```
+
+Inner loop iteration 2 — notification:
+```
+test "ship_order triggers notification":
+    notifier = mock(Notifier)
+    shipping_service = ShippingService(notifier)
+    shipping_service.ship(order)
+    assert notifier.received(:send_shipment_notification, order)
+```
+
+Inner loop iteration 3 — email notifier:
+```
+test "email notifier sends shipment email":
+    mailer = mock(Mailer)
+    notifier = EmailNotifier(mailer)
+    notifier.send_shipment_notification(order)
+    assert mailer.received(:send, to: order.email, subject: "Your order has shipped")
+```
+
+Wire it together → acceptance test goes green.
+
+## Walking Skeleton
+
+A walking skeleton is the thinnest possible end-to-end slice that exercises your full architecture.
+
+### Why It Matters
+
+- **Proves the architecture** — before investing in features, verify all layers connect
+- **Reduces integration risk** — find deployment and wiring issues on day one
+- **Provides a deployment pipeline** — the skeleton needs to build, test, and deploy
+- **Creates a foundation** — every subsequent feature adds flesh to the skeleton
+
+### Steps to Create One
+
+1. **Pick the simplest end-to-end scenario** — "user can see empty list" rather than "user can search and filter with pagination"
+2. **Write a failing acceptance test** for that scenario
+3. **Implement the thinnest slice through every layer**:
+   - Entry point (HTTP route, CLI command)
+   - Application logic (even if it just returns empty)
+   - Persistence (even if it's in-memory)
+   - Output (even if it's minimal JSON)
+4. **Deploy to a production-like environment**
+5. **Verify the acceptance test passes end-to-end**
+
+### Skeleton Test as First Acceptance Test
+
+```
+test "GET /todos returns empty list":
+    response = http_get("/todos")
+    assert response.status == 200
+    assert response.body == []
+```
+
+This simple test forces you to:
+- Set up an HTTP server
+- Define a route
+- Connect to a data store
+- Return a response
+- Have a working test harness
+
+That's a full architectural spike disguised as a trivial test.
+
+## Outside-In Design
+
+### Start at the Boundary
+
+The boundary is where the system meets the outside world. Start your tests there and work inward:
+
+```
+Boundary (test starts here)
+  │
+  ├── HTTP Handler
+  │     └── Application Service
+  │           ├── Domain Object
+  │           └── Repository (interface)
+  │                 └── Database Adapter (test double in tests)
+  │
+  └── Output
+```
+
+### Discover Interfaces Through Collaborator Questions
+
+When testing an object, ask: "What does this object need to do its job?"
+
+The answer defines an interface for a collaborator:
+
+```
+# Testing the OrderController — what does it need?
+# Answer: Something that can process orders → OrderService interface
+
+test "POST /orders creates an order":
+    order_service = mock(OrderService)
+    controller = OrderController(order_service)
+
+    controller.handle_post(item: "widget", qty: 3)
+
+    assert order_service.received(:create_order, item: "widget", qty: 3)
+```
+
+Now drop down and TDD the OrderService:
+
+```
+# Testing OrderService — what does it need?
+# Answer: Something that can save orders → OrderRepository interface
+
+test "create_order saves order to repository":
+    repo = mock(OrderRepository)
+    service = OrderService(repo)
+
+    service.create_order(item: "widget", qty: 3)
+
+    assert repo.received(:save, order_with(item: "widget", qty: 3))
+```
+
+Each layer discovers the next through its tests.
+
+## Ports and Adapters for Testability
+
+### Separating Domain from Infrastructure
+
+The domain defines **ports** — interfaces that describe what it needs. Infrastructure provides **adapters** — implementations that connect to real systems.
+
+```
+┌──────────────────────────────────────────────┐
+│                  Domain                       │
+│                                              │
+│  OrderService                                │
+│    needs: OrderRepository (port)             │
+│    needs: PaymentGateway (port)              │
+│    needs: Notifier (port)                    │
+│                                              │
+├──────────────────────────────────────────────┤
+│               Adapters                        │
+│                                              │
+│  PostgresOrderRepository (implements port)    │
+│  StripePaymentGateway (implements port)       │
+│  EmailNotifier (implements port)              │
+│                                              │
+├──────────────────────────────────────────────┤
+│             Test Doubles                      │
+│                                              │
+│  InMemoryOrderRepository (implements port)    │
+│  FakePaymentGateway (implements port)         │
+│  MockNotifier (implements port)               │
+│                                              │
+└──────────────────────────────────────────────┘
+```
+
+### Test Through Ports
+
+- Unit tests inject test doubles through the same ports as production adapters
+- The domain never knows whether it's talking to Postgres or an in-memory store
+- Swapping adapters requires zero changes to domain code or tests
+
+## Tell, Don't Ask
+
+Prefer telling objects what to do over querying their state and acting on it.
+
+### Ask (Fragile)
+
+```
+# Controller queries order, makes decisions, calls warehouse
+order = repo.find(order_id)
+if order.status == "paid":
+    items = order.line_items()
+    for item in items:
+        if warehouse.in_stock(item.sku, item.qty):
+            warehouse.reserve(item.sku, item.qty)
+        else:
+            raise OutOfStock(item.sku)
+    order.set_status("fulfilled")
+    repo.save(order)
+```
+
+Problems: controller knows too much about order internals, warehouse mechanics, and the fulfillment process.
+
+### Tell (Robust)
+
+```
+# Controller tells order to fulfill itself with the warehouse
+order = repo.find(order_id)
+order.fulfill(warehouse)
+repo.save(order)
+```
+
+Benefits: order encapsulates its own fulfillment logic, controller is thin, easy to test each piece independently.
+
+### Why This Matters for TDD
+
+Tell Don't Ask produces objects with clear responsibilities that are easy to test in isolation. Ask-style code produces tests that set up complex state, assert on internal details, and break when internals change.
+
+## Role-Based Interfaces
+
+Name interfaces by the *role* they play, not the implementation they use:
+
+```
+# By implementation (fragile):
+PostgresDatabase
+SmtpEmailSender
+StripeCharger
+
+# By role (stable):
+OrderRepository
+Notifier
+PaymentGateway
+```
+
+Role-based names:
+- Make tests read like specifications
+- Survive implementation changes
+- Encourage substitutability
+- Focus on behavior, not technology
+
+## Test Doubles and Their Roles
+
+| Double | Purpose | When to Use |
+|---|---|---|
+| **Stub** | Returns predetermined data | When you need to control indirect inputs |
+| **Mock** | Verifies expected interactions | When you need to verify an object sends the right messages |
+| **Fake** | Working implementation (simplified) | When you need realistic behavior without infrastructure (e.g., in-memory database) |
+| **Spy** | Records calls for later verification | When you want to verify after the fact without setting expectations upfront |
+
+### Choosing the Right Double
+
+- **Default to stubs** for most collaborators — control inputs, don't assert on them
+- **Use mocks sparingly** — only for interactions that are the *purpose* of the object under test
+- **Use fakes for integration** — when you need realistic behavior in integration tests
+- **Avoid mocking types you don't own** — wrap third-party code behind your own interface, then mock the wrapper
+
+## Listening to the Tests: Design Feedback Catalog
+
+Tests are a design tool. When they're hard to write, they're showing you a design problem.
+
+### Setup Difficulty
+
+| Symptom | Design Issue | Refactoring |
+|---|---|---|
+| Too many constructor parameters | Class has too many responsibilities | Extract class, apply SRP |
+| Deep object graph to construct | Tight coupling, missing abstractions | Introduce factory, builder, or facade |
+| Need to set many fields before acting | Object has too much state | Break into smaller objects with less state |
+| Complex test fixtures | Missing domain concepts | Extract value objects, introduce aggregates |
+
+### Assertion Difficulty
+
+| Symptom | Design Issue | Refactoring |
+|---|---|---|
+| Asserting on internal state | Insufficient public interface | Add query methods, improve API |
+| Asserting on many values at once | Method returns too much / does too much | Split method, return value objects |
+| Expected values are hard to compute | Logic is complex or unclear | Extract named calculations, simplify |
+| Need test-only accessors | Design doesn't expose needed information | Reconsider the public contract |
+
+### Structural Difficulty
+
+| Symptom | Design Issue | Refactoring |
+|---|---|---|
+| Can't test without a database | Domain coupled to infrastructure | Introduce port/adapter, inject dependency |
+| Static method calls block testing | Hidden dependencies | Convert to instance methods with injection |
+| Global state causes test interference | Shared mutable state | Make state explicit, pass through constructor |
+| Circular dependencies in test setup | Circular coupling in production code | Break cycle with interface or events |
+
+### Maintenance Difficulty
+
+| Symptom | Design Issue | Refactoring |
+|---|---|---|
+| Many tests break for one change | Feature envy, high coupling | Move behavior closer to data, add interfaces |
+| Tests duplicate production logic | Missing abstraction | Extract shared concept into named method |
+| Tests are hard to read | Poor naming, missing helpers | Extract test helpers, improve names |
+| Tests are slow | Hidden I/O, missing boundaries | Introduce seams, separate fast and slow tests |


### PR DESCRIPTION
## Summary

- Adds a language-agnostic TDD skill to the core plugin covering Red-Green-Refactor, test lists, strategies for getting to green, double-loop TDD, outside-in development, and walking skeletons
- Includes two reference files: Beck's canonical TDD deep-dive and Freeman & Pryce's GOOS outside-in approach
- Cross-references existing language testing skills (elixir, rust, zig) with a concept mapping table

## Files Changed (7)

**New:**
- `plugins/core/skills/tdd/SKILL.md` — methodology overview (~280 lines)
- `plugins/core/skills/tdd/references/beck-tdd.md` — Beck TDD deep-dive (~150 lines)
- `plugins/core/skills/tdd/references/goos-outside-in.md` — GOOS approach (~150 lines)

**Modified:**
- `plugins/core/.claude-plugin/plugin.json` — added skill + keyword, bumped 0.1.15 → 0.1.16
- `.claude-plugin/marketplace.json` — bumped core version 0.1.15 → 0.1.16
- `plugins/core/skills/beads/references/skill-catalog.md` — added `tdd` row
- `plugins/core/skills/sources.md` — added TDD sources section

## Test plan

- [x] `mise test` passes (marketplace, plugins, claude validation)
- [x] SKILL.md frontmatter is valid YAML
- [x] `./skills/tdd` present in plugin.json skills array
- [x] `tdd` row present in skill-catalog.md core plugin table
- [ ] CI passes on PR