### PR TITLE
feat(container): add apple container 0.10.0 support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.16",
+      "version": "0.3.17",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -32,7 +32,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "category": "development",
       "keywords": ["git", "documentation", "code-review", "tools", "beads", "bees", "container", "tdd"]
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/container/SKILL.md
+++ b/plugins/core/skills/container/SKILL.md
@@ -17,7 +17,7 @@ Activate when:
 - Managing container images (pull, push, tag, save, load)
 - Configuring container networks and volumes
 - Managing the container system service
-- Migrating between Apple Container versions (0.5.x to 0.9.x)
+- Migrating between Apple Container versions (0.5.x to 0.10.x)
 
 ## What is Apple Container?
 
@@ -26,7 +26,7 @@ Apple Container is a macOS-native tool for running Linux containers as lightweig
 - **Swift-based**: Built on Apple's Virtualization.framework
 - **OCI-compatible**: Produces and runs standard OCI container images
 - **Apple silicon only**: Requires Apple silicon Mac (M1 or later)
-- **Pre-1.0**: Currently at version 0.9.0, breaking changes expected between minor versions
+- **Pre-1.0**: Currently at version 0.10.0, breaking changes expected between minor versions
 - **Lightweight VMs**: Each container runs as a lightweight Linux VM
 
 ## Prerequisites
@@ -48,6 +48,9 @@ container system stop
 
 # Check service status
 container system status
+
+# Check service status with format (0.10.0+)
+container system status --format json
 
 # Show CLI version
 container system version
@@ -148,6 +151,15 @@ container run --mac-address 02:42:ac:11:00:02 --network mynet myapp:latest
 # Access host from container (0.9.0+)
 # Use host.docker.internal to reach host services
 container run -e API_URL=http://host.docker.internal:3000 myapp:latest
+
+# Run with custom init image (0.10.0+)
+container run --init-image custom-init:latest -d --name app myapp:latest
+
+# Run with init process (0.10.0+)
+container run --init -d --name app myapp:latest
+
+# Run with runtime selection (0.10.0+)
+container run --runtime myruntime -d --name app myapp:latest
 ```
 
 ### Manage Running Containers
@@ -191,6 +203,16 @@ container stats
 
 # Remove all stopped containers
 container prune
+```
+
+### Export Container (0.10.0+)
+
+```bash
+# Create an image from a running container
+container export <name-or-id> -o exported.tar
+
+# Export with a tag
+container export <name-or-id> -t myimage:snapshot
 ```
 
 ### Create Without Starting
@@ -416,11 +438,14 @@ container registry login <registry-url>
 
 # Log out from a registry
 container registry logout <registry-url>
+
+# List configured registries (0.10.0+)
+container registry list
 ```
 
 **Note**: In 0.5.0, the keychain ID changed from `com.apple.container` to `com.apple.container.registry`. Re-login is required after upgrading from 0.4.x.
 
-## Version Differences (0.5.0 to 0.9.0)
+## Version Differences (0.5.0 to 0.10.0)
 
 ### Breaking Changes
 
@@ -430,6 +455,9 @@ container registry logout <registry-url>
 | 0.7.0 | `--disable-progress-updates` removed | Use `--progress none\|ansi` instead |
 | 0.8.0 | Client API reorganization | Update API consumers |
 | 0.8.0 | Subnet allocation defaults changed | Review network configurations |
+| 0.10.0 | ClientContainer reworked as generic client | Update API consumers for generic client interface |
+| 0.10.0 | Bundle creation moved to SandboxService | Move bundle creation code from main container ops |
+| 0.10.0 | Multiple network plugins support | Review network configuration for multi-plugin model |
 
 ### New Features by Release
 
@@ -441,13 +469,18 @@ container registry logout <registry-url>
 
 **0.9.0**: Resource limits (`--cpus`/`--memory`), `host.docker.internal`, host-only/isolated networks, `--dns` on build, `--force` on image delete, zstd compression, container prune improvements, enhanced image inspection, Kata 3.26.0 kernel
 
-### Migration Checklist (0.5.x to 0.9.0)
+**0.10.0**: `--init-image` selection, `container export`, `--runtime` flag, `container registry list`, `--format` on `system status`, `--init` flag, minimum memory validation, multiple network plugins, SELinux kernel panic fix, env var duplication fix
+
+### Migration Checklist (0.5.x to 0.10.0)
 
 1. Replace `--disable-progress-updates` with `--progress none` in scripts
 2. Update any paths referencing `.build` directory to `builder`
 3. Review subnet configurations (allocation defaults changed in 0.8.0)
 4. Update API consumers for client API reorganization (0.8.0)
 5. Test build workflows with updated dependencies
+6. Update API consumers for generic ClientContainer interface (0.10.0)
+7. Move bundle creation code from main container operations to SandboxService (0.10.0)
+8. Review network configurations for multiple network plugins model (0.10.0)
 
 ### Dependencies
 
@@ -458,8 +491,9 @@ container registry logout <registry-url>
 | 0.7.0 | 0.16.0 | Builder shim 0.7.0 |
 | 0.8.0 | 0.21.1 | |
 | 0.9.0 | 0.24.0 | Kata 3.26.0 |
+| 0.10.0 | 0.26.2 | |
 
-See `templates/<version>/commands.md` for version-specific details (0.4.1, 0.5.0, 0.6.0, 0.7.0, 0.8.0, 0.9.0).
+See `templates/<version>/commands.md` for version-specific details (0.4.1, 0.5.0, 0.6.0, 0.7.0, 0.8.0, 0.9.0, 0.10.0).
 
 ## Scripts
 
@@ -506,7 +540,7 @@ nu scripts/container-images.nu prune
 
 ### container-lifecycle.nu
 
-Container run/stop/exec/logs:
+Container run/stop/exec/logs/export:
 
 ```bash
 # List running containers
