### PR TITLE
feat(claude-code): improve claude-skills skill + add skill benchmarking

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.12",
+      "version": "0.3.13",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -23,9 +23,9 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills: plugin marketplace management and validation",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "category": "tools",
-      "keywords": ["claude-code", "marketplace", "validation", "teams"]
+      "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark"]
     },
     {
       "name": "core",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -25,6 +25,7 @@
     "./plugins/tools/claude-code/skills/claude-skills",
     "./plugins/tools/claude-code/skills/claude-hooks",
     "./plugins/tools/claude-code/skills/claude-teams",
+    "./plugins/tools/claude-code/skills/claude-skills-benchmark",
     "./plugins/core/skills/git",
     "./plugins/core/skills/mise",
     "./plugins/core/skills/nushell",
@@ -37,6 +38,7 @@
     "./plugins/core/skills/security",
     "./plugins/core/skills/beads",
     "./plugins/core/skills/container",
+    "./plugins/core/skills/tdd",
     "./plugins/tools/dagu/skills/workflows",
     "./plugins/tools/dagu/skills/webui",
     "./plugins/tools/dagu/skills/rest-api",
@@ -48,6 +50,7 @@
     "./plugins/tools/github/skills/actions",
     "./plugins/tools/github/skills/workflows",
     "./plugins/tools/github/skills/act",
+    "./plugins/tools/github/skills/community-health",
     "./plugins/languages/rust/skills/rust",
     "./plugins/languages/rust/skills/ownership",
     "./plugins/languages/rust/skills/error-handling",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -702,6 +702,8 @@ Install the plugin to build your own plugins:
 - **Claude Skills Cookbook**: https://github.com/anthropics/claude-cookbooks/tree/main/skills
 - **Skill-Creator Skill**: https://github.com/anthropics/skills/tree/main/skill-creator
 - **Agent Skills Blog Post**: https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills
+- **Building Skills Guide (PDF)**: https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf
+- **Improving Skill Creator Blog**: https://claude.com/blog/improving-skill-creator-test-measure-and-refine-agent-skills
 - **Agent Skills Specification**: https://github.com/anthropics/skills/blob/main/agent_skills_spec.md
 - **Claude Code Plugins**: https://code.claude.com/docs/en/plugins
 - **Plugin Marketplaces**: https://code.claude.com/docs/en/plugin-marketplaces

--- a/README.md
+++ b/README.md
@@ -415,6 +415,48 @@ nu .claude-plugin/scripts/update-all-skills.nu
 
 See [test/README.md](test/README.md) for complete testing documentation.
 
+### Skill Quality Scorecard
+
+Analyze all skills against Anthropic's best practices:
+
+```bash
+# Run skill quality checks standalone
+mise test:skills-quality
+
+# Or as part of the full test suite (included automatically)
+mise test
+```
+
+This produces a scorecard table:
+
+```
+╭────┬─────────────────────────┬─────────────┬──────┬──────────┬─────────┬──────────┬──────────┬──────────┬───────╮
+│  # │          skill          │   plugin    │ desc │ use_when │  lines  │ lines_ok │ examples │ anti_fab │ score │
+├────┼─────────────────────────┼─────────────┼──────┼──────────┼─────────┼──────────┼──────────┼──────────┼───────┤
+│  0 │ plugin-marketplace      │ claude-code │ Pass │ Pass     │ 487/500 │ Pass     │ Pass     │ FAIL     │ 10/11 │
+│  1 │ anti-fabrication        │ core        │ Pass │ Pass     │ 265/500 │ Pass     │ Pass     │ Pass     │ 11/11 │
+│ .. │ ...                     │ ...         │ ...  │ ...      │ ...     │ ...      │ ...      │ ...      │ ...   │
+╰────┴─────────────────────────┴─────────────┴──────┴──────────┴─────────┴──────────┴──────────┴──────────┴───────╯
+```
+
+**Checks (11 total):**
+
+| Check | Pass Criteria | Source |
+|-------|--------------|--------|
+| desc | Non-empty, max 1024 chars | Anthropic Spec |
+| use_when | Description contains "Use when" triggers | Anthropic Best Practices |
+| third_person | No "I can", "You can" in description | Anthropic Best Practices |
+| kebab_case | Name matches `^[a-z0-9]+(-[a-z0-9]+)*$` | Anthropic Spec |
+| name_length | Name max 64 characters | Anthropic Spec |
+| no_reserved | No "anthropic"/"claude" in name | Anthropic Spec |
+| lines_ok | SKILL.md max 500 lines | Anthropic PDF Guide |
+| examples | Contains code blocks or example sections | Anthropic PDF Guide |
+| ref_depth | No nested references (one level deep only) | Anthropic PDF Guide |
+| anti_fab | Anti-fabrication rules present or referenced | Project Standard |
+| source_doc | Skill documented in plugin's `sources.md` | Project Convention |
+
+Use `/benchmark-skills` for a more detailed analysis with category classification and quality assessment.
+
 ### GitHub Actions CI/CD
 
 The repository includes automated CI/CD via GitHub Actions that runs on:
@@ -493,6 +535,8 @@ MIT License - see [LICENSE](LICENSE) file for details.
 - **Official Anthropic Skills Repository**: https://github.com/anthropics/skills
 - **Claude Skills Cookbook**: https://github.com/anthropics/claude-cookbooks/tree/main/skills
 - **Agent Skills Blog Post**: https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills
+- **Building Skills Guide (PDF)**: https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf
+- **Improving Skill Creator Blog**: https://claude.com/blog/improving-skill-creator-test-measure-and-refine-agent-skills
 - **Agent Skills Specification**: https://github.com/anthropics/skills/blob/main/agent_skills_spec.md
 - **Claude Code Plugins**: https://code.claude.com/docs/en/plugins
 - **Plugin Marketplaces**: https://code.claude.com/docs/en/plugin-marketplaces

--- a/mise.toml
+++ b/mise.toml
@@ -17,11 +17,11 @@ macos-arm64 = { asset_pattern = "beads_*_darwin_arm64.tar.gz" }
 
 [tasks.test]
 description = "Run all validation tests (Claude native + custom)"
-depends = ["test:claude", "test:marketplace", "test:plugins", "test:version-bumps"]
+depends = ["test:claude", "test:marketplace", "test:plugins", "test:version-bumps", "test:skills-quality"]
 
 [tasks."test:all"]
 description = "Run all validation tests (Claude native + custom)"
-depends = ["test:claude", "test:marketplace", "test:plugins", "test:version-bumps"]
+depends = ["test:claude", "test:marketplace", "test:plugins", "test:version-bumps", "test:skills-quality"]
 
 [tasks."test:claude"]
 description = "Run Claude's native plugin validation"
@@ -200,6 +200,15 @@ if $all_passed {
     print "❌ Some plugin validations failed"
     exit 1
 }
+"""
+
+[tasks."test:skills-quality"]
+description = "Validate skill quality across all plugins (scorecard)"
+run = """
+#!/usr/bin/env nu
+
+let repo_root = (git rev-parse --show-toplevel | str trim)
+nu ($repo_root | path join "test" "validate-skills-quality.nu")
 """
 
 [tasks."test:plugin"]

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"
@@ -15,6 +15,7 @@
     "./skills/claude-agents",
     "./skills/claude-skills",
     "./skills/claude-hooks",
-    "./skills/claude-teams"
+    "./skills/claude-teams",
+    "./skills/claude-skills-benchmark"
   ]
 }

--- a/plugins/tools/claude-code/commands/benchmark-skills.md
+++ b/plugins/tools/claude-code/commands/benchmark-skills.md
@@ -1,0 +1,57 @@
+---
+description: "Benchmark all skills across the marketplace with static analysis and quality assessment"
+argument-hint: "[--plugin=<name>]"
+---
+
+Benchmark all Agent Skills in the marketplace, producing a quality scorecard with static analysis and category classification.
+
+**What it does:**
+- Discovers all skills across all plugins (reads marketplace.json + plugin.json files)
+- Runs static analysis checks per skill (description, naming, line count, examples, anti-fabrication)
+- Classifies each skill (Capability Uplift vs Encoded Preference)
+- Assesses progressive disclosure usage (references, depth)
+- Produces a scorecard table with pass/fail per check and overall score
+
+**Output:**
+A scorecard table showing quality metrics for each skill:
+
+```
+Skill            | Plugin   | Desc | Lines   | Refs | Examples | Score
+─────────────────┼──────────┼──────┼─────────┼──────┼──────────┼──────
+git              | core     | Pass | 120/500 | Pass | Pass     | 9/11
+claude-skills    | cl-code  | Pass | 380/500 | Pass | Pass     | 10/11
+```
+
+**Examples:**
+```
+/benchmark-skills
+# Benchmark all skills across all plugins
+
+/benchmark-skills --plugin=core
+# Benchmark only skills in the core plugin
+```
+
+**Task Instructions:**
+Use Task tool with subagent_type: "general-purpose" to:
+
+1. Read `.claude-plugin/marketplace.json` to discover all plugins
+2. For each local plugin, read its `.claude-plugin/plugin.json` to get skill paths
+3. For each skill, read `SKILL.md` and analyze:
+   - **Description quality**: Non-empty, ≤1024 chars, has "Use when", third person
+   - **Name compliance**: Kebab-case, ≤64 chars, no reserved words
+   - **Content quality**: ≤500 lines, has examples, imperative language
+   - **Progressive disclosure**: Has references/, no nested references
+   - **Anti-fabrication**: Contains anti-fab rules or references `core:anti-fabrication`
+   - **Source documentation**: Skill appears in plugin's `sources.md`
+4. Classify each skill as Capability Uplift or Encoded Preference
+5. Calculate score (X/11 checks passing)
+6. Present results as a formatted scorecard table
+7. Summarize: total skills, average score, skills needing attention
+
+If `--plugin=<name>` is provided, only benchmark skills in that plugin.
+
+**Important:**
+- Read actual SKILL.md files — do not fabricate content or results
+- Report actual line counts and check results
+- Mark any checks that cannot be performed as "N/A" with explanation
+- Use the `claude-skills-benchmark` skill for methodology reference

--- a/plugins/tools/claude-code/skills/claude-skills-benchmark/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-skills-benchmark/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: claude-skills-benchmark
+description: Evaluate and benchmark Agent Skills quality using static analysis and evaluation methodology. Use when discussing skill quality, benchmarking skills, measuring activation rates, or reviewing skill effectiveness.
+---
+
+# Skill Benchmarking
+
+Evaluate Agent Skills through static analysis and evaluation-driven methodology. Source: Anthropic's skill evaluation guidance.
+
+## When to Use
+
+Activate when:
+- Assessing skill quality across a plugin or marketplace
+- Measuring skill activation accuracy (false positives/negatives)
+- Comparing skill versions or skill-vs-no-skill performance
+- Running the `/benchmark-skills` command
+- Reviewing skill descriptions for optimization
+
+## Static Analysis Checks
+
+Run these checks against every skill to produce a quality scorecard:
+
+| Check | Pass Criteria |
+|-------|--------------|
+| Description length | Non-empty, max 1024 chars |
+| Description has "Use when" | Contains activation triggers |
+| Description third person | No "I can", "You can" |
+| Name kebab-case | Matches `^[a-z0-9]+(-[a-z0-9]+)*$` |
+| Name max 64 chars | Length check |
+| No reserved words | No "anthropic"/"claude" in name |
+| SKILL.md max 500 lines | Line count |
+| Has examples | Contains code blocks or example sections |
+| Reference depth | No nested references (one level only) |
+| Anti-fabrication present | Contains anti-fab rules or references `core:anti-fabrication` |
+| Source documented | Skill appears in plugin's `sources.md` |
+
+## Skill Categories
+
+Classify each skill for appropriate evaluation:
+
+**Capability Uplift**: Enhances Claude's core abilities (coding, analysis, reasoning). Stable across model versions. Test by comparing base model performance with and without the skill.
+
+**Encoded Preference**: Encodes user-specific workflows, formatting, and conventions. May need updates when models change. Test by verifying fidelity to the encoded workflow.
+
+## Evaluation Methodology
+
+### Writing Evals
+
+For each skill, create:
+- 5-10 representative prompts that should trigger the skill
+- 3-5 out-of-scope prompts that should NOT trigger the skill
+- Expected behavior criteria for each prompt
+
+### A/B Testing
+
+Compare skill performance using independent agents:
+1. Agent A runs with the skill loaded
+2. Agent B runs without the skill
+3. A comparator judges outputs blindly
+4. Track: pass rate, token usage, execution time
+
+### Multi-Model Testing
+
+Test across model tiers to verify consistency:
+
+| Model | Target Pass Rate |
+|-------|-----------------|
+| Haiku | 70%+ |
+| Sonnet | 85%+ |
+| Opus | 95%+ |
+
+If Haiku fails but others pass, instructions may rely on implicit reasoning — make them more explicit.
+
+## Description Optimization
+
+The description determines activation accuracy. Optimize for:
+
+- **Reducing false positives**: Too-broad descriptions waste context. Add domain-specific terms.
+- **Reducing false negatives**: Too-narrow descriptions miss valid prompts. Add synonyms and related terms.
+- **Target**: 90%+ true positive rate, <5% false positive rate
+
+## Scorecard Output
+
+The benchmark produces a table per plugin:
+
+```
+Skill            | Plugin   | Desc | Lines   | Refs | Examples | Score
+─────────────────┼──────────┼──────┼─────────┼──────┼──────────┼──────
+git              | core     | Pass | 120/500 | Pass | Pass     | 9/11
+claude-skills    | cl-code  | Pass | 380/500 | Pass | Pass     | 10/11
+```
+
+## Running Benchmarks
+
+- **Static analysis**: `mise test:skills-quality` — runs all static checks, produces scorecard
+- **Command**: `/benchmark-skills` — full analysis with category classification and quality assessment
+- **Manual evals**: Use the evaluation checklist template at `templates/evaluation-checklist.md`
+
+## Iteration
+
+Follow the cycle: Test, Measure, Analyze, Refine, Verify.
+
+Stop iterating when:
+- Eval pass rates meet targets across model tiers
+- Description triggers accurately
+- Token usage is reasonable relative to benefit
+- No user-reported issues for 2+ model versions
+
+## Anti-Fabrication Requirements
+
+### Core Principles
+
+- Base all outputs on actual analysis using tool execution
+- Execute validation tools before making claims
+- Mark uncertain information as "requires analysis" or "needs validation"
+- Use precise, factual language without superlatives
+
+### Prohibited Language
+
+- **Superlatives**: Avoid "excellent", "comprehensive", "advanced", "optimal", "perfect"
+- **Unsubstantiated Metrics**: Never fabricate percentages, success rates, or performance numbers
+- **Assumed Capabilities**: Do not claim features exist without tool verification
+
+### Validation Requirements
+
+- **File Claims**: Use Read or Glob tools before claiming files exist
+- **Test Results**: Only report test outcomes after actual execution
+- **Performance Claims**: Base on actual measurement or analysis

--- a/plugins/tools/claude-code/skills/claude-skills/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-skills/SKILL.md
@@ -5,7 +5,7 @@ description: Guide for creating Agent Skills with progressive disclosure and bes
 
 # Agent Skills
 
-Comprehensive guide for creating modular, self-contained Agent Skills that extend Claude's capabilities with specialized knowledge.
+Guide for creating modular, self-contained Agent Skills that extend Claude's capabilities with specialized knowledge.
 
 ## What Are Agent Skills?
 
@@ -17,6 +17,16 @@ Agent Skills are organized directories containing instructions, scripts, and res
 - **Reusability**: Share and distribute expertise across projects and teams
 - **Progressive Disclosure**: Load context only when needed, keeping interactions efficient
 - **Specialization**: Deep domain knowledge without sacrificing generality
+
+### Skill Categories
+
+Skills fall into two categories (source: Anthropic PDF Guide):
+
+**Capability Uplift**: Enhances Claude's core abilities (coding, analysis, reasoning). These are stable across model versions because they build on general capabilities. Example: a code review skill that adds structured review steps.
+
+**Encoded Preference**: Encodes user-specific workflows, formatting, and conventions. These may need updates when models change because they depend on model behavior for fidelity. Example: a commit message skill that enforces team-specific format.
+
+When creating a skill, identify its category — this determines testing strategy and maintenance expectations.
 
 ## How Skills Work
 
@@ -80,7 +90,7 @@ Main instructional content goes here...
    Must contain only lowercase letters, numbers, and hyphens
    Cannot contain XML tags
    Cannot contain reserved words: "anthropic", "claude"
-- `description`: 
+- `description`:
    Explains the skill's purpose and when Claude should utilize it
    Must be non-empty
    Maximum 1024 characters
@@ -167,10 +177,6 @@ Develop resource files and update `SKILL.md` with:
 
 **Use imperative/infinitive form** rather than second-person instruction for clarity.
 
-✅ Good: "Follow the Conventional Commits specification"
-✅ Good: "Use descriptive branch names with type prefixes"
-❌ Avoid: "You should try to use descriptive names when possible"
-
 Keep core procedural information in `SKILL.md` and detailed reference material in separate files.
 
 ### 5. Documentation
@@ -185,21 +191,60 @@ This maintains traceability and helps others understand the skill's foundation.
 
 ### 6. Validation
 
-Test the skill with representative scenarios to ensure:
-- Claude activates it appropriately
-- Instructions are clear and actionable
-- Progressive disclosure works effectively
-- Token usage remains efficient
+Test the skill using the validation loop pattern:
+
+1. Define success criteria (what correct activation and output look like)
+2. Create eval prompts — both in-scope (should activate) and out-of-scope (should not)
+3. Run evaluations and record pass/fail rates
+4. Verify progressive disclosure works (references load when needed)
+5. Check token usage remains efficient
+6. If any validation fails, iterate on the skill before publishing
+
+For the complete evaluation methodology, see `references/evaluation-guide.md`.
 
 ### 7. Iteration
 
-Refine based on real-world usage feedback. Monitor how Claude actually uses the skill and adjust the description and content accordingly.
+Refine based on real-world usage and evaluation data:
+- **Optimize descriptions**: Reduce false positives (too broad) and false negatives (too narrow)
+- **Test across models**: Verify behavior on Haiku, Sonnet, and Opus
+- **Monitor activation**: Track when the skill triggers correctly vs incorrectly
+- **Deprecation signal**: If the base model passes evals without the skill loaded, the skill may no longer be needed
+
+For description optimization techniques, see `references/evaluation-guide.md`.
 
 ## Best Practices
 
-### Start with Evaluation
+### Evaluation-Driven Development
 
-Identify specific capability gaps by testing agents on representative tasks. Build skills incrementally to address actual shortcomings rather than anticipated needs.
+Build skills using an evaluation-first approach (source: Anthropic Blog Post):
+
+1. **Write evals first**: Define test prompts and expected behaviors before writing skill content
+2. **Test with and without**: Compare Claude's output with the skill loaded vs without it
+3. **Measure, don't guess**: Track pass rates, token usage, and timing — not subjective quality
+4. **Run A/B comparisons**: Use independent agents to compare skill versions blindly
+5. **Detect obsolescence**: When the base model passes evals without the skill, consider deprecation
+
+For the complete methodology, see `references/evaluation-guide.md`. For a copyable checklist, see `templates/evaluation-checklist.md`.
+
+### Degree of Freedom
+
+Balance specificity against fragility in skill instructions (source: Anthropic PDF Guide):
+
+- **Specify constraints, not implementations**: "Ensure commit messages follow conventional format" not "Run git commit -m with prefix type(scope):"
+- **Allow model adaptation**: Instructions should work across Haiku, Sonnet, and Opus without modification
+- **Test fragility**: If a minor model update breaks your skill, instructions are too rigid
+- **Test looseness**: If Claude produces inconsistent results, instructions are too loose
+
+For the full framework with examples, see `references/design-patterns.md`.
+
+### Context Window Discipline
+
+The context window is a shared resource (source: Anthropic PDF Guide):
+
+- Keep SKILL.md under **500 lines** — larger files degrade performance in smaller context windows
+- Move detailed content to `references/` and load only when needed
+- Monitor cumulative load: skill + prompt + conversation history must all fit
+- Every line in SKILL.md is loaded on every activation — justify each line's presence
 
 ### Structure for Scale
 
@@ -207,14 +252,23 @@ Split unwieldy `SKILL.md` files into separate referenced documents:
 - Keep commonly-used contexts together
 - Separate mutually exclusive information to reduce token usage
 - Use progressive disclosure to load details only when needed
+- **Reference depth**: Keep references one level deep only (SKILL.md → reference, not reference → reference)
+- **TOC in long references**: Add a Table of Contents to reference files over 100 lines
+- **Scripts**: Execute scripts for deterministic tasks; read scripts for patterns to adapt contextually
 
-**Example:**
-```markdown
-# Git Skill
+For design patterns and detailed guidance, see `references/design-patterns.md`.
 
-For detailed conventional commit format, see references/conventional-commits.md
-For rebase workflow, see references/rebasing-guide.md
-```
+### Claude A/B Testing
+
+Compare skill effectiveness using blind evaluation (source: Anthropic Blog Post):
+
+1. Run the same prompt through Agent A (with skill) and Agent B (without skill)
+2. Each agent uses a clean context — no accumulated state between tests
+3. A comparator agent judges outputs without knowing which is which
+4. Track token usage, timing, and quality metrics independently
+5. Run 10+ evals for statistical significance
+
+For detailed setup instructions, see `references/evaluation-guide.md`.
 
 ### Consider Claude's Perspective
 
@@ -227,24 +281,26 @@ The skill name and description heavily influence when Claude activates it. Pay p
 > The body's "When to Use" section only loads AFTER activation (Level 2) and cannot trigger it.
 > All activation triggers must be in the description using patterns like "Use when [scenarios]".
 
-**Examples:**
-
-✅ Good Description:
-```yaml
-description: Guide for Git operations including commits, branches, rebasing, and conflict resolution. Use when working with version control or the user mentions git, commits, or branches.
-```
-
-❌ Too Vague:
-```yaml
-description: Helps with Git
-```
-
-❌ Missing "Use when" triggers:
-```yaml
-description: Guide for Git operations including commits, branches, rebasing, and conflict resolution
-```
+**Description optimization** (source: Anthropic Blog Post):
+- **False positives**: Description too broad — add domain-specific terms
+- **False negatives**: Description too narrow — add synonyms and trigger scenarios
+- **Target**: 90%+ true positive rate, <5% false positive rate
+- Test with 10+ in-scope prompts and 5+ out-of-scope prompts
 
 Monitor real usage patterns and iterate based on actual behavior.
+
+### Platform Constraints
+
+Skills may run in different environments with different capabilities (source: Anthropic PDF Guide):
+
+| Platform | Script Execution | Network | Filesystem |
+|----------|-----------------|---------|------------|
+| Claude Code (CLI) | Full Bash access | Available | Full access |
+| Claude.ai (Web) | Sandbox only | Limited | Limited |
+| API | Tool-dependent | Tool-dependent | Tool-dependent |
+| Mobile | None | None | Read-only |
+
+Document which platform features each skill requires. Never assume external API availability.
 
 ### Iterate Collaboratively
 
@@ -254,15 +310,11 @@ Work with Claude to capture successful approaches and common mistakes into reusa
 
 Use clear, imperative language that Claude can follow:
 
-✅ Good:
 - "Follow the Conventional Commits specification"
 - "Use descriptive branch names with type prefixes"
 - "Run tests before committing"
 
-❌ Avoid:
-- "You should try to use descriptive names when possible"
-- "It might be good to run tests"
-- "Consider following best practices"
+Avoid hedging language like "You should try to" or "It might be good to" or "Consider following".
 
 Include concrete examples wherever possible to illustrate patterns and approaches.
 
@@ -276,7 +328,9 @@ Install skills only from trusted sources. When evaluating unfamiliar skills:
 
 ## Anti-Fabrication Requirements
 
-All skills MUST adhere to strict anti-fabrication requirements to ensure factual, measurable content.
+All skills MUST adhere to strict anti-fabrication requirements to ensure factual, measurable content. Every SKILL.md must include anti-fabrication rules — either inline (template below) or by referencing `core:anti-fabrication`.
+
+For skill-creation-specific anti-fabrication guidance, see `references/anti-fabrication.md`. For the authoritative anti-fabrication guide, see the `core:anti-fabrication` skill.
 
 ### Core Principles
 
@@ -312,152 +366,31 @@ All skills MUST adhere to strict anti-fabrication requirements to ensure factual
 
 ## Skill Examples
 
-### Simple Skill (Git)
-
-```markdown
----
-name: git
-description: Guide for Git operations including commits, branches, rebasing, and conflict resolution
-license: MIT
----
-
-# Git Operations
-
-## When to Use
-
-Activate when:
-- Creating commit messages
-- Managing branches
-- Resolving conflicts
-- Rebasing or merging
-
-## Conventional Commits
-
-Follow the format: `type(scope): description`
-
-Types: feat, fix, docs, style, refactor, test, chore
-
-Example: `feat(auth): add OAuth2 login support`
-
-## Branch Naming
-
-Use format: `type/description`
-
-Examples:
-- `feature/user-authentication`
-- `fix/memory-leak`
-- `docs/api-reference`
-
-## Rebasing Workflow
-
-1. Update main: `git checkout main && git pull`
-2. Rebase feature: `git checkout feature-branch && git rebase main`
-3. Resolve conflicts if needed
-4. Force push: `git push --force-with-lease`
-```
-
-### Complex Skill (Phoenix)
-
-```markdown
----
-name: phoenix
-description: Guide for building Phoenix web applications with LiveView, contexts, and best practices
-license: MIT
----
-
-# Phoenix Framework
-
-## When to Use
-
-Activate for:
-- Phoenix application development
-- LiveView implementations
-- Context design
-- Channel setup
-
-## Project Structure
-
-Phoenix apps follow:
-```
-lib/
-├── my_app/          # Business logic (contexts)
-├── my_app_web/      # Web interface
-└── my_app.ex
-```
-
-## Contexts
-
-Group related functionality:
-
-```elixir
-defmodule MyApp.Accounts do
-  def list_users, do: Repo.all(User)
-  def get_user!(id), do: Repo.get!(User, id)
-  def create_user(attrs), do: ...
-end
-```
-
-For detailed context patterns, see references/contexts.md
-
-## LiveView
-
-For real-time interfaces, see references/liveview-guide.md
-```
+For annotated examples of simple and complex skills with category classifications, see `references/examples.md`.
 
 ## Common Pitfalls
 
-### Too Generic
-
-❌ Avoid:
-```yaml
-name: programming
-description: Helps with programming
-```
-
-✅ Better:
-```yaml
-name: elixir-phoenix
-description: Guide for building Phoenix web applications with LiveView, contexts, and Elixir best practices
-```
-
-### Too Much in SKILL.md
-
-❌ Avoid putting entire API reference in SKILL.md
-
-✅ Better: Keep core patterns in SKILL.md, detailed reference in `references/`
-
-### Missing Activation Criteria
-
-❌ Avoid:
-```markdown
-# My Skill
-
-This skill helps with stuff.
-```
-
-✅ Better:
-```markdown
-# My Skill
-
-## When to Use
-
-Activate when:
-- Specific scenario 1
-- Specific scenario 2
-- Specific scenario 3
-```
+For common mistakes and how to avoid them, see `references/examples.md`.
 
 ## References
 
 claude-skills/
+├── references/
+│   ├── design-patterns.md    # Degree of freedom, validation loops, conditional workflows
+│   ├── evaluation-guide.md   # Eval-driven development, A/B testing, multi-model testing
+│   ├── anti-fabrication.md   # Skill-creation-specific anti-fab guidance
+│   └── examples.md           # Annotated skill examples and common pitfalls
 └── templates/
-    └── level1.md (example skill metadata)
-    └── level2.md (example skill body)
-    └── level3.md (example skill folder structure)
-    └── skill.md (example basic skill)
+    ├── evaluation-checklist.md  # Copyable eval checklist
+    ├── level1.md                # Example skill metadata
+    ├── level2.md                # Example skill body
+    ├── level3.md                # Example skill folder structure
+    └── skill.md                 # Example basic skill
 
 For more information:
 - **Agent Skills Blog**: https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills
+- **Building Skills Guide (PDF)**: https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf
+- **Improving Skill Creator Blog**: https://claude.com/blog/improving-skill-creator-test-measure-and-refine-agent-skills
 - **Example Skills**: https://github.com/anthropics/skills
 - **Skills Cookbook**: https://github.com/anthropics/claude-cookbooks/tree/main/skills
 - **Skill Creator Guide**: https://github.com/anthropics/skills/blob/main/skill-creator/SKILL.md

--- a/plugins/tools/claude-code/skills/claude-skills/references/anti-fabrication.md
+++ b/plugins/tools/claude-code/skills/claude-skills/references/anti-fabrication.md
@@ -1,0 +1,57 @@
+# Anti-Fabrication for Skill Creation
+
+> Reference file for the `claude-skills` skill. Guidance for maintaining factual integrity when creating, testing, and documenting skills. For the authoritative anti-fabrication guide, see the `core:anti-fabrication` skill.
+
+## Validating Skill Descriptions
+
+Before claiming a description triggers correctly:
+
+- **Test activation**: Send representative prompts and verify the skill activates
+- **Test non-activation**: Send out-of-scope prompts and verify the skill does not activate
+- **Report actual rates**: State observed activation counts, not estimated percentages
+- **Mark untested claims**: Use "requires testing" for activation claims without verification
+
+## Testing Skills Without Fabrication
+
+- **Run evals before claiming pass rates**: Never state "95% pass rate" without actual eval execution
+- **Report actual results**: "Passed 8 of 10 evals" not "high pass rate"
+- **Document failures**: Record which evals failed and why, not just successes
+- **Distinguish tested from untested**: Clearly mark which model tiers have been tested
+- **Avoid assumed compatibility**: Do not claim "works across Haiku/Sonnet/Opus" without testing each
+
+## Minimum Anti-Fabrication Template
+
+Every SKILL.md must include anti-fabrication rules. Use this as the minimum template:
+
+```markdown
+## Anti-Fabrication Requirements
+
+### Core Principles
+
+- Base all outputs on actual analysis using tool execution
+- Execute validation tools before making claims
+- Mark uncertain information as "requires analysis" or "needs validation"
+- Use precise, factual language without superlatives
+
+### Prohibited Language
+
+- **Superlatives**: Avoid "excellent", "comprehensive", "advanced", "optimal", "perfect"
+- **Unsubstantiated Metrics**: Never fabricate percentages, success rates, or performance numbers
+- **Assumed Capabilities**: Do not claim features exist without tool verification
+
+### Validation Requirements
+
+- **File Claims**: Use Read or Glob tools before claiming files exist
+- **Test Results**: Only report test outcomes after actual execution
+- **Performance Claims**: Base on actual measurement or analysis
+```
+
+## Common Fabrication Risks in Skill Development
+
+| Risk | Example | Prevention |
+|------|---------|------------|
+| Claiming activation accuracy | "Triggers correctly 95% of the time" | Run actual eval suite and report counts |
+| Fabricated examples | Showing output Claude never produced | Test examples and include actual output |
+| Assumed model compatibility | "Works on all model tiers" | Test on each tier and report results |
+| Fabricated performance gains | "Reduces errors by 50%" | Measure baseline vs skill and report data |
+| Untested reference files | "References load correctly" | Verify progressive disclosure through testing |

--- a/plugins/tools/claude-code/skills/claude-skills/references/design-patterns.md
+++ b/plugins/tools/claude-code/skills/claude-skills/references/design-patterns.md
@@ -1,0 +1,228 @@
+# Skill Design Patterns
+
+> Reference file for the `claude-skills` skill. Design patterns sourced from Anthropic's "The Complete Guide to Building Skills for Claude" (PDF).
+
+## Table of Contents
+
+- [Degree of Freedom Framework](#degree-of-freedom-framework)
+- [Validation Loop Pattern](#validation-loop-pattern)
+- [Checklist-Based Workflows](#checklist-based-workflows)
+- [Conditional Workflows](#conditional-workflows)
+- [Script Execution vs Reading](#script-execution-vs-reading)
+- [Self-Documenting Constants](#self-documenting-constants)
+- [Visual Analysis Pattern](#visual-analysis-pattern)
+
+## Degree of Freedom Framework
+
+Balance specificity against fragility when writing skill instructions. The bridge analogy: overly rigid specifications break under stress (model updates, edge cases), while too-loose guidance provides no value.
+
+**Principle**: Specify constraints, not implementations.
+
+### Spectrum
+
+| Too Rigid | Balanced | Too Loose |
+|-----------|----------|-----------|
+| "Always use exactly 3 paragraphs" | "Keep responses concise, typically 2-4 paragraphs" | "Write some paragraphs" |
+| "Return JSON with fields x, y, z in that order" | "Return structured data with required fields: x, y, z" | "Return some data" |
+| "Use setTimeout with 500ms delay" | "Add a brief delay to prevent race conditions" | "Handle timing" |
+
+### Guidelines
+
+- **Constrain outcomes, not methods**: "Ensure commit messages follow conventional format" not "Run git commit -m with prefix type(scope):"
+- **Allow model adaptation**: Instructions that work across Haiku, Sonnet, and Opus without modification
+- **Test fragility**: If a minor model update breaks your skill, it is too rigid
+- **Test looseness**: If Claude produces inconsistent results, it is too loose
+- **Prefer patterns over prescriptions**: Show the shape of correct output rather than dictating exact steps
+
+### Anti-Pattern: Brittle Instructions
+
+```markdown
+# Bad — breaks if model behavior changes
+Step 1: Output exactly "Analyzing..." on line 1
+Step 2: Wait 2 seconds
+Step 3: Output results in a 3-column table with headers "Name", "Value", "Status"
+```
+
+```markdown
+# Good — resilient across model versions
+Analyze the input and present results in a structured table.
+Include columns for identification, measurement, and status.
+Indicate progress to the user before presenting results.
+```
+
+## Validation Loop Pattern
+
+Structure skills to include self-checking mechanisms that verify output quality before presenting results.
+
+### Components
+
+1. **Success criteria**: Define what correct output looks like
+2. **Self-check step**: Verify output meets criteria before presenting
+3. **Error handling**: Explicit guidance for common failure modes
+4. **Iteration prompt**: Instructions for refining if validation fails
+
+### Example
+
+```markdown
+## Code Review Process
+
+1. Read the file and identify changes
+2. Check each change against the style guide
+3. **Validate**: Before presenting review, verify:
+   - [ ] All flagged issues include file path and line number
+   - [ ] Each issue has a concrete fix suggestion
+   - [ ] No false positives from standard library usage
+   - [ ] Severity levels (error, warning, info) are assigned
+4. If any check fails, revise the review before presenting
+```
+
+### When to Use
+
+- Tasks with measurable correctness criteria
+- Multi-step processes where errors compound
+- Output that will be consumed by other tools or processes
+- Skills that generate structured data (JSON, YAML, tables)
+
+## Checklist-Based Workflows
+
+Use structured checklists for multi-step processes to ensure completeness and consistency.
+
+### Pattern
+
+```markdown
+## Deployment Checklist
+
+Before deploying:
+- [ ] All tests pass locally
+- [ ] Environment variables are configured
+- [ ] Database migrations are prepared
+- [ ] Rollback plan is documented
+
+During deployment:
+- [ ] Run migrations
+- [ ] Deploy application
+- [ ] Verify health checks
+
+After deployment:
+- [ ] Monitor error rates for 15 minutes
+- [ ] Verify critical user flows
+- [ ] Update deployment log
+```
+
+### Benefits
+
+- Prevents skipped steps in complex workflows
+- Provides clear progress tracking
+- Works as both instruction and verification tool
+- Naturally supports the validation loop pattern
+
+## Conditional Workflows
+
+Branch logic explicitly within skills to handle different scenarios without ambiguity.
+
+### Pattern
+
+```markdown
+## Error Handling Strategy
+
+**If the error is a compilation error:**
+1. Read the error message and identify the source file
+2. Fix the syntax or type error
+3. Re-run the compiler
+
+**If the error is a runtime error:**
+1. Check the stack trace for the originating function
+2. Add logging at the failure point
+3. Reproduce and diagnose
+
+**If the error is a test failure:**
+1. Run the failing test in isolation
+2. Compare expected vs actual output
+3. Determine if the test or implementation is wrong
+```
+
+### Guidelines
+
+- Use "If X, then Y" structure explicitly
+- Cover all expected branches
+- Include a fallback for unexpected cases
+- Avoid nested conditionals deeper than 2 levels
+
+## Script Execution vs Reading
+
+Skills can include scripts, but Claude interacts with them differently depending on the platform.
+
+### Key Distinction
+
+- **Script Execution**: Claude runs the script via Bash or shell tool. Use for deterministic tasks (validation, formatting, data processing).
+- **Script Reading**: Claude reads the script content for reference. Use for patterns, templates, or logic that Claude should adapt contextually.
+
+### When to Execute
+
+- Validation checks (linting, schema validation)
+- Data transformations (JSON processing, file manipulation)
+- Environment detection (installed tools, OS features)
+- Repeatable operations with exact output requirements
+
+### When to Read
+
+- Code patterns to adapt to the current context
+- Templates that need modification before use
+- Reference implementations for understanding approach
+- Configuration examples to customize
+
+### Platform Considerations
+
+- **Claude Code (CLI)**: Full Bash access, can execute scripts directly
+- **Claude.ai (Web)**: Code execution sandbox, limited filesystem
+- **API**: Depends on tool configuration; may not have shell access
+- **Mobile**: Read-only; no script execution
+
+Document which mode each script supports in the skill's SKILL.md.
+
+## Self-Documenting Constants
+
+Define values with clear naming and immediate context so Claude understands their purpose without external references.
+
+### Pattern
+
+```markdown
+## Configuration
+
+| Constant | Value | Purpose |
+|----------|-------|---------|
+| MAX_RETRIES | 3 | API call retry limit before failing |
+| TIMEOUT_MS | 5000 | Request timeout in milliseconds |
+| BATCH_SIZE | 100 | Records per processing batch |
+```
+
+### Anti-Pattern
+
+```markdown
+# Bad — magic numbers without context
+Set retries to 3, timeout to 5000, and batch to 100.
+```
+
+## Visual Analysis Pattern
+
+Provide structured templates for analyzing visual content (diagrams, charts, screenshots).
+
+### Pattern
+
+```markdown
+## Diagram Analysis
+
+When analyzing a diagram:
+1. **Identify type**: Flowchart, sequence diagram, architecture diagram, etc.
+2. **Extract components**: List all nodes, actors, or services
+3. **Map relationships**: Document connections and data flows
+4. **Note annotations**: Capture labels, conditions, and notes
+5. **Summarize**: Describe the overall system or process
+```
+
+### Use Cases
+
+- Architecture review skills
+- UI/UX analysis skills
+- Data visualization interpretation
+- Technical diagram documentation

--- a/plugins/tools/claude-code/skills/claude-skills/references/evaluation-guide.md
+++ b/plugins/tools/claude-code/skills/claude-skills/references/evaluation-guide.md
@@ -1,0 +1,247 @@
+# Skill Evaluation Guide
+
+> Reference file for the `claude-skills` skill. Evaluation methodology sourced from Anthropic's "Improving skill-creator: Test, measure, and refine Agent Skills" (Blog Post).
+
+## Table of Contents
+
+- [Evaluation-Driven Development](#evaluation-driven-development)
+- [Writing Evals](#writing-evals)
+- [Claude A/B Testing](#claude-ab-testing)
+- [Description Optimization](#description-optimization)
+- [Multi-Model Testing](#multi-model-testing)
+- [Observations Checklist](#observations-checklist)
+- [Iteration Cycle](#iteration-cycle)
+
+## Evaluation-Driven Development
+
+Build skills using an evaluation-first approach: define test prompts, describe expected behavior, then verify the skill produces correct results.
+
+### Core Methodology
+
+1. **Define test prompts**: Create representative inputs that exercise the skill
+2. **Describe expected behavior**: Specify what correct output looks like
+3. **Run evaluations**: Test the skill against the prompts
+4. **Measure results**: Track pass/fail, timing, and token usage
+5. **Iterate**: Refine the skill based on evaluation results
+
+### Two Testing Purposes
+
+**Regression detection**: Run evals against new model versions to detect behavioral shifts before they impact work. Model updates can change how skills are interpreted.
+
+**Capability assessment**: Track when the base model passes evals without the skill loaded. This signals the skill may no longer be necessary — the model has internalized the capability.
+
+### When to Run Evals
+
+- After creating or modifying a skill
+- After model updates (new Claude versions)
+- When users report unexpected behavior
+- Before publishing or distributing a skill
+- Periodically as part of maintenance
+
+## Writing Evals
+
+Each eval consists of a test prompt, optional context files, and expected behavior criteria.
+
+### Eval Structure
+
+```markdown
+## Eval: [Name]
+
+**Prompt**: [The input to send to Claude]
+
+**Context files** (if needed):
+- [file1.ext]: [description]
+- [file2.ext]: [description]
+
+**Expected behavior**:
+- [ ] [Specific observable outcome 1]
+- [ ] [Specific observable outcome 2]
+- [ ] [Specific observable outcome 3]
+
+**Failure indicators**:
+- [What incorrect behavior looks like]
+```
+
+### Guidelines
+
+- Write 5-10 evals per skill minimum
+- Cover common cases AND edge cases
+- Include at least one "should NOT activate" eval (tests false positive rate)
+- Test with and without the skill loaded for comparison
+- Keep prompts realistic — use actual user requests, not synthetic tests
+
+### Example Evals
+
+```markdown
+## Eval: Git Commit Message
+
+**Prompt**: "Create a commit for adding user authentication with bcrypt"
+
+**Expected behavior**:
+- [ ] Uses conventional commit format (type(scope): description)
+- [ ] Selects "feat" as the type
+- [ ] Mentions authentication in the description
+- [ ] Uses imperative mood
+
+## Eval: False Positive Check
+
+**Prompt**: "What's the weather in Tokyo?"
+
+**Expected behavior**:
+- [ ] Skill does NOT activate
+- [ ] No git-related content in response
+```
+
+## Claude A/B Testing
+
+Compare skill versions or skill-vs-no-skill performance using independent comparator agents.
+
+### Setup
+
+1. **Agent A**: Runs with the skill loaded
+2. **Agent B**: Runs without the skill (or with an alternative version)
+3. **Comparator**: Judges outputs without knowing which agent produced them
+
+### Process
+
+1. Send the same eval prompt to both agents
+2. Collect outputs independently (clean contexts, no cross-contamination)
+3. Present both outputs to the comparator agent
+4. Record which output better meets the eval criteria
+5. Track metrics: token usage, execution time, output quality
+
+### Key Principles
+
+- Each agent runs in a clean context — no accumulated state between evals
+- Track token and timing metrics independently per agent
+- The comparator must not know which output came from which agent
+- Run sufficient evals (10+) to establish statistical significance
+
+### What to Compare
+
+- **Skill vs no skill**: Does the skill improve output quality?
+- **Skill v1 vs v2**: Did the revision improve behavior?
+- **Different descriptions**: Which description triggers more accurately?
+- **Cross-model**: Does the skill work consistently across Haiku/Sonnet/Opus?
+
+## Description Optimization
+
+The description is the most impactful field — it determines when Claude activates the skill during discovery (Level 1).
+
+### False Positive Reduction
+
+A description that is too broad causes the skill to activate for unrelated prompts, wasting context window.
+
+**Symptoms**: Skill activates for prompts outside its domain.
+
+**Fix**: Add specificity to the description. Replace general terms with domain-specific triggers.
+
+```yaml
+# Too broad — triggers on any code question
+description: Guide for writing code
+
+# Optimized — triggers only for Git operations
+description: Guide for Git operations including commits, branches, rebasing, and conflict resolution. Use when working with version control or the user mentions git, commits, or branches.
+```
+
+### False Negative Reduction
+
+A description that is too narrow causes the skill to miss prompts it should handle.
+
+**Symptoms**: Skill fails to activate for prompts within its domain.
+
+**Fix**: Add more trigger scenarios. Include synonyms and related terms.
+
+```yaml
+# Too narrow — misses synonym prompts
+description: Guide for Phoenix LiveView. Use when implementing LiveView.
+
+# Optimized — covers related terms
+description: Guide for Phoenix web applications with LiveView, contexts, and Ecto. Use when building Elixir web apps, implementing real-time features, or designing Phoenix contexts.
+```
+
+### Testing Descriptions
+
+1. Create 10+ eval prompts covering the skill's domain
+2. Create 5+ eval prompts outside the skill's domain
+3. Test activation rates: target 90%+ true positives, <5% false positives
+4. Iterate on description wording until targets are met
+
+## Multi-Model Testing
+
+Test skills across Haiku, Sonnet, and Opus to ensure consistent behavior.
+
+### Why Multi-Model Matters
+
+- **Capability uplift** skills: Should work uniformly across model sizes. If a skill only helps Opus but not Haiku, the instructions may be too implicit.
+- **Encoded preference** skills: May degrade gracefully on smaller models. Verify that core behavior is preserved even if nuance is lost.
+
+### Testing Matrix
+
+| Model | Eval Pass Rate | Notes |
+|-------|---------------|-------|
+| Haiku | Target: 70%+ | Core behavior preserved |
+| Sonnet | Target: 85%+ | Full behavior expected |
+| Opus | Target: 95%+ | Complete behavior with nuance |
+
+### What Model Differences Reveal
+
+- **Haiku fails, others pass**: Instructions may rely on implicit reasoning. Make instructions more explicit.
+- **All models fail**: The skill instructions need fundamental revision.
+- **Opus passes without skill**: The capability may now be built into the model. Consider deprecating.
+
+## Observations Checklist
+
+Track these metrics during skill evaluation:
+
+### Performance Metrics
+
+- [ ] Eval pass/fail rate (per eval and overall)
+- [ ] Elapsed execution time per eval
+- [ ] Token usage (input + output) per eval
+- [ ] False trigger frequency (activated when it should not)
+- [ ] Missed trigger frequency (did not activate when it should)
+
+### Quality Indicators
+
+- [ ] Output follows skill instructions consistently
+- [ ] Edge cases handled appropriately
+- [ ] No fabricated or hallucinated content
+- [ ] Structured output matches expected format
+- [ ] Progressive disclosure loads correctly (references accessed when needed)
+
+### Maintenance Signals
+
+- [ ] Model version compatibility (current + previous)
+- [ ] Base model now passes evals without skill (deprecation signal)
+- [ ] User-reported issues or confusion
+- [ ] Context window impact (skill size vs benefit)
+
+## Iteration Cycle
+
+Follow this cycle to continuously improve skills:
+
+```
+Test → Measure → Analyze → Refine → Verify
+  ↑                                    |
+  └────────────────────────────────────┘
+```
+
+### Steps
+
+1. **Test**: Run eval suite against the skill
+2. **Measure**: Record all metrics from the observations checklist
+3. **Analyze**: Identify failures, patterns, and improvement opportunities
+4. **Refine**: Update skill content, description, or structure
+5. **Verify**: Re-run evals to confirm improvement without regressions
+
+### When to Stop Iterating
+
+- Eval pass rates meet targets across all model tiers
+- Description triggers accurately (low false positives and negatives)
+- Token usage is reasonable relative to benefit
+- No user-reported issues for 2+ model versions
+
+### Storage
+
+Store evals and results locally, integrate with a dashboard, or plug into CI. The evaluation data belongs to the skill author and should be versioned alongside the skill.

--- a/plugins/tools/claude-code/skills/claude-skills/references/examples.md
+++ b/plugins/tools/claude-code/skills/claude-skills/references/examples.md
@@ -1,0 +1,170 @@
+# Skill Examples
+
+> Reference file for the `claude-skills` skill. Contains annotated examples of skill structures.
+
+## Table of Contents
+
+- [Simple Skill: Capability Uplift](#simple-skill-capability-uplift)
+- [Complex Skill: Encoded Preference](#complex-skill-encoded-preference)
+- [Common Pitfalls](#common-pitfalls)
+
+## Simple Skill: Capability Uplift
+
+**Category**: Capability Uplift — enhances Claude's core abilities (coding, analysis) without encoding user-specific preferences. Stable across model versions.
+
+```markdown
+---
+name: git
+description: Guide for Git operations including commits, branches, rebasing, and conflict resolution. Use when working with version control or the user mentions git, commits, or branches.
+license: MIT
+---
+
+# Git Operations
+
+## When to Use
+
+Activate when:
+- Creating commit messages
+- Managing branches
+- Resolving conflicts
+- Rebasing or merging
+
+## Conventional Commits
+
+Follow the format: `type(scope): description`
+
+Types: feat, fix, docs, style, refactor, test, chore
+
+Example: `feat(auth): add OAuth2 login support`
+
+## Branch Naming
+
+Use format: `type/description`
+
+Examples:
+- `feature/user-authentication`
+- `fix/memory-leak`
+- `docs/api-reference`
+
+## Rebasing Workflow
+
+1. Update main: `git checkout main && git pull`
+2. Rebase feature: `git checkout feature-branch && git rebase main`
+3. Resolve conflicts if needed
+4. Force push: `git push --force-with-lease`
+```
+
+**Why this works**: Clear activation triggers in description, imperative language, concrete examples, focused scope.
+
+## Complex Skill: Encoded Preference
+
+**Category**: Encoded Preference — encodes team-specific workflows, formatting, and conventions. May need updates when models change.
+
+```markdown
+---
+name: phoenix
+description: Guide for building Phoenix web applications with LiveView, contexts, and best practices. Use when developing Elixir Phoenix apps, implementing LiveView, or designing contexts.
+license: MIT
+---
+
+# Phoenix Framework
+
+## When to Use
+
+Activate for:
+- Phoenix application development
+- LiveView implementations
+- Context design
+- Channel setup
+
+## Project Structure
+
+Phoenix apps follow:
+```
+lib/
+├── my_app/          # Business logic (contexts)
+├── my_app_web/      # Web interface
+└── my_app.ex
+```
+
+## Contexts
+
+Group related functionality:
+
+```elixir
+defmodule MyApp.Accounts do
+  def list_users, do: Repo.all(User)
+  def get_user!(id), do: Repo.get!(User, id)
+  def create_user(attrs), do: ...
+end
+```
+
+For detailed context patterns, see references/contexts.md
+
+## LiveView
+
+For real-time interfaces, see references/liveview-guide.md
+```
+
+**Why this works**: Uses progressive disclosure — core patterns inline, detailed references separate. Description includes "Use when" triggers.
+
+## Common Pitfalls
+
+### Too Generic
+
+A skill that is too broad activates when it should not (false positives) and provides unfocused guidance.
+
+```yaml
+# Bad
+name: programming
+description: Helps with programming
+```
+
+```yaml
+# Good
+name: elixir-phoenix
+description: Guide for building Phoenix web applications with LiveView, contexts, and Elixir best practices. Use when developing Phoenix apps or implementing LiveView.
+```
+
+### Too Much in SKILL.md
+
+Loading entire API references into SKILL.md wastes context window space for every activation.
+
+- Keep core patterns and decision logic in SKILL.md
+- Move detailed reference material to `references/`
+- Keep SKILL.md under 500 lines (Anthropic recommendation)
+
+### Missing Activation Criteria
+
+Without a "When to Use" section and description triggers, Claude cannot determine when to activate the skill.
+
+```markdown
+# Bad — no activation guidance
+# My Skill
+
+This skill helps with stuff.
+```
+
+```markdown
+# Good — clear activation criteria
+# My Skill
+
+## When to Use
+
+Activate when:
+- Specific scenario 1
+- Specific scenario 2
+- Specific scenario 3
+```
+
+### Missing "Use when" in Description
+
+The description is the ONLY text visible during discovery (Level 1). Body content loads only after activation.
+
+```yaml
+# Bad — missing triggers
+description: Guide for Git operations including commits, branches, rebasing, and conflict resolution
+
+# Good — includes triggers
+description: Guide for Git operations including commits, branches, rebasing, and conflict resolution. Use when working with version control or the user mentions git, commits, or branches.
+```

--- a/plugins/tools/claude-code/skills/claude-skills/templates/evaluation-checklist.md
+++ b/plugins/tools/claude-code/skills/claude-skills/templates/evaluation-checklist.md
@@ -1,0 +1,73 @@
+# Skill Evaluation Checklist
+
+> Copyable checklist for testing a skill. Source: Anthropic "Improving skill-creator" blog post.
+
+## Skill: [NAME]
+
+### Pre-Evaluation
+
+- [ ] Skill has YAML frontmatter with `name` and `description`
+- [ ] Description includes "Use when" activation triggers
+- [ ] Description uses third person (no "I can" or "You can")
+- [ ] SKILL.md is under 500 lines
+- [ ] Anti-fabrication rules are present (inline or referenced)
+
+### Eval Prompts
+
+Create 5-10 representative prompts:
+
+| # | Prompt | Expected | Pass? |
+|---|--------|----------|-------|
+| 1 | | | |
+| 2 | | | |
+| 3 | | | |
+| 4 | | | |
+| 5 | | | |
+
+### False Positive Prompts
+
+Create 3-5 out-of-scope prompts (skill should NOT activate):
+
+| # | Prompt | Activated? | Pass? |
+|---|--------|-----------|-------|
+| 1 | | | |
+| 2 | | | |
+| 3 | | | |
+
+### A/B Comparison
+
+| Metric | With Skill | Without Skill |
+|--------|-----------|---------------|
+| Eval pass rate | /10 | /10 |
+| Avg tokens used | | |
+| Avg time | | |
+
+### Multi-Model Results
+
+| Model | Evals Passed | Notes |
+|-------|-------------|-------|
+| Haiku | /10 | |
+| Sonnet | /10 | |
+| Opus | /10 | |
+
+### Quality Check
+
+- [ ] Output follows skill instructions consistently
+- [ ] Edge cases handled appropriately
+- [ ] No fabricated content in outputs
+- [ ] Progressive disclosure works (references load when needed)
+- [ ] Description triggers accurately (low false positive/negative rate)
+
+### Iteration Notes
+
+**Issues found**: (describe any failures or unexpected behavior)
+
+**Changes made**: (describe revisions to skill content or description)
+
+**Verification**: (results after changes)
+
+### Decision
+
+- [ ] **Ship**: Meets targets across all checks
+- [ ] **Iterate**: Needs refinement (see notes above)
+- [ ] **Deprecate**: Base model passes evals without skill

--- a/plugins/tools/claude-code/skills/sources.md
+++ b/plugins/tools/claude-code/skills/sources.md
@@ -245,6 +245,39 @@ Create a modular Claude Code plugin marketplace that:
 - **Distribution**: Git-based with marketplace support
 - **Validation**: Automated Nushell scripts for schema compliance
 
+## Skill Building Guide (PDF)
+
+### The Complete Guide to Building Skills for Claude
+- **URL**: https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf
+- **Purpose**: Comprehensive guide to skill design patterns, categories, and best practices
+- **Date Accessed**: 2026-03-07
+- **Key Concepts**:
+  - Skill categories: Capability Uplift vs Encoded Preference
+  - Degree of Freedom framework (specificity vs fragility)
+  - Context window discipline (500-line limit, "context window is a public good")
+  - Validation loop pattern
+  - Nested reference anti-pattern (one level deep only)
+  - TOC requirement for reference files over 100 lines
+  - Script execution vs reading distinction
+  - Platform constraints (network, runtime, filesystem by platform)
+  - Design patterns: checklist-based, conditional workflows, self-documenting constants
+  - Multi-model testing across Haiku/Sonnet/Opus
+- **Used In**: skills/claude-skills/SKILL.md, skills/claude-skills/references/design-patterns.md, skills/claude-skills-benchmark/SKILL.md
+
+### Improving skill-creator: Test, measure, and refine Agent Skills
+- **URL**: https://claude.com/blog/improving-skill-creator-test-measure-and-refine-agent-skills
+- **Purpose**: Evaluation-driven development methodology for skills
+- **Date Accessed**: 2026-03-07
+- **Key Concepts**:
+  - Evaluation-driven development workflow
+  - Claude A/B testing pattern (comparator agents)
+  - Description optimization (false positives/negatives)
+  - Multi-agent evaluation with independent contexts
+  - Observations checklist (pass rate, tokens, timing, triggers)
+  - Iteration cycle: Test → Measure → Analyze → Refine → Verify
+  - Capability assessment: detecting when base model outgrows a skill
+- **Used In**: skills/claude-skills/SKILL.md, skills/claude-skills/references/evaluation-guide.md, skills/claude-skills-benchmark/SKILL.md
+
 ## Plugin Information
 
 - **Name**: claude-code

--- a/test/validate-skills-quality.nu
+++ b/test/validate-skills-quality.nu
@@ -1,0 +1,223 @@
+#!/usr/bin/env nu
+# Validate skill quality across all plugins
+#
+# Runs static analysis checks on every skill and produces a scorecard table.
+# Checks are sourced from Anthropic's skill best practices and the Agent Skills Specification.
+
+def main [] {
+    print "Validating skill quality across all plugins..."
+    print ""
+
+    let repo_root = (git rev-parse --show-toplevel | str trim)
+    let marketplace_path = ($repo_root | path join ".claude-plugin" "marketplace.json")
+    let marketplace = (open $marketplace_path)
+    let code_fence = (['`' '`' '`'] | str join)
+
+    mut results = []
+    mut total_skills = 0
+    mut total_pass = 0
+
+    for plugin in $marketplace.plugins {
+        let source_type = ($plugin.source | describe)
+
+        # Skip external plugins (source is an object)
+        if ($source_type | str starts-with "record") {
+            continue
+        }
+
+        # Skip meta-plugin (all-skills) to avoid double-counting
+        if ($plugin.name == "all-skills") {
+            continue
+        }
+
+        let plugin_dir = ($repo_root | path join ($plugin.source | str replace --regex '^\./' ''))
+        let plugin_json_path = ($plugin_dir | path join ".claude-plugin" "plugin.json")
+
+        if not ($plugin_json_path | path exists) {
+            continue
+        }
+
+        let plugin_json = (open $plugin_json_path)
+        let plugin_name = $plugin_json.name
+        let skills = ($plugin_json | get -o skills | default [])
+
+        # Find sources.md for the plugin
+        let sources_path = ($plugin_dir | path join "skills" "sources.md")
+        let sources_content = if ($sources_path | path exists) {
+            open $sources_path
+        } else {
+            ""
+        }
+
+        for skill_path in $skills {
+            let skill_dir = ($plugin_dir | path join ($skill_path | str replace --regex '^\./' ''))
+            let skill_md_path = ($skill_dir | path join "SKILL.md")
+
+            if not ($skill_md_path | path exists) {
+                continue
+            }
+
+            $total_skills = $total_skills + 1
+
+            let content = (open $skill_md_path)
+            let all_lines = ($content | lines)
+            let line_count = ($all_lines | length)
+
+            # Parse YAML frontmatter (between --- markers)
+            let fm_lines = if ($all_lines | first | default "" | str trim) == "---" {
+                let rest = ($all_lines | skip 1)
+                let end_matches = ($rest | enumerate | where {|item| ($item.item | str trim) == "---"})
+                if ($end_matches | is-not-empty) {
+                    let end_idx = ($end_matches | first | get index)
+                    $rest | first $end_idx
+                } else {
+                    []
+                }
+            } else {
+                []
+            }
+
+            # Extract name field
+            let name_lines = ($fm_lines | where {|line| $line | str starts-with "name:"})
+            let name = if ($name_lines | is-not-empty) {
+                $name_lines | first | str replace "name:" "" | str trim | str trim -c '"' | str trim -c "'"
+            } else {
+                ""
+            }
+
+            # Extract description field
+            let desc_lines = ($fm_lines | where {|line| $line | str starts-with "description:"})
+            let description = if ($desc_lines | is-not-empty) {
+                $desc_lines | first | str replace "description:" "" | str trim | str trim -c '"' | str trim -c "'"
+            } else {
+                ""
+            }
+
+            # Run checks
+            mut score = 0
+
+            # 1. Description length: non-empty, ≤1024 chars
+            let desc_len = ($description | str length)
+            let desc_ok = $desc_len > 0 and $desc_len <= 1024
+            if $desc_ok { $score = $score + 1 }
+
+            # 2. Description has "Use when"
+            let desc_lower = ($description | str downcase)
+            let use_when_ok = ($desc_lower | str contains "use when")
+            if $use_when_ok { $score = $score + 1 }
+
+            # 3. Description third person (no "I can", "You can")
+            let has_first = ($description | str contains "I can")
+            let has_second = ($description | str contains "You can")
+            let has_first_will = ($description | str contains "I will")
+            let has_second_will = ($description | str contains "You will")
+            let third_person_ok = not ($has_first or $has_second or $has_first_will or $has_second_will)
+            if $third_person_ok { $score = $score + 1 }
+
+            # 4. Name kebab-case
+            let kebab_matches = ($name | parse --regex '^[a-z0-9]+(-[a-z0-9]+)*$')
+            let kebab_ok = ($kebab_matches | is-not-empty)
+            if $kebab_ok { $score = $score + 1 }
+
+            # 5. Name ≤64 chars
+            let name_len = ($name | str length)
+            let name_len_ok = $name_len <= 64 and $name_len > 0
+            if $name_len_ok { $score = $score + 1 }
+
+            # 6. No reserved words
+            let has_anthropic = ($name | str contains "anthropic")
+            let has_claude = ($name | str contains "claude")
+            let no_reserved = not ($has_anthropic or $has_claude)
+            if $no_reserved { $score = $score + 1 }
+
+            # 7. SKILL.md ≤500 lines
+            let lines_ok = $line_count <= 500
+            if $lines_ok { $score = $score + 1 }
+
+            # 8. Has examples (code blocks or example sections)
+            let has_code_fence = ($content | str contains $code_fence)
+            let has_example_header = ($content | str downcase | str contains "## example")
+            let has_examples = $has_code_fence or $has_example_header
+            if $has_examples { $score = $score + 1 }
+
+            # 9. Reference depth (no nested references)
+            let refs_dir = ($skill_dir | path join "references")
+            let ref_depth_ok = if ($refs_dir | path exists) {
+                let ref_files = (glob ($refs_dir | path join "*.md"))
+                let nested = ($ref_files | where {|f|
+                    let ref_content = (open $f)
+                    $ref_content | str contains "references/"
+                })
+                ($nested | length) == 0
+            } else {
+                true
+            }
+            if $ref_depth_ok { $score = $score + 1 }
+
+            # 10. Anti-fabrication present
+            let content_lower = ($content | str downcase)
+            let has_anti_fab_header = ($content_lower | str contains "anti-fabrication")
+            let has_anti_fab_ref = ($content | str contains "core:anti-fabrication")
+            let has_fabricat = ($content_lower | str contains "fabricat")
+            let anti_fab_ok = $has_anti_fab_header or $has_anti_fab_ref or $has_fabricat
+            if $anti_fab_ok { $score = $score + 1 }
+
+            # 11. Source documented
+            let source_ok = if ($sources_content | str length) > 0 {
+                let has_exact = ($sources_content | str contains $name)
+                let has_lower = ($sources_content | str downcase | str contains ($name | str downcase))
+                $has_exact or $has_lower
+            } else {
+                false
+            }
+            if $source_ok { $score = $score + 1 }
+
+            let desc_result = if $desc_ok { "Pass" } else { "FAIL" }
+            let use_when_result = if $use_when_ok { "Pass" } else { "FAIL" }
+            let lines_str = $"($line_count)/500"
+            let lines_result = if $lines_ok { "Pass" } else { "FAIL" }
+            let examples_result = if $has_examples { "Pass" } else { "FAIL" }
+            let anti_fab_result = if $anti_fab_ok { "Pass" } else { "FAIL" }
+            let score_str = $"($score)/11"
+
+            $results = ($results | append {
+                skill: $name
+                plugin: $plugin_name
+                desc: $desc_result
+                use_when: $use_when_result
+                lines: $lines_str
+                lines_ok: $lines_result
+                examples: $examples_result
+                anti_fab: $anti_fab_result
+                score: $score_str
+            })
+
+            if $score == 11 {
+                $total_pass = $total_pass + 1
+            }
+        }
+    }
+
+    if ($results | is-empty) {
+        print "No skills found to validate."
+        exit 1
+    }
+
+    # Print scorecard
+    print ($results | table --expand --width 200)
+
+    print ""
+    print $"Total skills: ($total_skills)"
+    print $"Perfect score 11/11: ($total_pass)/($total_skills)"
+
+    # Check for critical failures (name or description issues)
+    let failures = ($results | where desc == "FAIL" or use_when == "FAIL")
+    if ($failures | is-not-empty) {
+        print ""
+        print "Skills with description issues:"
+        print ($failures | select skill plugin desc use_when | table --expand)
+    }
+
+    print ""
+    print "Skill quality validation complete!"
+}


### PR DESCRIPTION
- Incorporate Anthropic PDF Guide and Blog Post learnings into claude-skills SKILL.md
- Add skill categories (Capability Uplift vs Encoded Preference), degree of freedom framework, context window discipline, evaluation-driven development, A/B testing, platform constraints, description optimization
- Restructure SKILL.md from 465 to 397 lines (under 500-line Anthropic recommendation)
- Move examples and pitfalls to references/examples.md
- Create references/design-patterns.md, references/evaluation-guide.md, references/anti-fabrication.md
- Create templates/evaluation-checklist.md for skill testing
- Add claude-skills-benchmark skill for evaluation methodology
- Add /benchmark-skills command for full marketplace quality assessment
- Add test/validate-skills-quality.nu static analysis (11 checks per skill, scorecard output)
- Add mise test:skills-quality task (included in mise test)
- Add skill quality scorecard documentation to README.md
- Bump claude-code 0.1.5 → 0.1.6, all-skills 0.3.12 → 0.3.13
- Add both Anthropic source URLs to README.md, CLAUDE.md, and sources.md