### PR TITLE
feat(elixir): add standalone tidewave skill and update to v0.5.6

### DIFF
--- a/.bees/.gitignore
+++ b/.bees/.gitignore
@@ -1,0 +1,16 @@
+# SQLite databases
+*.db
+*.db?*
+*.db-journal
+*.db-wal
+*.db-shm
+
+# Daemon runtime files
+daemon.lock
+daemon.log
+daemon.pid
+bd.sock
+last-touched
+
+# Lock files
+.jsonl.lock

--- a/.bees/config.json
+++ b/.bees/config.json
@@ -1,0 +1,3 @@
+{
+  "issue_prefix": "claude-skills"
+}

--- a/.bees/metadata.json
+++ b/.bees/metadata.json
@@ -1,0 +1,4 @@
+{
+  "database": "bees.db",
+  "jsonl_export": "issues.jsonl"
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.15",
+      "version": "0.3.16",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -23,7 +23,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills: plugin marketplace management and validation",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "category": "tools",
       "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark"]
     },
@@ -50,7 +50,7 @@
       "source": "./plugins/languages/elixir",
       "strict": true,
       "description": "Elixir development skills: Phoenix, OTP, Tidewave MCP, testing, configuration",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "category": "language",
       "keywords": ["elixir", "phoenix", "otp", "beam"]
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -48,6 +48,7 @@
     "./plugins/languages/elixir/skills/otp",
     "./plugins/languages/elixir/skills/testing",
     "./plugins/languages/elixir/skills/config",
+    "./plugins/languages/elixir/skills/tidewave",
     "./plugins/tools/github/skills/actions",
     "./plugins/tools/github/skills/workflows",
     "./plugins/tools/github/skills/act",

--- a/mise.toml
+++ b/mise.toml
@@ -15,6 +15,16 @@ version = "latest"
 linux-x64 = { asset_pattern = "beads_*_linux_amd64.tar.gz" }
 macos-arm64 = { asset_pattern = "beads_*_darwin_arm64.tar.gz" }
 
+# Multi-arch bees install
+[tools."github:ctxshift/bees"]
+version = "latest"
+
+[tools."github:ctxshift/bees".platforms]
+linux-x64 = { asset_pattern = "bees-linux-x86_64.tar.gz" }
+linux-arm64 = { asset_pattern = "bees-linux-aarch64.tar.gz" }
+macos-arm64 = { asset_pattern = "bees-macos-aarch64.tar.gz" }
+macos-x64 = { asset_pattern = "bees-macos-x86_64.tar.gz" }
+
 [tasks.test]
 description = "Run all validation tests (Claude native + custom)"
 depends = ["test:claude", "test:marketplace", "test:plugins", "test:version-bumps", "test:skills-quality"]