@@ -520,6 +554,9 @@ nu scripts/container-lifecycle.nu logs mycontainer
 
 # Execute command
 nu scripts/container-lifecycle.nu exec mycontainer /bin/bash
+
+# Export container to image (0.10.0+)
+nu scripts/container-lifecycle.nu export mycontainer -o exported.tar
 ```
 
 ### container-cleanup.nu

--- a/plugins/core/skills/container/references/command-reference.md
+++ b/plugins/core/skills/container/references/command-reference.md
@@ -43,10 +43,11 @@ container run [FLAGS] IMAGE [COMMAND] [ARGS...]
 | `--tmpfs` | | Mount a tmpfs filesystem |
 | `--cidfile` | | Write container ID to file |
 | `--publish-socket` | | Publish a socket |
-| `--init-image` | | Init image for VM |
+| `--init` | | Run an init process in the container (0.10.0+) |
+| `--init-image` | | Init image for VM (0.10.0+ selection support) |
 | `--kernel` | | Custom kernel for VM |
 | `--virtualization` | | Virtualization backend |
-| `--runtime` | | Container runtime |
+| `--runtime` | | Container runtime (0.10.0+) |
 | `--scheme` | | Image scheme |
 | `--progress` | | Progress output (`none`, `ansi`) (0.7.0+) |
 | `--gid` | | Group ID |
@@ -65,7 +66,7 @@ Create a container without starting it.
 container create [FLAGS] IMAGE [COMMAND] [ARGS...]
 ```
 
-Accepts all the same flags as `container run` except `--detach`. Includes `--read-only` (0.8.0+), `--cpus`/`--memory` (0.9.0+), and all DNS flags.
+Accepts all the same flags as `container run` except `--detach`. Includes `--read-only` (0.8.0+), `--cpus`/`--memory` (0.9.0+), `--init`/`--init-image`/`--runtime` (0.10.0+), and all DNS flags.
 
 ### `container start`
 
@@ -166,6 +167,19 @@ container prune
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--force` | `-f` | Skip confirmation |
+
+### `container export`
+
+Create an image from a container's changes. (0.10.0+)
+
+```
+container export [FLAGS] CONTAINER
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--output` | `-o` | Output file path |
+| `--tag` | `-t` | Name and tag for the exported image |
 
 ### `container list` / `container ls`
 
@@ -459,6 +473,14 @@ Prompts for username and password. Credentials stored in macOS Keychain.
 - 0.4.x: `com.apple.container`
 - 0.5.0+: `com.apple.container.registry`
 
+### `container registry list`
+
+List configured container registries. (0.10.0+)
+
+```
+container registry list
+```
+
 ### `container registry logout`
 
 Log out from a container registry.
@@ -490,8 +512,12 @@ container system stop
 Check if the system service is running.
 
 ```
-container system status
+container system status [FLAGS]
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (e.g., `json`) (0.10.0+) |
 
 Exit code 0 if running, non-zero if not.
 

--- a/plugins/core/skills/container/scripts/container-lifecycle.nu
+++ b/plugins/core/skills/container/scripts/container-lifecycle.nu
@@ -1,10 +1,10 @@
 #!/usr/bin/env nu
 
 # Apple Container lifecycle management
-# Supports: run, ps, start, stop, kill, rm, exec, logs, inspect, stats
+# Supports: run, ps, start, stop, kill, rm, exec, logs, inspect, stats, export
 
 def main [
-    command: string   # Subcommand: run, ps, start, stop, kill, rm, exec, logs, inspect, stats
+    command: string   # Subcommand: run, ps, start, stop, kill, rm, exec, logs, inspect, stats, export
     ...args: string   # Additional arguments passed to the command
 ] {
     match $command {
@@ -18,9 +18,10 @@ def main [
         "logs" => { cmd-logs $args }
         "inspect" => { cmd-inspect $args }
         "stats" => { cmd-stats }
+        "export" => { cmd-export $args }
         _ => {
             print $"(ansi red)Error:(ansi reset) Unknown command '($command)'"
-            print "Available: run, ps, start, stop, kill, rm, exec, logs, inspect, stats"
+            print "Available: run, ps, start, stop, kill, rm, exec, logs, inspect, stats, export"
             exit 1
         }
     }
@@ -191,5 +192,22 @@ def cmd-stats [] {
     } else {
         print $"(ansi red)Error:(ansi reset) ($result.stderr)"
         exit 1
+    }
+}
+
+def cmd-export [args: list<string>] {
+    ensure-running
+    if ($args | is-empty) {
+        print $"(ansi red)Error:(ansi reset) Container name or ID required"
+        print "Usage: container-lifecycle.nu export <container> [-o file] [-t tag]"
+        exit 1
+    }
+    let result = (do { ^container export ...$args } | complete)
+    if $result.exit_code == 0 {
+        print $result.stdout
+        print $"(ansi green)Export complete(ansi reset)"
+    } else {
+        print $"(ansi red)Error:(ansi reset) ($result.stderr)"
+        exit $result.exit_code
     }
 }

--- a/plugins/core/skills/container/templates/0.10.0/commands.md
+++ b/plugins/core/skills/container/templates/0.10.0/commands.md
@@ -1,0 +1,54 @@
+# Apple Container CLI - Version 0.10.0 Commands
+
+Changes from 0.9.0.
+
+## Breaking Changes from 0.9.0
+
+| Change | Migration |
+|--------|-----------|
+| ClientContainer reworked as generic client | Update API consumers for generic client interface |
+| API terminology: 'cleanup' corrected to 'clean up' | Update API calls using old terminology |
+| Container bundle creation moved to SandboxService | Move bundle creation code from main container ops |
+| Multiple network plugins support | Review network configuration for multi-plugin model |
+
+## New Features in 0.10.0
+
+- VM init image selection: `--init-image` flag on `container run`/`container create`
+- Container export: create images from running containers (`container export`)
+- Runtime flag: `--runtime` on `container run`/`container create`
+- `--init` flag on `container run`/`container create`
+- `container registry list` to list configured registries
+- `--format` option on `container system status`
+- Minimum memory validation on container creation
+- Enhanced directory watcher functionality
+
+## Container Lifecycle
+
+| Command | Description |
+|---------|-------------|
+| `container run` | **`--init`, `--init-image`, `--runtime` flags formalized** |
+| `container create` | **`--init`, `--init-image`, `--runtime` flags formalized** |
+| `container export` | **New command: create image from running container** |
+
+## Registry
+
+| Command | Description |
+|---------|-------------|
+| `container registry list` | **New command: list configured registries** |
+
+## System Management
+
+| Command | Description |
+|---------|-------------|
+| `container system status` | **`--format` flag added** |
+
+## Bug Fixes
+
+- Kernel panic fix for SELinux inode security under load
+- Environment variable duplication fix in run operations
+- Coldstart integration test fixes
+- Enhanced directory watcher
+
+## Dependencies
+
+- Containerization 0.26.2

--- a/plugins/core/skills/sources.md
+++ b/plugins/core/skills/sources.md
@@ -222,6 +222,12 @@ This file documents the sources used to create the core plugin skills.
 - **Purpose**: Version 0.9.0 release notes
 - **Key Topics**: Resource limits (--cpus/--memory), host.docker.internal, host-only/isolated networks, --dns on build, --force on image delete, zstd compression, Kata 3.26.0
 
+### Apple Container Release 0.10.0
+- **URL**: https://github.com/apple/container/releases/tag/0.10.0
+- **Purpose**: Version 0.10.0 release notes
+- **Date Accessed**: 2026-03-24
+- **Key Topics**: VM init image selection, container export, runtime flag, registry list, --format on system status, --init flag, generic ClientContainer, SandboxService bundle creation, multiple network plugins, minimum memory validation, SELinux kernel panic fix, env var duplication fix, Containerization 0.26.2
+
 ## TDD Skill
 
 ### Test-Driven Development by Example
@@ -258,7 +264,7 @@ This file documents the sources used to create the core plugin skills.
 ## Plugin Information
 
 - **Name**: core
-- **Version**: 0.1.10
+- **Version**: 0.1.19
 - **Description**: Essential development skills: Git, documentation, code review, accessibility, security
 - **Skills**: 12 skills covering fundamental development tools and best practices
 - **Created**: 2025-11-15


### PR DESCRIPTION
- Add 0.10.0 version template with breaking changes, new features, and dependencies
- Add container export command, registry list, --init, --init-image, --runtime flags
- Add --format flag on system status
- Update SKILL.md with 0.10.0 version differences, migration checklist, and examples
- Update command-reference.md with new commands and flag annotations
- Add export subcommand to container-lifecycle.nu script
- Add 0.10.0 release to sources.md
- Bump core plugin 0.1.18 -> 0.1.19, all-skills 0.3.16 -> 0.3.17