@@ -566,6 +576,266 @@ if $result.exit_code == 0 {
     exit 1
 }
 """
+
+# =============================================================================
+# Bees - Lightweight SQLite-Backed Issue Tracker
+# =============================================================================
+
+[tasks."bees:init"]
+description = "Initialize bees in the repository"
+run = "bees init"
+
+[tasks."bees:ready"]
+description = "List unblocked issues ready for work"
+run = '''
+#!/usr/bin/env nu
+let issues = (bees ready --json | from json)
+if ($issues | is-empty) {
+    print "No ready issues"
+} else {
+    $issues | select id title labels? | table
+}
+'''
+
+[tasks."bees:list"]
+description = "List all issues with formatted output"
+run = '''
+#!/usr/bin/env nu
+let issues = (bees list --json | from json)
+if ($issues | is-empty) {
+    print "No issues found"
+} else {
+    $issues | select id title status labels? assignee? | table
+}
+'''
+
+[tasks."bees:show"]
+description = "Show issue details by ID"
+run = '''
+#!/usr/bin/env nu
+def main [issue_id: string] {
+    let issue = (bees show $issue_id --json | from json)
+    print $"(ansi green_bold)Issue: ($issue.id)(ansi reset)"
+    print $"Title: ($issue.title)"
+    print $"Status: ($issue.status)"
+    if ($issue.description? | is-not-empty) {
+        print $"Description: ($issue.description)"
+    }
+    if ($issue.labels? | is-not-empty) {
+        print $"Labels: ($issue.labels | str join ', ')"
+    }
+    if ($issue.assignee? | is-not-empty) {
+        print $"Assignee: ($issue.assignee)"
+    }
+}
+'''
+
+[tasks."bees:create"]
+description = "Create a new issue"
+run = '''
+#!/usr/bin/env nu
+def main [
+    title: string
+    --description (-d): string  # Issue description
+    --labels (-l): string       # Comma-separated labels
+    --assignee (-a): string     # Assignee name
+    --owner (-o): string        # Owner name
+    --parent (-p): string       # Parent issue ID
+] {
+    mut args = ["create", $title]
+    if ($description | is-not-empty) {
+        $args = ($args | append ["-d", $description])
+    }
+    if ($labels | is-not-empty) {
+        $args = ($args | append ["-l", $labels])
+    }
+    if ($assignee | is-not-empty) {
+        $args = ($args | append ["-a", $assignee])
+    }
+    if ($owner | is-not-empty) {
+        $args = ($args | append ["-o", $owner])
+    }
+    if ($parent | is-not-empty) {
+        $args = ($args | append ["-p", $parent])
+    }
+    ^bees ...$args
+}
+'''
+
+[tasks."bees:close"]
+description = "Close an issue by ID"
+run = '''
+#!/usr/bin/env nu
+def main [
+    issue_id: string
+    --reason (-r): string  # Closing reason
+] {
+    mut args = ["close", $issue_id]
+    if ($reason | is-not-empty) {
+        $args = ($args | append ["-r", $reason])
+    }
+    ^bees ...$args
+    print $"(ansi green)Closed issue: ($issue_id)(ansi reset)"
+}
+'''
+
+[tasks."bees:update"]
+description = "Update an issue"
+run = '''
+#!/usr/bin/env nu
+def main [
+    issue_id: string
+    --description (-d): string  # Updated description
+    --assignee (-a): string     # Assignee name
+    --status (-s): string       # Status (open, in_progress, closed)
+] {
+    mut args = ["update", $issue_id]
+    if ($description | is-not-empty) {
+        $args = ($args | append ["-d", $description])
+    }
+    if ($assignee | is-not-empty) {
+        $args = ($args | append ["-a", $assignee])
+    }
+    if ($status | is-not-empty) {
+        $args = ($args | append ["--status", $status])
+    }
+    ^bees ...$args
+    print $"(ansi cyan)Updated issue: ($issue_id)(ansi reset)"
+}
+'''
+
+[tasks."bees:sync"]
+description = "Export issues to JSONL format"
+run = "bees sync"
+
+[tasks."bees:prime"]
+description = "Generate markdown output for LLM context"
+run = '''
+#!/usr/bin/env nu
+def main [
+    --status (-s): string   # Filter by status
+    --labels (-l): string   # Filter by labels
+] {
+    mut args = ["prime"]
+    if ($status | is-not-empty) {
+        $args = ($args | append ["--status", $status])
+    }
+    if ($labels | is-not-empty) {
+        $args = ($args | append ["--labels", $labels])
+    }
+    ^bees ...$args
+}
+'''
+
+[tasks."bees:config"]
+description = "Show or set bees configuration"
+run = '''
+#!/usr/bin/env nu
+def main [
+    action?: string  # "set" or "get" (omit to show all)
+    key?: string     # Config key
+    value?: string   # Config value (for set)
+] {
+    if ($action | is-empty) {
+        bees config
+    } else if $action == "set" {
+        bees config set $key $value
+        print $"(ansi green)Set ($key) = ($value)(ansi reset)"
+    } else if $action == "get" {
+        bees config get $key
+    } else {
+        print $"(ansi red)Unknown action: ($action). Use 'set' or 'get'.(ansi reset)"
+    }
+}
+'''
+
+[tasks."bees:dep:add"]
+description = "Add a dependency (issue depends on blocker)"
+run = '''
+#!/usr/bin/env nu
+def main [
+    issue_id: string    # Issue that will be blocked
+    blocker_id: string  # Issue that blocks
+    --type (-t): string # Dependency type: blocks, related, parent
+] {
+    mut args = ["dep", "add", $issue_id, $blocker_id]
+    if ($type | is-not-empty) {
+        $args = ($args | append ["-t", $type])
+    }
+    ^bees ...$args
+    print $"(ansi cyan)Added dependency: ($issue_id) depends on ($blocker_id)(ansi reset)"
+}
+'''
+
+[tasks."bees:dep:remove"]
+description = "Remove a dependency"
+run = '''
+#!/usr/bin/env nu
+def main [
+    issue_id: string    # Issue to unblock
+    blocker_id: string  # Blocker to remove
+] {
+    bees dep remove $issue_id $blocker_id
+    print $"(ansi yellow)Removed dependency: ($issue_id) no longer depends on ($blocker_id)(ansi reset)"
+}
+'''
+
+[tasks."bees:dep:list"]
+description = "List dependencies for an issue"
+run = '''
+#!/usr/bin/env nu
+def main [issue_id: string] {
+    bees dep list $issue_id
+}
+'''
+
+[tasks."bees:comment:add"]
+description = "Add a comment to an issue"
+run = '''
+#!/usr/bin/env nu
+def main [
+    issue_id: string # Issue ID
+    body: string     # Comment body
+] {
+    bees comment add $issue_id $body
+    print $"(ansi green)Added comment to: ($issue_id)(ansi reset)"
+}
+'''
+
+[tasks."bees:comment:list"]
+description = "List comments on an issue"
+run = '''
+#!/usr/bin/env nu
+def main [issue_id: string] {
+    bees comment list $issue_id
+}
+'''
+
+[tasks."bees:label:add"]
+description = "Add labels to an issue"
+run = '''
+#!/usr/bin/env nu
+def main [
+    issue_id: string # Issue ID
+    labels: string   # Comma-separated labels to add
+] {
+    bees label add $issue_id $labels
+    print $"(ansi cyan)Added labels to ($issue_id): ($labels)(ansi reset)"
+}
+'''
+
+[tasks."bees:label:remove"]
+description = "Remove labels from an issue"
+run = '''
+#!/usr/bin/env nu
+def main [
+    issue_id: string # Issue ID
+    labels: string   # Comma-separated labels to remove
+] {
+    bees label remove $issue_id $labels
+    print $"(ansi yellow)Removed labels from ($issue_id): ($labels)(ansi reset)"
+}
+'''
 
 # =============================================================================
 # Beads (bd) - Distributed Git-Backed Issue Tracker

--- a/plugins/languages/elixir/.claude-plugin/plugin.json
+++ b/plugins/languages/elixir/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "elixir",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Elixir development skills: Phoenix, OTP, Tidewave MCP, testing, configuration, and anti-patterns",
   "author": {
     "name": "vinnie357"
@@ -16,6 +16,7 @@
     "./skills/phoenix",
     "./skills/otp",
     "./skills/testing",
-    "./skills/config"
+    "./skills/config",
+    "./skills/tidewave"
   ]
 }

--- a/plugins/languages/elixir/agents/tidewave.md
+++ b/plugins/languages/elixir/agents/tidewave.md
@@ -14,7 +14,7 @@ You are a Phoenix runtime introspection agent. Your role is to investigate, debu
 3. **Inspect**: Use `get_docs` or `search_package_docs` for documentation lookup
 4. **Evaluate**: Use `project_eval` to execute Elixir code in the running app
 5. **Query**: Use `execute_sql_query` to inspect database state
-6. **Debug**: Use `get_logs` to review server output
+6. **Debug**: Use `get_logs` to review server output (supports log level filtering)
 7. **Cross-reference**: Use Read, Glob, Grep to examine source code alongside runtime state
 
 ## Guidelines
@@ -27,15 +27,15 @@ You are a Phoenix runtime introspection agent. Your role is to investigate, debu
 
 ## Tool Selection
 
-| Need | Tool |
-|------|------|
-| List schemas and fields | `get_ecto_schemas` |
-| List Ash resources | `get_ash_resources` |
-| Find module source file | `get_source_location` |
-| List all modules | `get_models` |
-| Read module/function docs | `get_docs` |
-| Search hex dependency docs | `search_package_docs` |
-| Run Elixir code in app | `project_eval` |
-| Run SQL against database | `execute_sql_query` |
-| Check server logs | `get_logs` |
-| Read source files | Read, Glob, Grep |
+| Need | Tool | Notes |
+|------|------|-------|
+| List schemas and fields | `get_ecto_schemas` | Phoenix-specific |
+| List Ash resources | `get_ash_resources` | Ash framework only |
+| Find module source file | `get_source_location` | |
+| List all modules | `get_models` | |
+| Read module/function docs | `get_docs` | Uses project dependency versions |
+| Search hex dependency docs | `search_package_docs` | May not be available in all frameworks |
+| Run Elixir code in app | `project_eval` | |
+| Run SQL against database | `execute_sql_query` | |
+| Check server logs | `get_logs` | Supports log level filtering (added v0.5.5) |
+| Read source files | Read, Glob, Grep | |

--- a/plugins/languages/elixir/skills/phoenix/SKILL.md
+++ b/plugins/languages/elixir/skills/phoenix/SKILL.md
@@ -495,51 +495,15 @@ end
 
 Tidewave connects AI coding assistants to running Phoenix applications via MCP, exposing runtime introspection tools (Ecto schemas, code execution, docs, logs, SQL queries).
 
-### When to Use Tidewave
+Add to `mix.exs`: `{:tidewave, "~> 0.5", only: :dev}`
 
-- Introspecting a running Phoenix app (schemas, modules, logs)
-- Executing Elixir code or SQL queries against a live dev server
-- Looking up documentation for project dependencies at runtime
-- Debugging LiveView components with source annotations
+Add to `endpoint.ex` before `code_reloading?`: `plug Tidewave` (guarded by `if Mix.env() == :dev`)
 
-### Quick Setup
+Connect Claude Code: `claude mcp add --transport http tidewave http://localhost:4000/tidewave/mcp`
 
-1. Add dependency to `mix.exs`:
+Tidewave is dev-only — never deploy to production. It only accepts localhost requests by default.
 
-```elixir
-{:tidewave, "~> 0.5", only: :dev}
-```
-
-2. Add plug to `endpoint.ex` (before `code_reloading?`):
-
-```elixir
-if Mix.env() == :dev do
-  plug Tidewave
-end
-```
-
-3. Connect Claude Code to the MCP server:
-
-```bash
-claude mcp add --transport http tidewave http://localhost:4000/tidewave/mcp
-```
-
-### Key MCP Tools
-
-| Tool | Purpose |
-|------|---------|
-| `project_eval` | Execute Elixir code in the running app |
-| `execute_sql_query` | Run SQL queries against the database |
-| `get_ecto_schemas` | List schemas with fields and associations |
-| `get_docs` | Retrieve module/function documentation |
-| `get_source_location` | Find source file paths and line numbers |
-| `get_logs` | Access server logs |
-
-### Security
-
-Tidewave is dev-only. Always guard with `Mix.env() == :dev` and never deploy to production. It only accepts localhost requests by default.
-
-For full setup details, configuration options, LiveView debug annotations, and troubleshooting, see `references/tidewave.md`.
+For full setup, MCP tools reference, CLI app, editor configs, LiveView annotations, and troubleshooting, load the `tidewave` skill or see `references/tidewave.md`.
 
 ## Key Principles
 

--- a/plugins/languages/elixir/skills/tidewave/SKILL.md
+++ b/plugins/languages/elixir/skills/tidewave/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: tidewave
+description: Tidewave MCP dev tools for Phoenix applications. Use when setting up Tidewave, connecting AI coding assistants to a running Phoenix app, configuring MCP server access, debugging with runtime introspection tools, or troubleshooting Tidewave integration.
+license: MIT
+---
+
+# Tidewave MCP Dev Tools
+
+Tidewave is a dev tool by Dashbit that connects AI coding assistants to running Phoenix applications via the Model Context Protocol (MCP). It exposes runtime introspection tools: Ecto schemas, code execution, documentation lookup, log inspection, and SQL queries.
+
+Current version: `~> 0.5` (v0.5.6 released 2026-03-13)
+
+## Installation
+
+### New Projects (via Igniter)
+
+```bash
+mix archive.install hex igniter_new
+mix igniter.install tidewave
+```
+
+### Existing Projects (Manual)
+
+1. Add to `mix.exs`:
+
+```elixir
+defp deps do
+  [
+    {:tidewave, "~> 0.5", only: :dev}
+  ]
+end
+```
+
+2. Add plug to `lib/my_app_web/endpoint.ex` before the `code_reloading?` block:
+
+```elixir
+if Mix.env() == :dev do
+  plug Tidewave
+end
+
+if code_reloading? do
+  # ...existing code reload plugs...
+end
+```
+
+3. Fetch dependencies:
+
+```bash
+mix deps.get
+```
+
+### Umbrella Projects
+
+Apply the manual steps to the application defining the Phoenix endpoint (typically `apps/your_app_web`).
+
+## MCP Server Configuration
+
+Tidewave exposes an MCP server at `/tidewave/mcp` on the Phoenix app's port. The transport type is HTTP (streamable).
+
+Default URL: `http://localhost:4000/tidewave/mcp`
+
+### Claude Code
+
+```bash
+claude mcp add --transport http tidewave http://localhost:4000/tidewave/mcp
+```
+
+Add to `CLAUDE.md` to encourage MCP tool usage:
+
+```markdown
+Always use Tidewave's tools for evaluating code, querying the database, etc.
+Use `get_docs` to access documentation and `get_source_location` to find module/function definitions.
+```
+
+### Other Editors
+
+| Editor | Config File | URL Key |
+|--------|-------------|---------|
+| Cursor | `.cursor/mcp.json` | `mcpServers.tidewave.url` |
+| VS Code | `.vscode/mcp.json` | `servers.tidewave.url` |
+| Zed | Zed `settings.json` | `context_servers.tidewave.settings.url` |
+
+All use URL: `http://localhost:4000/tidewave/mcp`
+
+## MCP Tools Reference
+
+| Tool | Description |
+|------|-------------|
+| `project_eval` | Execute Elixir code within the running application runtime |
+| `execute_sql_query` | Run SQL queries against the application database |
+| `get_ecto_schemas` | List all Ecto schema modules with their fields and associations |
+| `get_ash_resources` | List all Ash resources (when using the Ash framework) |
+| `get_docs` | Retrieve documentation for modules/functions using exact project versions |
+| `search_package_docs` | Query hexdocs.pm filtered to project dependencies (availability varies by framework) |
+| `get_source_location` | Find module/function source code file paths and line numbers |
+| `get_models` | List all application modules with their file locations |
+| `get_logs` | Access server logs; supports log level filtering (added v0.5.5) |
+
+**Note**: `search_package_docs` may not be available in all frameworks. Verify availability for your setup.
+
+### Usage Patterns
+
+Introspect schemas before writing queries:
+```
+get_ecto_schemas → discover schema structure → execute_sql_query
+```
+
+Look up documentation for project dependencies:
+```
+get_docs for specific modules, search_package_docs for broader hex dependency searches
+```
+
+Execute and test code in the running app:
+```
+project_eval → run Elixir expressions against live application state
+```
+
+## Plug Configuration Options
+
+```elixir
+if Mix.env() == :dev do
+  plug Tidewave,
+    allow_remote_access: false,
+    inspect_opts: [pretty: true, limit: 50]
+end
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `allow_remote_access` | `false` | Allow connections from non-localhost |
+| `inspect_opts` | `[]` | Options passed to `Kernel.inspect/2` for output formatting |
+| `team` | `nil` | Team configuration (e.g., `[id: "my-company"]`) |
+
+## CLI App (Standalone MCP Server)
+
+The Tidewave desktop/CLI app (`tidewave_app`) runs a standalone MCP server without requiring a Phoenix application. Useful for containers, remote dev environments, or non-Phoenix Elixir projects.
+
+- Default server: `http://localhost:9832`
+- Only allows access from the same machine by default
+
+### Installation
+
+- **Desktop app** (macOS, Windows, Linux): https://tidewave.ai/install
+- **Development CLI**: `cargo run -p tidewave-cli [-- --help]`
+
+### When to Use CLI vs Phoenix Plug
+
+| Scenario | Use |
+|----------|-----|
+| Phoenix application | `plug Tidewave` in endpoint.ex |
+| Container/remote dev | CLI app or plug with `allow_remote_access: true` |
+| Non-Phoenix Elixir | CLI app |
+| Standalone MCP server | CLI app on port 9832 |
+
+## LiveView Debug Annotations
+
+Enable in `config/dev.exs` to help Tidewave map rendered HTML back to source HEEx templates:
+
+```elixir
+config :phoenix_live_view,
+  debug_heex_annotations: true
+
+config :phoenix,
+  debug_attributes: true
+```
+
+Requires Phoenix LiveView v1.1+.
+
+## Security
+
+- **Dev-only**: Always guard with `Mix.env() == :dev` or `only: :dev` in deps
+- **Localhost-only**: Tidewave only accepts localhost requests by default
+- **No production use**: Tidewave exposes code execution and database access — never deploy to production
+- **Docker/remote dev**: Set `allow_remote_access: true` only on trusted networks
+- **CSP**: Tidewave injects `unsafe-eval` in `script-src` directives and disables `frame-ancestors` restrictions
+
+## Troubleshooting
+
+### MCP connection fails
+- Verify Phoenix server is running: `mix phx.server`
+- Check the port matches your configuration (default 4000)
+- Try `http://127.0.0.1:4000/tidewave/mcp` if IPv6 causes issues
+
+### Tools not appearing
+- Confirm `plug Tidewave` is placed before `if code_reloading?` in `endpoint.ex`
+- Restart the Phoenix server after adding the plug
+- Verify the dependency is installed: `mix deps.get`
+
+### Claude Code authentication error
+- Run `claude` in your terminal and confirm authentication
+- Verify CLI availability: `which claude`
+
+### Umbrella project issues
+- Add the plug only in the endpoint of the web application
+- Ensure `:tidewave` is added to the correct `mix.exs` in the umbrella

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/templates/CLAUDE.md
+++ b/plugins/tools/claude-code/templates/CLAUDE.md
@@ -1,0 +1,48 @@
+Before starting any work, make sure you have used `bd ready` (/core:beads), or `bees ready` (/core:bees). 
+load our /core:bees or /core:beads skills to help depending on which you find.
+if you find neither, use our /core:bees skill to setup bees
+to ensure we are working on an epic or task created and tracked by one of these project tracking tools.
+all epics should be aware of claude-code teams, and have teams defined in the epic with models assigned by complexity of the task, all epics should have
+tasks that are claude skills aware, the primary library of skills available is here: https://github.com/vinnie357/claude-skills/blob/main/.claude-plugin/marketplace.json
+if the task needs a skill you don't have suggest or ask the user for this new skill.
+
+Phase 1: Pre flight checks
+- use `bd ready` or `bees ready` to look for open work items
+- make sure the epic you are working, has a team defined with the relevent models for each team member
+- a members model should attempt to use haiku first if possible based on the complexity of their task
+- all tasks must have relevent skills for the work, eg: elixir skill when working with elixir
+- ensure all the core skills are loaded:  /core:*
+- instruct team members/tasks to always load these core skills first:
+    - /core:anti-fabrication
+    - /core:git
+    - /core:tdd
+    - /core:twelve-factor
+    - /core:security
+    - /core:mise
+    - /core:nushell
+- all tasks must use the claude task-list tool to work their items
+- check that we are working on a feature branch per epic
+- label all team members with their model
+
+Phase 2: Working the items
+- ask clarifying questions to the user
+- spawn teamm members for all tasks including simple ones, like research or running tests
+- instruct team members to use the claude task-list tool for all their work items
+- instruct team members to load their tasks labels skills on start
+- instruct team members that code without tests is not complete /core:tdd
+- if a team member fails in a task twice, collect the members summary,then spawn the agent agent with the summary and promote the model it is using, haiku -> sonnet -> opus
+
+Phase 3: Validation
+- assign a haiku agent by default to run the strictest linting and validation possible for each language
+    - eg: elixir code, mix format, mix compile --warnings-as-errors, mix test --warnings-as-errors --max-failures=1, mix credo --strict ( mise run ci, or mix ci task)
+- have the agent pass each test runs results to another agent to address fixes and issues
+- this validation group should work in concert to address all issues found by `mise run ci`, or the languages strictest test/linting/ci suite.
+- if the project doesn't have a `mise run ci` command, we should use the /core:mise skill to make one  
+- Code without tests is not complete /core:tdd
+
+Phase 4: Submit loop
+- we never commit or pr with attribution
+- we give summary prs without a changes section as git has the diff
+- we wait for ci to pass then ask the user to squash merge and delete the merged branch
+- once merged, we checkout main, pull and delete our merged feature branch
+- we go back to Phase1 to work a new epic


### PR DESCRIPTION
- Add standalone tidewave skill with installation, MCP tools, editor setup, CLI app, and security docs
- Update tidewave agent for v0.5.6 (log level filtering, search_package_docs caveat)
- Slim phoenix SKILL.md tidewave section to quick-start with link to standalone skill
- Add bees tool and 17 mise task definitions to repo mise.toml
- Initialize bees issue tracker in .bees/
- Add CLAUDE.md workflow template for teams-aware epics
- Bump elixir plugin 0.1.3 → 0.1.4, claude-code plugin 0.1.6 → 0.1.7, all-skills 0.3.16