### PR TITLE
feat(claude-code): add skill-update skill for upstream version tracking

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.17",
+      "version": "0.3.18",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -23,9 +23,9 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills: plugin marketplace management and validation",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "category": "tools",
-      "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark"]
+      "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark", "skill-update"]
     },
     {
       "name": "core",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -26,6 +26,7 @@
     "./plugins/tools/claude-code/skills/claude-hooks",
     "./plugins/tools/claude-code/skills/claude-teams",
     "./plugins/tools/claude-code/skills/claude-skills-benchmark",
+    "./plugins/tools/claude-code/skills/skill-update",
     "./plugins/core/skills/git",
     "./plugins/core/skills/mise",
     "./plugins/core/skills/nushell",

--- a/mise.toml
+++ b/mise.toml
@@ -1049,3 +1049,68 @@ def main [task_id?: string] {
 [tasks."beads:rebuild"]
 description = "Rebuild SQLite cache from JSONL files"
 run = "bd rebuild"
+
+# ========================
+# Sources Management Tasks
+# ========================
+
+[tasks."sources:check"]
+description = "Check all tracked sources for version updates"
+run = '''
+#!/usr/bin/env bash
+SCRIPT="plugins/tools/claude-code/skills/skill-update/scripts/sources-check.nu"
+if [ -n "$1" ]; then
+    nu "$SCRIPT" --plugin "$1"
+else
+    nu "$SCRIPT"
+fi
+'''
+
+[tasks."sources:stale"]
+description = "Show only stale/outdated sources"
+run = '''
+#!/usr/bin/env bash
+SCRIPT="plugins/tools/claude-code/skills/skill-update/scripts/sources-stale.nu"
+DAYS="${1:-30}"
+PLUGIN="${2:-}"
+if [ -n "$PLUGIN" ]; then
+    nu "$SCRIPT" --days "$DAYS" --plugin "$PLUGIN"
+else
+    nu "$SCRIPT" --days "$DAYS"
+fi
+'''
+
+[tasks."sources:validate"]
+description = "Validate all source URLs are accessible"
+run = '''
+#!/usr/bin/env bash
+SCRIPT="plugins/tools/claude-code/skills/skill-update/scripts/sources-validate-urls.nu"
+if [ -n "$1" ]; then
+    nu "$SCRIPT" --plugin "$1"
+else
+    nu "$SCRIPT"
+fi
+'''
+
+[tasks."sources:report"]
+description = "Generate markdown update report"
+run = '''
+#!/usr/bin/env bash
+SCRIPT="plugins/tools/claude-code/skills/skill-update/scripts/sources-report.nu"
+if [ -n "$1" ]; then
+    nu "$SCRIPT" --plugin "$1"
+else
+    nu "$SCRIPT"
+fi
+'''
+
+[tasks."sources:init"]
+description = "Bootstrap sources.toml from existing sources.md"
+run = '''
+#!/usr/bin/env bash
+if [ -z "$1" ]; then
+    echo "Usage: mise sources:init <plugin-name>"
+    exit 1
+fi
+nu "plugins/tools/claude-code/skills/skill-update/scripts/sources-init.nu" "$1"
+'''

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"
@@ -16,6 +16,7 @@
     "./skills/claude-skills",
     "./skills/claude-hooks",
     "./skills/claude-teams",
-    "./skills/claude-skills-benchmark"
+    "./skills/claude-skills-benchmark",
+    "./skills/skill-update"
   ]
 }

--- a/plugins/tools/claude-code/skills/skill-update/SKILL.md
+++ b/plugins/tools/claude-code/skills/skill-update/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: skill-update
+description: Repeatable process for keeping skills up-to-date with upstream sources and versions. Use when checking for stale skills, updating a skill for a new upstream version, auditing source freshness, or bootstrapping version tracking for a plugin.
+license: MIT
+---
+
+# Skill Update
+
+Structured workflow for keeping skills current with upstream sources. Execute all phases in order.
+
+## Quick Reference
+
+| Command | Purpose |
+|---|---|
+| `mise sources:check` | Compare current vs latest for all plugins |
+| `mise sources:stale` | List only stale sources |
+| `mise sources:validate` | Validate sources.toml schema in all plugins |
+| `mise sources:report` | Full freshness report with priorities |
+| `mise sources:init <plugin>` | Bootstrap sources.toml for a plugin |
+
+## sources.toml Schema
+
+Each plugin's `skills/sources.toml` tracks upstream dependencies. See `templates/sources.toml` for the complete annotated template.
+
+| Field | Values | Required | Description |
+|---|---|---|---|
+| `skill` | string | yes | Skill directory name |
+| `name` | string | yes | Human-readable source identifier |
+| `url` | string | yes | Primary source URL |
+| `releases_url` | string | no | Release tracking URL |
+| `check_method` | see table below | yes | How to query latest version |
+| `github_repo` | `owner/repo` | conditional | Required for `github-releases` |
+| `hex_package` | string | conditional | Required for `hex-pm` |
+| `crate_name` | string | conditional | Required for `crates-io` |
+| `current_version` | string | yes | Currently documented version |
+| `version_constraint` | `pre-1.0` \| `semver` \| `rolling` \| `stable` | yes | Version stability model |
+| `last_checked` | `YYYY-MM-DD` | yes | Date of last check |
+| `update_priority` | `high` \| `medium` \| `low` | yes | Update urgency |
+| `breaking_changes_likely` | bool | no | Minor bumps may break (default: false) |
+| `notes` | string | no | Free-form context |
+
+## Check Method API Endpoints
+
+| `check_method` | Endpoint | Auth | Rate Limit |
+|---|---|---|---|
+| `github-releases` | `https://api.github.com/repos/{owner}/{repo}/releases/latest` | Optional `GITHUB_TOKEN` | 60/hr unauth, 5000/hr auth |
+| `hex-pm` | `https://hex.pm/api/packages/{package}` | None | 100/min |
+| `crates-io` | `https://crates.io/api/v1/crates/{crate}` | `User-Agent` header required | 1/sec |
+| `manual` | N/A | N/A | N/A — check `releases_url` manually |
+
+See `references/version-check-methods.md` for Nushell parsing examples.
+
+---
+
+## Phase 1: Discovery
+
+Run `mise sources:check` to produce a staleness table:
+
+```
+plugin        | skill       | source          | current | latest  | stale | priority
+claude-code   | container   | apple-container | 0.10.0  | 0.11.0  | yes   | high
+elixir        | tidewave    | tidewave        | 0.5.6   | 0.5.6   | no    | medium
+```
+
+If `sources.toml` does not exist for a plugin, run `mise sources:init <plugin>` first.
+
+**Anti-fabrication**: Do not report version numbers without executing `mise sources:check` or querying the upstream API directly. Mark unknown versions as `"requires-check"`.
+
+---
+
+## Phase 2: Triage
+
+Classify each stale source before updating:
+
+| Condition | Classification | Action |
+|---|---|---|
+| `pre-1.0` + `breaking_changes_likely = true` + major bump | Critical | Full migration checklist |
+| `semver` + major version bump | Breaking | Breaking changes review required |
+| `semver` + minor/patch bump | Standard | Light-touch update |
+| `rolling` or `stable` | Docs | Documentation refresh only |
+
+**Priority order**: high → medium → low. Within same priority: breaking changes first.
+
+---
+
+## Phase 3: Research
+
+For each update target, collect before writing any changes:
+
+1. Fetch release notes from `releases_url`
+2. Identify: breaking changes, new features, deprecations, bug fixes
+3. Compare against skill's currently documented features
+4. Determine if a versioned template is needed (e.g., `templates/0.11.0/commands.md`)
+
+**Anti-fabrication requirements**:
+- Read actual release notes before claiming any feature exists in a new version
+- Use `WebFetch` or equivalent to retrieve changelog content
+- Mark any feature as "requires verification" if release notes are unavailable
+- Never assume a command or flag exists — verify against official docs or release notes
+
+---
+
+## Phase 4: Update
+
+Apply changes following the type-specific checklist in `references/update-checklist.md`.
+
+### Skill Type Lookup
+
+| Skill type | Examples | Checklist section |
+|---|---|---|
+| CLI tool | container, bees, beads | CLI Tools |
+| Library package | tidewave, wasmex, phoenix | Library Packages |
+| Language/runtime | rust, zig | Language/Runtime |
+| Documentation-based | git, accessibility, twelve-factor | Documentation-Based |
+
+### Versioned Templates
+
+When a CLI tool has breaking command changes across versions, create a versioned template:
+
+```
+skills/<skill-name>/
+└── templates/
+    └── <new-version>/
+        └── commands.md     # Commands snapshot for this version
+```
+
+Reference the old version template in the migration section of SKILL.md.
+
+---
+
+## Phase 5: Bookkeeping
+
+Complete in this order after every update:
+
+1. Update `sources.toml`: set `current_version` and `last_checked`
+2. Update `sources.md`: add release entry with date and summary
+3. Bump plugin version in `<plugin>/.claude-plugin/plugin.json`
+4. Bump matching version in `.claude-plugin/marketplace.json`
+5. Run `mise update-all-skills`
+6. Run `mise test`
+
+Use patch bumps (e.g., `0.5.6` → `0.5.7`) unless the skill itself has breaking changes.
+
+---
+
+## Phase 6: Validation
+
+| Check | Command | Pass Criteria |
+|---|---|---|
+| Schema | `mise test` | All plugins pass |
+| SKILL.md length | `wc -l SKILL.md` | Under 500 lines |
+| Sources valid | `mise sources:validate` | No schema errors |
+| Commit format | — | Conventional commit, no attribution |
+
+Commit format: `chore(<plugin>): update <skill> to <version>`
+
+Example: `chore(claude-code): update container to 0.11.0`
+
+Create PR with minimal format (title + bullet list, no attribution, no boilerplate sections).
+
+---
+
+## Agent Team Pattern
+
+For batch updates across multiple plugins, spawn agents per plugin:
+
+```
+Orchestrator (sonnet)
+├── Plugin checker (haiku) — runs mise sources:check for one plugin
+├── Plugin checker (haiku) — runs mise sources:check for another plugin
+└── ...
+
+For each stale source:
+├── Standard update (haiku)    — minor/patch semver, docs-based
+└── Breaking update (sonnet)   — major semver, pre-1.0 breaking, CLI tools
+```
+
+Promote model if an agent fails the same task twice: haiku → sonnet → opus.
+
+---
+
+## Bootstrapping a New Plugin
+
+When a plugin has no `sources.toml`:
+
+1. Run `mise sources:init <plugin>` to generate a skeleton
+2. Fill in all `[[sources]]` entries for each skill
+3. Set `current_version` by reading the skill's current SKILL.md
+4. Set `last_checked` to today's date
+5. Run `mise sources:validate` to confirm schema
+6. Commit: `chore(<plugin>): add sources.toml for version tracking`

--- a/plugins/tools/claude-code/skills/skill-update/references/update-checklist.md
+++ b/plugins/tools/claude-code/skills/skill-update/references/update-checklist.md
@@ -1,0 +1,185 @@
+# Update Checklist
+
+Detailed per-type checklists for applying upstream updates to skills. Load this file when executing Phase 4 of the skill-update workflow.
+
+---
+
+## CLI Tools
+
+For skills wrapping command-line tools (e.g., container, bees, beads).
+
+### Pre-Update Research
+
+- [ ] Fetch full release notes from `releases_url`
+- [ ] List all new commands and subcommands
+- [ ] List all new flags and options
+- [ ] Identify removed or renamed commands (breaking changes)
+- [ ] Identify deprecated flags with their replacements
+- [ ] Note any changed default behaviors
+- [ ] Check if config file format changed
+
+### Version Template
+
+- [ ] Create `templates/<new-version>/commands.md` with a snapshot of commands for this version
+- [ ] Verify the old version template still exists at `templates/<old-version>/commands.md`
+- [ ] Add migration note in SKILL.md pointing users from old to new template
+
+### SKILL.md Updates
+
+- [ ] Update version number in frontmatter or version table
+- [ ] Update installation instructions (new download URL, checksum)
+- [ ] Update quick reference table with new commands
+- [ ] Add breaking changes table if any removals or renames
+- [ ] Add migration checklist section if major version bump
+- [ ] Update features list to reflect new capabilities
+- [ ] Remove references to deprecated commands
+- [ ] Update any inline examples that use changed syntax
+
+### references/command-reference.md (if present)
+
+- [ ] Add new commands with full flag documentation
+- [ ] Annotate deprecated flags with `[DEPRECATED in vX.Y]`
+- [ ] Annotate new flags with `[NEW in vX.Y]`
+- [ ] Remove commands that no longer exist (or mark `[REMOVED in vX.Y]`)
+- [ ] Verify all examples produce valid output with the new version
+
+### Scripts (if present)
+
+- [ ] Add Nushell helper functions for new subcommands
+- [ ] Update existing functions if flag syntax changed
+- [ ] Remove helpers for removed commands
+- [ ] Run scripts against new version to verify behavior
+
+### Bookkeeping
+
+- [ ] Update `current_version` in `sources.toml`
+- [ ] Update `last_checked` in `sources.toml`
+- [ ] Add entry to `sources.md`: date, from-version, to-version, summary
+- [ ] Bump `plugin.json` version (patch unless breaking changes to skill itself)
+- [ ] Bump matching version in `marketplace.json`
+- [ ] Run `mise update-all-skills`
+- [ ] Run `mise test`
+
+---
+
+## Library Packages
+
+For skills wrapping hex.pm packages, crates, or npm packages (e.g., tidewave, wasmex, phoenix).
+
+### Pre-Update Research
+
+- [ ] Query check_method endpoint for latest version number
+- [ ] Read CHANGELOG or release notes for all changes since `current_version`
+- [ ] Identify API additions (new functions, modules, types)
+- [ ] Identify API removals or renames (breaking changes)
+- [ ] Identify changed function signatures
+- [ ] Note new optional dependencies or feature flags
+- [ ] Check minimum runtime/language version requirement changes
+
+### SKILL.md Updates
+
+- [ ] Update version constraint (e.g., `~> 0.5.6` → `~> 0.6.0`)
+- [ ] Update installation instructions (`mix.exs`, `Cargo.toml`, etc.)
+- [ ] Document new APIs with usage examples
+- [ ] Update changed API examples
+- [ ] Note deprecated APIs with migration path
+- [ ] Update minimum runtime version if changed
+- [ ] Update any feature flags or optional dependency instructions
+
+### References (if present)
+
+- [ ] Update API reference with new functions/modules
+- [ ] Annotate changed signatures with version info
+- [ ] Update integration examples
+
+### Bookkeeping
+
+- [ ] Update `current_version` in `sources.toml`
+- [ ] Update `last_checked` in `sources.toml`
+- [ ] Add entry to `sources.md`
+- [ ] Bump `plugin.json` version
+- [ ] Bump matching version in `marketplace.json`
+- [ ] Run `mise update-all-skills`
+- [ ] Run `mise test`
+
+---
+
+## Language / Runtime
+
+For skills covering a programming language or runtime (e.g., rust, zig).
+
+### Pre-Update Research
+
+- [ ] Identify new stable release version
+- [ ] Read official release blog post or changelog
+- [ ] List new language features (syntax, keywords, concepts)
+- [ ] List new standard library additions
+- [ ] Identify removed or changed language features
+- [ ] Note changes to compiler flags or toolchain commands
+- [ ] Check for edition/epoch changes (Rust editions, Zig stages)
+- [ ] Identify ecosystem tooling changes (formatter, linter, package manager)
+
+### SKILL.md Updates
+
+- [ ] Update version references throughout
+- [ ] Add new language features with examples
+- [ ] Update compiler command examples for new flags
+- [ ] Update toolchain installation instructions
+- [ ] Document new standard library features
+- [ ] Note removed features with migration path
+- [ ] Update any idiom recommendations based on new best practices
+
+### References (if present)
+
+- [ ] Update language reference with new syntax
+- [ ] Update toolchain reference
+- [ ] Add edition/migration guide if applicable
+
+### Bookkeeping
+
+- [ ] Update `current_version` in `sources.toml`
+- [ ] Update `last_checked` in `sources.toml`
+- [ ] Add entry to `sources.md`
+- [ ] Bump `plugin.json` version
+- [ ] Bump matching version in `marketplace.json`
+- [ ] Run `mise update-all-skills`
+- [ ] Run `mise test`
+
+---
+
+## Documentation-Based
+
+For skills based on evolving documentation or standards (e.g., git, accessibility, twelve-factor).
+
+### Pre-Update Research
+
+- [ ] Check if upstream specification or guide has changed
+- [ ] Look for new best practices or recommendations
+- [ ] Check if any referenced external URLs have moved or gone stale
+- [ ] Note any community-driven changes (new conventions, deprecations)
+
+### SKILL.md Updates (only if content has changed)
+
+- [ ] Refresh outdated examples
+- [ ] Update or replace broken external links
+- [ ] Add new best practices
+- [ ] Remove outdated recommendations
+- [ ] Update version references if specification is versioned
+
+### Bookkeeping
+
+- [ ] Update `last_checked` in `sources.toml` (always)
+- [ ] Update `current_version` if specification version changed
+- [ ] Add entry to `sources.md` only if content changed
+- [ ] Bump `plugin.json` version only if SKILL.md content changed
+- [ ] Run `mise test` if versions were bumped
+
+---
+
+## Anti-Fabrication Rules for All Types
+
+- Do not check off any item without executing the corresponding verification
+- Do not claim a command, flag, or API exists without reading official release notes or documentation
+- Do not mark a version as "current" until `sources.toml` is updated with the verified version string
+- If release notes are unavailable, mark the source as `check_method = "manual"` and add a note in `sources.toml`
+- Do not report test results without actual execution

--- a/plugins/tools/claude-code/skills/skill-update/references/version-check-methods.md
+++ b/plugins/tools/claude-code/skills/skill-update/references/version-check-methods.md
@@ -1,0 +1,183 @@
+# Version Check Methods
+
+Reference for each `check_method` value in `sources.toml`. Includes API endpoints, authentication, response parsing, rate limits, and Nushell examples.
+
+---
+
+## github-releases
+
+Queries the GitHub Releases API for the latest published release.
+
+| Property | Value |
+|---|---|
+| Endpoint | `https://api.github.com/repos/{owner}/{repo}/releases/latest` |
+| Auth | Optional `Authorization: Bearer $GITHUB_TOKEN` |
+| Rate limit (unauth) | 60 requests/hour per IP |
+| Rate limit (auth) | 5,000 requests/hour |
+| Required field | `github_repo = "owner/repo"` |
+
+**Response parsing**: Extract `.tag_name`. Strip leading `v` prefix if present.
+
+```nushell
+# Query latest release for a GitHub repo
+def get-github-latest [repo: string] -> string {
+    let url = $"https://api.github.com/repos/($repo)/releases/latest"
+    let headers = if ("GITHUB_TOKEN" in $env) {
+        {Authorization: $"Bearer ($env.GITHUB_TOKEN)", "X-GitHub-Api-Version": "2022-11-28"}
+    } else {
+        {"X-GitHub-Api-Version": "2022-11-28"}
+    }
+    let response = http get --headers $headers $url
+    $response.tag_name | str replace --regex '^v' ''
+}
+
+# Example
+let latest = get-github-latest "apple/container"
+# Returns: "0.11.0"
+```
+
+**Notes**:
+- Use `GITHUB_TOKEN` to avoid rate limiting during batch checks
+- The `releases/latest` endpoint skips pre-releases; use `releases` list if pre-releases must be tracked
+- Some repos use `tag_name` values like `release-0.11.0` — strip non-numeric prefixes as needed
+
+---
+
+## hex-pm
+
+Queries the Hex.pm package registry for Elixir/Erlang packages.
+
+| Property | Value |
+|---|---|
+| Endpoint | `https://hex.pm/api/packages/{package}` |
+| Auth | None required |
+| Rate limit | 100 requests/minute |
+| Required field | `hex_package = "package_name"` |
+
+**Response parsing**: Extract `.latest_stable_version` or the first entry in `.releases[].version` sorted by insertion order.
+
+```nushell
+# Query latest stable version for a Hex.pm package
+def get-hex-latest [package: string] -> string {
+    let url = $"https://hex.pm/api/packages/($package)"
+    let response = http get $url
+    $response.latest_stable_version
+}
+
+# Example
+let latest = get-hex-latest "tidewave"
+# Returns: "0.5.6"
+```
+
+**Notes**:
+- `latest_stable_version` excludes pre-release versions (rc, alpha, beta)
+- To include pre-releases, inspect `$response.releases | first | get version`
+- No authentication needed for public packages
+- Response also contains `$response.meta.description` and `$response.meta.links` for documentation URLs
+
+---
+
+## crates-io
+
+Queries the crates.io registry for Rust packages.
+
+| Property | Value |
+|---|---|
+| Endpoint | `https://crates.io/api/v1/crates/{crate}` |
+| Auth | None required (but `User-Agent` is mandatory) |
+| Rate limit | 1 request/second |
+| Required field | `crate_name = "crate_name"` |
+
+**Response parsing**: Extract `.crate.newest_version` for the latest version (including pre-releases), or `.crate.max_stable_version` for latest stable.
+
+```nushell
+# Query latest stable version for a crates.io package
+def get-crates-latest [crate_name: string] -> string {
+    let url = $"https://crates.io/api/v1/crates/($crate_name)"
+    # User-Agent is REQUIRED by crates.io policy
+    let headers = {"User-Agent": "claude-skills/mise-sources-check (github.com/vinnie357/claude-skills)"}
+    let response = http get --headers $headers $url
+    $response.crate.max_stable_version
+}
+
+# Example
+let latest = get-crates-latest "wasmtime"
+# Returns: "28.0.0"
+```
+
+**Notes**:
+- Omitting `User-Agent` results in a 403 error
+- `max_stable_version` excludes pre-releases; `newest_version` includes them
+- Rate limit is enforced per IP; add `sleep 1sec` between calls in batch scripts
+- Response also includes `$response.crate.homepage` and `$response.crate.documentation`
+
+---
+
+## manual
+
+No automated API check. Requires human review of the `releases_url`.
+
+| Property | Value |
+|---|---|
+| Endpoint | N/A |
+| Auth | N/A |
+| Rate limit | N/A |
+| Required field | `releases_url` strongly recommended |
+
+**When to use**:
+- Source is documentation or a specification (no versioned releases)
+- Source uses a custom release page not covered by other methods
+- Source is behind authentication
+- Upstream does not publish machine-readable release metadata
+
+```nushell
+# Manual sources appear in sources:check output with latest = "manual"
+# The operator must visit releases_url and update current_version manually
+```
+
+**Workflow for manual sources**:
+1. Open `releases_url` in a browser
+2. Compare the latest posted version against `current_version` in `sources.toml`
+3. If stale, follow the Phase 3 research steps manually
+4. Update `current_version` and `last_checked` after verifying
+
+---
+
+## Batch Check Script Pattern
+
+The `mise sources:check` task implements the following pattern across all plugins:
+
+```nushell
+# Pseudocode for mise sources:check
+def check-all-sources [] {
+    glob "plugins/**/skills/sources.toml"
+    | each { |toml_path|
+        open $toml_path
+        | get sources
+        | each { |source|
+            let latest = match $source.check_method {
+                "github-releases" => { get-github-latest $source.github_repo },
+                "hex-pm"          => { get-hex-latest $source.hex_package },
+                "crates-io"       => { get-crates-latest $source.crate_name },
+                "manual"          => { "manual" },
+                _                 => { error make { msg: $"Unknown check_method: ($source.check_method)" } }
+            }
+            let stale = if $latest == "manual" { false } else {
+                $latest != $source.current_version
+            }
+            {
+                plugin: $source.skill,
+                source: $source.name,
+                current: $source.current_version,
+                latest: $latest,
+                stale: $stale,
+                priority: $source.update_priority
+            }
+        }
+    }
+    | flatten
+    | sort-by priority stale --reverse
+}
+```
+
+**Anti-fabrication**: The `mise sources:check` command must be implemented and executed before reporting version data. Do not estimate or guess version numbers.

--- a/plugins/tools/claude-code/skills/skill-update/scripts/sources-check.nu
+++ b/plugins/tools/claude-code/skills/skill-update/scripts/sources-check.nu
@@ -1,0 +1,223 @@
+#!/usr/bin/env nu
+
+# Check all tracked sources for version updates
+# Reads sources.toml files across all plugins and queries upstream APIs
+#
+# Usage: nu sources-check.nu [--plugin <name>]
+#
+# Output: table with columns: plugin | skill | source | current | latest | stale | priority
+
+# Resolve the repo root relative to this script's location
+def repo-root [] {
+    $env.FILE_PWD | path join ".." ".." ".." ".." ".." ".." ".." | path expand
+}
+
+# Load marketplace.json and return plugins list
+def load-marketplace [repo: string] {
+    let mp_path = $"($repo)/.claude-plugin/marketplace.json"
+    if not ($mp_path | path exists) {
+        error make { msg: $"marketplace.json not found at ($mp_path)" }
+    }
+    open $mp_path
+}
+
+# Resolve a plugin's source path to an absolute directory path
+def resolve-plugin-path [repo: string, source: any] {
+    if ($source | describe) == "string" {
+        # e.g. "./plugins/core" -> absolute path
+        let rel = $source | str replace -r '^\./' ''
+        $"($repo)/($rel)"
+    } else {
+        # External source object — not a local path, skip
+        null
+    }
+}
+
+# Find all sources.toml files for a given plugin directory
+def find-sources-toml [plugin_dir: string] {
+    let toml_path = $"($plugin_dir)/skills/sources.toml"
+    if ($toml_path | path exists) {
+        [$toml_path]
+    } else {
+        []
+    }
+}
+
+# Check latest version via github-releases API
+def check-github-releases [repo: string] {
+    let url = $"https://api.github.com/repos/($repo)/releases/latest"
+    let token = $env.GITHUB_TOKEN? | default ""
+    let headers = if ($token | is-not-empty) {
+        [Authorization $"Bearer ($token)" User-Agent "sources-check.nu/1.0"]
+    } else {
+        [User-Agent "sources-check.nu/1.0"]
+    }
+    try {
+        let response = http get -H $headers $url
+        let tag = $response.tag_name? | default ""
+        $tag | str replace -r '^v' ''
+    } catch {
+        "error"
+    }
+}
+
+# Check latest version via hex.pm API
+def check-hex-pm [package: string] {
+    let url = $"https://hex.pm/api/packages/($package)"
+    try {
+        let response = http get $url
+        let releases = $response.releases? | default []
+        if ($releases | length) > 0 {
+            $releases | first | get version? | default "unknown"
+        } else {
+            "unknown"
+        }
+    } catch {
+        "error"
+    }
+}
+
+# Check latest version via crates.io API
+def check-crates-io [crate_name: string] {
+    let url = $"https://crates.io/api/v1/crates/($crate_name)"
+    let headers = [User-Agent "sources-check.nu/1.0 (claude-skills)"]
+    try {
+        let response = http get -H $headers $url
+        $response.crate?.max_version? | default "unknown"
+    } catch {
+        "error"
+    }
+}
+
+# Dispatch version check by method
+def fetch-latest [source: record] {
+    let method = $source.check_method? | default "manual"
+    match $method {
+        "github-releases" => {
+            let repo = $source.github_repo? | default ""
+            if ($repo | is-empty) { "error" } else { check-github-releases $repo }
+        }
+        "hex-pm" => {
+            let pkg = $source.hex_package? | default ""
+            if ($pkg | is-empty) { "error" } else { check-hex-pm $pkg }
+        }
+        "crates-io" => {
+            let crate_name = $source.crate_name? | default ""
+            if ($crate_name | is-empty) { "error" } else { check-crates-io $crate_name }
+        }
+        "manual" => { "manual" }
+        _ => { "unknown-method" }
+    }
+}
+
+# Process a single sources.toml file and return rows
+def process-sources-toml [toml_path: string, plugin_name: string] {
+    let data = try {
+        open $toml_path
+    } catch {
+        print $"(ansi yellow)Warning: could not parse ($toml_path)(ansi reset)"
+        return []
+    }
+
+    let sources = $data.sources? | default []
+    if ($sources | is-empty) {
+        return []
+    }
+
+    $sources | each { |src|
+        let skill     = $src.skill?    | default ""
+        let name      = $src.name?     | default ""
+        let current   = $src.current_version? | default "unset"
+        let priority  = $src.update_priority? | default "medium"
+        let method    = $src.check_method? | default "manual"
+        let last_checked = $src.last_checked? | default ""
+
+        print $"  Checking ($plugin_name)/($skill)/($name) via ($method)..."
+
+        let latest = fetch-latest $src
+
+        let stale = if $latest == "manual" {
+            "manual"
+        } else if $latest == "error" {
+            "error"
+        } else if $current == "unset" {
+            "unset"
+        } else if $current != $latest {
+            "yes"
+        } else {
+            "no"
+        }
+
+        {
+            plugin:   $plugin_name
+            skill:    $skill
+            source:   $name
+            current:  $current
+            latest:   $latest
+            stale:    $stale
+            priority: $priority
+            method:   $method
+            last_checked: $last_checked
+        }
+    }
+}
+
+def main [--plugin: string = ""] {
+    let repo = repo-root
+
+    print $"(ansi cyan_bold)Sources Version Check(ansi reset)"
+    print $"Repo root: ($repo)"
+    print ""
+
+    let marketplace = load-marketplace $repo
+    let plugins = $marketplace.plugins? | default []
+
+    let filtered_plugins = if ($plugin | is-empty) {
+        $plugins
+    } else {
+        $plugins | where name == $plugin
+    }
+
+    if ($filtered_plugins | is-empty) {
+        if not ($plugin | is-empty) {
+            print $"(ansi red)No plugin found with name: ($plugin)(ansi reset)"
+            exit 1
+        }
+        print $"(ansi yellow)No plugins found in marketplace.(ansi reset)"
+        exit 0
+    }
+
+    mut all_rows = []
+
+    for pl in $filtered_plugins {
+        let pl_name = $pl.name
+        let pl_dir  = resolve-plugin-path $repo $pl.source
+
+        if $pl_dir == null {
+            continue
+        }
+
+        let toml_files = find-sources-toml $pl_dir
+
+        if ($toml_files | is-empty) {
+            continue
+        }
+
+        print $"(ansi green)Plugin: ($pl_name)(ansi reset)"
+
+        for toml_file in $toml_files {
+            let rows = process-sources-toml $toml_file $pl_name
+            $all_rows = ($all_rows | append $rows)
+        }
+    }
+
+    print ""
+
+    if ($all_rows | is-empty) {
+        print $"(ansi yellow)No sources.toml files found. Run sources-init.nu to bootstrap them.(ansi reset)"
+        exit 0
+    }
+
+    # Render results table
+    $all_rows | select plugin skill source current latest stale priority
+}

--- a/plugins/tools/claude-code/skills/skill-update/scripts/sources-init.nu
+++ b/plugins/tools/claude-code/skills/skill-update/scripts/sources-init.nu
@@ -1,0 +1,268 @@
+#!/usr/bin/env nu
+
+# Bootstrap a sources.toml from an existing sources.md file
+# Parses skill sections, source subsections, URLs, and dates from the markdown
+# and writes a TOML file with check_method = "manual" as default
+#
+# Usage: nu sources-init.nu <plugin-name> [--dry-run]
+
+# Resolve the repo root relative to this script's location
+def repo-root [] {
+    $env.FILE_PWD | path join ".." ".." ".." ".." ".." ".." ".." | path expand
+}
+
+# Load marketplace.json
+def load-marketplace [repo: string] {
+    let mp_path = $"($repo)/.claude-plugin/marketplace.json"
+    if not ($mp_path | path exists) {
+        error make { msg: $"marketplace.json not found at ($mp_path)" }
+    }
+    open $mp_path
+}
+
+# Resolve plugin source path to absolute directory
+def resolve-plugin-path [repo: string, source: any] {
+    if ($source | describe) == "string" {
+        let rel = $source | str replace -r '^\./' ''
+        $"($repo)/($rel)"
+    } else {
+        null
+    }
+}
+
+# Convert a heading string to a kebab-case slug used as a name
+def to-slug [text: string] {
+    $text
+        | str downcase
+        | str replace -ra '[^a-z0-9\s-]' ''
+        | str replace -ra '\s+' '-'
+        | str replace -ra '-+' '-'
+        | str trim -c '-'
+}
+
+# Extract a URL from a markdown bullet like: - **URL**: https://...
+def extract-url [line: string] {
+    let m = $line | parse -r '\*\*URL\*\*:\s*(?P<url>https?://\S+)'
+    if ($m | length) > 0 {
+        $m | first | get url
+    } else {
+        ""
+    }
+}
+
+# Extract a date from a markdown bullet like: - **Date Accessed**: 2025-11-15
+def extract-date [line: string] {
+    let m = $line | parse -r '\*\*Date Accessed\*\*:\s*(?P<date>\d{4}-\d{2}-\d{2})'
+    if ($m | length) > 0 {
+        $m | first | get date
+    } else {
+        ""
+    }
+}
+
+# Parse sources.md into structured records
+# Returns list of: { skill, name, url, date }
+def parse-sources-md [md_path: string] {
+    let lines = open $md_path | lines
+
+    mut current_skill = "general"
+    mut current_source = ""
+    mut current_url = ""
+    mut current_date = ""
+    mut sources = []
+
+    for line in $lines {
+        let trimmed = $line | str trim
+
+        # ## Heading → skill section
+        if ($trimmed | str starts-with "## ") {
+            # Save previous source if any
+            if not ($current_source | is-empty) {
+                $sources = ($sources | append {
+                    skill: $current_skill
+                    name:  $current_source
+                    url:   $current_url
+                    date:  $current_date
+                })
+                $current_source = ""
+                $current_url = ""
+                $current_date = ""
+            }
+            let heading = $trimmed | str replace -r '^#{1,2}\s+' ''
+            # Skip known non-skill sections
+            if $heading not-in ["Plugin Information", "Project Context", "Implementation Approach", "Overall Goals"] {
+                $current_skill = to-slug $heading
+            }
+            continue
+        }
+
+        # ### Heading → source entry
+        if ($trimmed | str starts-with "### ") {
+            # Save previous source if any
+            if not ($current_source | is-empty) {
+                $sources = ($sources | append {
+                    skill: $current_skill
+                    name:  $current_source
+                    url:   $current_url
+                    date:  $current_date
+                })
+            }
+            $current_source = $trimmed | str replace -r '^#{1,3}\s+' ''
+            $current_url = ""
+            $current_date = ""
+            continue
+        }
+
+        # Extract URL from bullet lines
+        if ($trimmed | str starts-with "- **URL**:") or ($trimmed | str starts-with "- **Url**:") {
+            $current_url = extract-url $trimmed
+            continue
+        }
+
+        # Extract date from bullet lines
+        if ($trimmed | str starts-with "- **Date Accessed**:") {
+            $current_date = extract-date $trimmed
+            continue
+        }
+    }
+
+    # Flush last source
+    if not ($current_source | is-empty) {
+        $sources = ($sources | append {
+            skill: $current_skill
+            name:  $current_source
+            url:   $current_url
+            date:  $current_date
+        })
+    }
+
+    # Filter out empty entries
+    $sources | where { |s| not ($s.name | is-empty) }
+}
+
+# Render a single [[sources]] TOML block as a string
+def render-source-block [s: record, index: int] {
+    let name_slug = to-slug $s.name
+    let url_line = if not ($s.url | is-empty) {
+        $"url           = \"($s.url)\"\n"
+    } else {
+        $"# url         = \"\"\n"
+    }
+    let date_line = if not ($s.date | is-empty) {
+        $"last_checked  = \"($s.date)\"\n"
+    } else {
+        $"# last_checked = \"\"\n"
+    }
+
+    $"[[sources]]\nskill         = \"($s.skill)\"\nname          = \"($s.name)\"\n($url_line)check_method  = \"manual\"\ncurrent_version = \"unknown\"\npriority      = \"normal\"\n($date_line)"
+}
+
+# Generate TOML content string from parsed sources list
+def generate-toml [plugin_name: string, sources: list] {
+    let today = (date now | format date "%Y-%m-%d")
+    let count = $sources | length
+
+    let header = $"# sources.toml — machine-readable source tracking for plugin: ($plugin_name)
+# Generated by sources-init.nu on ($today)
+# Edit check_method and repo/package/crate fields to enable automated version checks.
+# Valid check_method values: github-releases | hex-pm | crates-io | manual
+
+\[meta\]
+plugin       = \"($plugin_name)\"
+generated_at = \"($today)\"
+source_count = ($count)
+
+"
+
+    let blocks = $sources | enumerate | each { |it|
+        render-source-block $it.item $it.index
+    }
+
+    $header + ($blocks | str join "\n")
+}
+
+def main [plugin_name: string, --dry-run] {
+    let repo = repo-root
+
+    print $"(ansi cyan_bold)Bootstrapping sources.toml for plugin: ($plugin_name)(ansi reset)"
+    print $"Repo root: ($repo)"
+    print ""
+
+    # Find the plugin in the marketplace
+    let marketplace = load-marketplace $repo
+    let plugins = $marketplace.plugins? | default []
+    let matches = $plugins | where name == $plugin_name
+
+    if ($matches | is-empty) {
+        print $"(ansi red)Error: plugin '($plugin_name)' not found in marketplace.json(ansi reset)"
+        print ""
+        print "Available plugins:"
+        $plugins | get name | each { |n| print $"  - ($n)" }
+        exit 1
+    }
+
+    let pl = $matches | first
+    let pl_dir = resolve-plugin-path $repo $pl.source
+
+    if $pl_dir == null {
+        print $"(ansi red)Error: plugin '($plugin_name)' has an external source and cannot be bootstrapped locally.(ansi reset)"
+        exit 1
+    }
+
+    let md_path   = $"($pl_dir)/skills/sources.md"
+    let toml_path = $"($pl_dir)/skills/sources.toml"
+
+    if not ($md_path | path exists) {
+        print $"(ansi red)Error: sources.md not found at ($md_path)(ansi reset)"
+        print "Create a sources.md first, then re-run this script."
+        exit 1
+    }
+
+    if ($toml_path | path exists) and not $dry_run {
+        print $"(ansi yellow)Warning: ($toml_path) already exists.(ansi reset)"
+        print "Overwrite? [y/N] " --no-newline
+        let answer = input
+        if ($answer | str trim | str downcase) != "y" {
+            print "Aborted."
+            exit 0
+        }
+    }
+
+    print $"Parsing: ($md_path)"
+    let sources = parse-sources-md $md_path
+
+    if ($sources | is-empty) {
+        print $"(ansi yellow)No sources found in ($md_path).(ansi reset)"
+        print "Ensure sources.md has ## skill and ### source headings with - **URL**: lines."
+        exit 1
+    }
+
+    print $"Found ($sources | length) source\(s\):"
+    for s in $sources {
+        let url_display = if not ($s.url | is-empty) { $s.url } else { "(no URL)" }
+        print $"  [$($s.skill)] ($s.name) — ($url_display)"
+    }
+    print ""
+
+    let toml_content = generate-toml $plugin_name $sources
+
+    if $dry_run {
+        print $"(ansi cyan_bold)--- Dry run: would write to ($toml_path) ---(ansi reset)"
+        print ""
+        print $toml_content
+        print $"(ansi cyan_bold)--- End dry run ---(ansi reset)"
+    } else {
+        $toml_content | save --force $toml_path
+        print $"(ansi green)Written: ($toml_path)(ansi reset)"
+        print ""
+        print "Next steps:"
+        print "  1. Open the generated sources.toml"
+        print "  2. Set check_method for each source:"
+        print "       github-releases  → add: repo = \"owner/repo\""
+        print "       hex-pm           → add: package = \"package_name\""
+        print "       crates-io        → add: crate = \"crate_name\""
+        print "       manual           → no additional fields needed"
+        print "  3. Set current_version to the version you currently depend on"
+        print "  4. Run: nu sources-check.nu --plugin ($plugin_name)"
+    }
+}

--- a/plugins/tools/claude-code/skills/skill-update/scripts/sources-report.nu
+++ b/plugins/tools/claude-code/skills/skill-update/scripts/sources-report.nu
@@ -1,0 +1,292 @@
+#!/usr/bin/env nu
+
+# Generate a full markdown update report for all tracked sources
+# Suitable for pasting into a GitHub issue body
+#
+# Usage: nu sources-report.nu [--plugin <name>]
+#
+# Output: markdown to stdout (redirect to a file or pipe to pbcopy)
+
+# Resolve the repo root relative to this script's location
+def repo-root [] {
+    $env.FILE_PWD | path join ".." ".." ".." ".." ".." ".." ".." | path expand
+}
+
+# Load marketplace.json
+def load-marketplace [repo: string] {
+    let mp_path = $"($repo)/.claude-plugin/marketplace.json"
+    if not ($mp_path | path exists) {
+        error make { msg: $"marketplace.json not found at ($mp_path)" }
+    }
+    open $mp_path
+}
+
+# Resolve plugin source path to absolute directory
+def resolve-plugin-path [repo: string, source: any] {
+    if ($source | describe) == "string" {
+        let rel = $source | str replace -r '^\./' ''
+        $"($repo)/($rel)"
+    } else {
+        null
+    }
+}
+
+# Check latest version via github-releases API
+def check-github-releases [repo: string] {
+    let url = $"https://api.github.com/repos/($repo)/releases/latest"
+    let token = $env.GITHUB_TOKEN? | default ""
+    let headers = if ($token | is-not-empty) {
+        [Authorization $"Bearer ($token)" User-Agent "sources-report.nu/1.0"]
+    } else {
+        [User-Agent "sources-report.nu/1.0"]
+    }
+    try {
+        let response = http get -H $headers $url
+        let tag = $response.tag_name? | default ""
+        $tag | str replace -r '^v' ''
+    } catch {
+        "error"
+    }
+}
+
+# Check latest version via hex.pm API
+def check-hex-pm [package: string] {
+    let url = $"https://hex.pm/api/packages/($package)"
+    try {
+        let response = http get $url
+        let releases = $response.releases? | default []
+        if ($releases | length) > 0 {
+            $releases | first | get version? | default "unknown"
+        } else {
+            "unknown"
+        }
+    } catch {
+        "error"
+    }
+}
+
+# Check latest version via crates.io API
+def check-crates-io [crate_name: string] {
+    let url = $"https://crates.io/api/v1/crates/($crate_name)"
+    let headers = [User-Agent "sources-report.nu/1.0 (claude-skills)"]
+    try {
+        let response = http get -H $headers $url
+        $response.crate?.max_version? | default "unknown"
+    } catch {
+        "error"
+    }
+}
+
+# Dispatch version check by method
+def fetch-latest [source: record] {
+    let method = $source.check_method? | default "manual"
+    match $method {
+        "github-releases" => {
+            let repo = $source.github_repo? | default ""
+            if ($repo | is-empty) { "error" } else { check-github-releases $repo }
+        }
+        "hex-pm" => {
+            let pkg = $source.hex_package? | default ""
+            if ($pkg | is-empty) { "error" } else { check-hex-pm $pkg }
+        }
+        "crates-io" => {
+            let crate_name = $source.crate_name? | default ""
+            if ($crate_name | is-empty) { "error" } else { check-crates-io $crate_name }
+        }
+        "manual" => { "manual" }
+        _ => { "unknown-method" }
+    }
+}
+
+# Render a stale indicator emoji for markdown
+def stale-badge [stale: string] {
+    match $stale {
+        "yes"    => "🔴 stale"
+        "no"     => "🟢 current"
+        "manual" => "🔵 manual"
+        "error"  => "⚠️ error"
+        "unset"  => "❓ unset"
+        _        => $stale
+    }
+}
+
+# Process a sources.toml and return enriched rows
+def process-sources-toml [toml_path: string, plugin_name: string] {
+    let data = try {
+        open $toml_path
+    } catch {
+        return []
+    }
+
+    let sources = $data.sources? | default []
+
+    $sources | each { |src|
+        let skill    = $src.skill?           | default ""
+        let name     = $src.name?            | default ""
+        let current  = $src.current_version? | default "unset"
+        let priority = $src.update_priority?  | default "medium"
+        let method   = $src.check_method?    | default "manual"
+        let url      = $src.url?             | default ""
+        let last_checked = $src.last_checked? | default "unknown"
+
+        let latest = fetch-latest $src
+
+        let stale = if $latest == "manual" {
+            "manual"
+        } else if $latest == "error" {
+            "error"
+        } else if $current == "unset" {
+            "unset"
+        } else if $current != $latest {
+            "yes"
+        } else {
+            "no"
+        }
+
+        {
+            plugin:       $plugin_name
+            skill:        $skill
+            source:       $name
+            url:          $url
+            current:      $current
+            latest:       $latest
+            stale:        $stale
+            priority:     $priority
+            method:       $method
+            last_checked: $last_checked
+        }
+    }
+}
+
+# Render markdown table row
+def md-row [r: record] {
+    let badge = stale-badge $r.stale
+    let link = if not ($r.url | is-empty) {
+        $"[($r.source)]\(($r.url)\)"
+    } else {
+        $r.source
+    }
+    $"| ($r.plugin) | ($r.skill) | ($link) | ($r.current) | ($r.latest) | ($badge) | ($r.priority) |"
+}
+
+def main [--plugin: string = ""] {
+    let repo = repo-root
+
+    # Suppress progress output when redirected (stderr vs stdout)
+    print -e $"(ansi cyan)Gathering source data...(ansi reset)"
+
+    let marketplace = load-marketplace $repo
+    let plugins = $marketplace.plugins? | default []
+
+    let filtered = if ($plugin | is-empty) {
+        $plugins
+    } else {
+        $plugins | where name == $plugin
+    }
+
+    mut all_rows = []
+    mut plugin_groups: record = {}
+
+    for pl in $filtered {
+        let pl_name = $pl.name
+        let pl_dir  = resolve-plugin-path $repo $pl.source
+
+        if $pl_dir == null { continue }
+
+        let toml_path = $"($pl_dir)/skills/sources.toml"
+        if not ($toml_path | path exists) { continue }
+
+        print -e $"  Processing ($pl_name)..."
+        let rows = process-sources-toml $toml_path $pl_name
+        $all_rows = ($all_rows | append $rows)
+    }
+
+    # ─── Render markdown ───────────────────────────────────────────────────────
+
+    let today = (date now | format date "%Y-%m-%d")
+    let stale_count = $all_rows | where stale == "yes" | length
+
+    print $"# Skill Sources Update Report"
+    print ""
+    print $"Generated: ($today)"
+    if not ($plugin | is-empty) {
+        print $"Plugin filter: `($plugin)`"
+    }
+    print ""
+
+    # ─── Summary table ─────────────────────────────────────────────────────────
+    print "## Summary"
+    print ""
+
+    let total   = $all_rows | length
+    let current = $all_rows | where stale == "no"     | length
+    let stale   = $all_rows | where stale == "yes"    | length
+    let manual  = $all_rows | where stale == "manual" | length
+    let errored = $all_rows | where stale == "error"  | length
+
+    print $"| Metric | Count |"
+    print $"| ------ | ----- |"
+    print $"| Total sources tracked | ($total) |"
+    print $"| Up to date | ($current) |"
+    print $"| Stale (needs update) | ($stale) |"
+    print $"| Manual check required | ($manual) |"
+    print $"| Check errors | ($errored) |"
+    print ""
+
+    if $stale_count > 0 {
+        print $"## Stale Sources"
+        print ""
+        print $"> The following ($stale_count) source\(s\) have newer versions available."
+        print ""
+        print "| Plugin | Skill | Source | Current | Latest | Status | Priority |"
+        print "| ------ | ----- | ------ | ------- | ------ | ------ | -------- |"
+        for r in ($all_rows | where stale == "yes" | sort-by priority) {
+            print (md-row $r)
+        }
+        print ""
+    }
+
+    # ─── All sources table ─────────────────────────────────────────────────────
+    print "## All Tracked Sources"
+    print ""
+    print "| Plugin | Skill | Source | Current | Latest | Status | Priority |"
+    print "| ------ | ----- | ------ | ------- | ------ | ------ | -------- |"
+    for r in $all_rows {
+        print (md-row $r)
+    }
+    print ""
+
+    # ─── Per-plugin sections ───────────────────────────────────────────────────
+    print "## Per-Plugin Details"
+    print ""
+
+    let plugin_names = $all_rows | get plugin | uniq
+    for pl_name in $plugin_names {
+        let pl_rows = $all_rows | where plugin == $pl_name
+        let pl_stale = $pl_rows | where stale == "yes" | length
+
+        print $"### ($pl_name)"
+        print ""
+        if $pl_stale > 0 {
+            print $"> ($pl_stale) stale source\(s\)"
+            print ""
+        }
+        print "| Skill | Source | Current | Latest | Status |"
+        print "| ----- | ------ | ------- | ------ | ------ |"
+        for r in $pl_rows {
+            let badge = stale-badge $r.stale
+            let link = if not ($r.url | is-empty) {
+                $"[($r.source)]\(($r.url)\)"
+            } else {
+                $r.source
+            }
+            print $"| ($r.skill) | ($link) | ($r.current) | ($r.latest) | ($badge) |"
+        }
+        print ""
+    }
+
+    if ($all_rows | is-empty) {
+        print $"_No sources.toml files found. Run `sources-init.nu` to bootstrap them._"
+        print ""
+    }
+}

--- a/plugins/tools/claude-code/skills/skill-update/scripts/sources-stale.nu
+++ b/plugins/tools/claude-code/skills/skill-update/scripts/sources-stale.nu
@@ -1,0 +1,239 @@
+#!/usr/bin/env nu
+
+# Show only stale or outdated sources
+# A source is stale when current_version != latest_version, or last_checked is older than --days threshold
+#
+# Usage: nu sources-stale.nu [--days <int>] [--plugin <name>]
+#
+# Output: table sorted by priority (high first), showing only stale entries
+
+# Resolve the repo root relative to this script's location
+def repo-root [] {
+    $env.FILE_PWD | path join ".." ".." ".." ".." ".." ".." ".." | path expand
+}
+
+# Load marketplace.json
+def load-marketplace [repo: string] {
+    let mp_path = $"($repo)/.claude-plugin/marketplace.json"
+    if not ($mp_path | path exists) {
+        error make { msg: $"marketplace.json not found at ($mp_path)" }
+    }
+    open $mp_path
+}
+
+# Resolve plugin source path to absolute directory
+def resolve-plugin-path [repo: string, source: any] {
+    if ($source | describe) == "string" {
+        let rel = $source | str replace -r '^\./' ''
+        $"($repo)/($rel)"
+    } else {
+        null
+    }
+}
+
+# Check latest version via github-releases API
+def check-github-releases [repo: string] {
+    let url = $"https://api.github.com/repos/($repo)/releases/latest"
+    let token = $env.GITHUB_TOKEN? | default ""
+    let headers = if ($token | is-not-empty) {
+        [Authorization $"Bearer ($token)" User-Agent "sources-stale.nu/1.0"]
+    } else {
+        [User-Agent "sources-stale.nu/1.0"]
+    }
+    try {
+        let response = http get -H $headers $url
+        let tag = $response.tag_name? | default ""
+        $tag | str replace -r '^v' ''
+    } catch {
+        "error"
+    }
+}
+
+# Check latest version via hex.pm API
+def check-hex-pm [package: string] {
+    let url = $"https://hex.pm/api/packages/($package)"
+    try {
+        let response = http get $url
+        let releases = $response.releases? | default []
+        if ($releases | length) > 0 {
+            $releases | first | get version? | default "unknown"
+        } else {
+            "unknown"
+        }
+    } catch {
+        "error"
+    }
+}
+
+# Check latest version via crates.io API
+def check-crates-io [crate_name: string] {
+    let url = $"https://crates.io/api/v1/crates/($crate_name)"
+    let headers = [User-Agent "sources-stale.nu/1.0 (claude-skills)"]
+    try {
+        let response = http get -H $headers $url
+        $response.crate?.max_version? | default "unknown"
+    } catch {
+        "error"
+    }
+}
+
+# Dispatch version check by method
+def fetch-latest [source: record] {
+    let method = $source.check_method? | default "manual"
+    match $method {
+        "github-releases" => {
+            let repo = $source.github_repo? | default ""
+            if ($repo | is-empty) { "error" } else { check-github-releases $repo }
+        }
+        "hex-pm" => {
+            let pkg = $source.hex_package? | default ""
+            if ($pkg | is-empty) { "error" } else { check-hex-pm $pkg }
+        }
+        "crates-io" => {
+            let crate_name = $source.crate_name? | default ""
+            if ($crate_name | is-empty) { "error" } else { check-crates-io $crate_name }
+        }
+        "manual" => { "manual" }
+        _ => { "unknown-method" }
+    }
+}
+
+# Map priority string to sort weight (lower = higher priority)
+def priority-weight [p: string] {
+    match $p {
+        "critical" => 0
+        "high"     => 1
+        "normal"   => 2
+        "low"      => 3
+        _          => 4
+    }
+}
+
+# Check whether a date string is older than N days from today
+def is-date-stale [date_str: string, days: int] {
+    if ($date_str | is-empty) {
+        return true
+    }
+    try {
+        let checked = $date_str | into datetime
+        let now     = (date now)
+        let diff    = ($now - $checked)
+        # diff is a duration; compare to threshold in seconds
+        let threshold_secs = $days * 86400
+        ($diff | into int) > ($threshold_secs * 1_000_000_000)
+    } catch {
+        true
+    }
+}
+
+# Process a single sources.toml and return only stale rows
+def process-sources-toml [toml_path: string, plugin_name: string, days: int] {
+    let data = try {
+        open $toml_path
+    } catch {
+        print $"(ansi yellow)Warning: could not parse ($toml_path)(ansi reset)"
+        return []
+    }
+
+    let sources = $data.sources? | default []
+
+    $sources | each { |src|
+        let skill        = $src.skill?            | default ""
+        let name         = $src.name?             | default ""
+        let current      = $src.current_version?  | default "unset"
+        let priority     = $src.update_priority?   | default "medium"
+        let method       = $src.check_method?     | default "manual"
+        let last_checked = $src.last_checked?     | default ""
+
+        let latest = fetch-latest $src
+
+        let version_stale = if $latest in ["manual", "error", "unknown", "unknown-method"] {
+            false
+        } else if $current == "unset" {
+            true
+        } else {
+            $current != $latest
+        }
+
+        let date_stale = is-date-stale $last_checked $days
+
+        if $version_stale or $date_stale {
+            let reason = if $version_stale and $date_stale {
+                "version+date"
+            } else if $version_stale {
+                "version"
+            } else {
+                "date"
+            }
+            {
+                plugin:       $plugin_name
+                skill:        $skill
+                source:       $name
+                current:      $current
+                latest:       $latest
+                priority:     $priority
+                reason:       $reason
+                last_checked: $last_checked
+                _sort_key:    (priority-weight $priority)
+            }
+        } else {
+            null
+        }
+    } | where { |r| $r != null }
+}
+
+def main [--days: int = 30, --plugin: string = ""] {
+    let repo = repo-root
+
+    print $"(ansi cyan_bold)Stale Sources Report(ansi reset)"
+    print $"Staleness threshold: ($days) days | Repo: ($repo)"
+    print ""
+
+    let marketplace = load-marketplace $repo
+    let plugins = $marketplace.plugins? | default []
+
+    let filtered = if ($plugin | is-empty) {
+        $plugins
+    } else {
+        $plugins | where name == $plugin
+    }
+
+    if ($filtered | is-empty) {
+        if not ($plugin | is-empty) {
+            print $"(ansi red)No plugin found with name: ($plugin)(ansi reset)"
+            exit 1
+        }
+        print $"(ansi yellow)No plugins found in marketplace.(ansi reset)"
+        exit 0
+    }
+
+    mut stale_rows = []
+
+    for pl in $filtered {
+        let pl_name = $pl.name
+        let pl_dir  = resolve-plugin-path $repo $pl.source
+
+        if $pl_dir == null {
+            continue
+        }
+
+        let toml_path = $"($pl_dir)/skills/sources.toml"
+        if not ($toml_path | path exists) {
+            continue
+        }
+
+        let rows = process-sources-toml $toml_path $pl_name $days
+        $stale_rows = ($stale_rows | append $rows)
+    }
+
+    if ($stale_rows | is-empty) {
+        print $"(ansi green)All sources are up to date. No stale entries found.(ansi reset)"
+        exit 0
+    }
+
+    let sorted = $stale_rows | sort-by _sort_key | select plugin skill source current latest priority reason last_checked
+
+    print $"(ansi yellow_bold)Found ($sorted | length) stale source\(s\):(ansi reset)"
+    print ""
+    $sorted
+}

--- a/plugins/tools/claude-code/skills/skill-update/scripts/sources-validate-urls.nu
+++ b/plugins/tools/claude-code/skills/skill-update/scripts/sources-validate-urls.nu
@@ -1,0 +1,186 @@
+#!/usr/bin/env nu
+
+# Validate all source URLs in sources.toml files are accessible
+# Uses HTTP HEAD requests and reports status per URL
+#
+# Usage: nu sources-validate-urls.nu [--plugin <name>]
+#
+# Output: table with columns: plugin | skill | source | url | status | notes
+
+# Resolve the repo root relative to this script's location
+def repo-root [] {
+    $env.FILE_PWD | path join ".." ".." ".." ".." ".." ".." ".." | path expand
+}
+
+# Load marketplace.json
+def load-marketplace [repo: string] {
+    let mp_path = $"($repo)/.claude-plugin/marketplace.json"
+    if not ($mp_path | path exists) {
+        error make { msg: $"marketplace.json not found at ($mp_path)" }
+    }
+    open $mp_path
+}
+
+# Resolve plugin source path to absolute directory
+def resolve-plugin-path [repo: string, source: any] {
+    if ($source | describe) == "string" {
+        let rel = $source | str replace -r '^\./' ''
+        $"($repo)/($rel)"
+    } else {
+        null
+    }
+}
+
+# Classify HTTP status code into a human-readable status
+def classify-status [code: int] {
+    if $code >= 200 and $code < 300 {
+        "pass"
+    } else if $code >= 300 and $code < 400 {
+        "redirect"
+    } else {
+        "fail"
+    }
+}
+
+# Perform an HTTP HEAD check on a URL and return a result record
+def check-url [plugin: string, skill: string, source_name: string, url: string] {
+    if ($url | is-empty) {
+        return null
+    }
+
+    let result = try {
+        # http head returns headers as a record; a successful return means 2xx
+        http head $url
+        {
+            plugin: $plugin
+            skill:  $skill
+            source: $source_name
+            url:    $url
+            status: "pass"
+            notes:  "OK"
+        }
+    } catch { |err|
+        let msg = $err.msg? | default "request failed"
+        let status = if ($msg | str contains "redirect") {
+            "redirect"
+        } else if ($msg | str contains "404") or ($msg | str contains "not found") {
+            "fail"
+        } else {
+            "error"
+        }
+        {
+            plugin: $plugin
+            skill:  $skill
+            source: $source_name
+            url:    $url
+            status: $status
+            notes:  ($msg | str substring 0..80)
+        }
+    }
+
+    $result
+}
+
+# Process a single sources.toml file and return URL check results
+def process-sources-toml [toml_path: string, plugin_name: string] {
+    let data = try {
+        open $toml_path
+    } catch {
+        print $"(ansi yellow)Warning: could not parse ($toml_path)(ansi reset)"
+        return []
+    }
+
+    let sources = $data.sources? | default []
+    mut rows = []
+
+    for src in $sources {
+        let skill       = $src.skill?         | default ""
+        let name        = $src.name?          | default ""
+        let url         = $src.url?           | default ""
+        let releases_url = $src.releases_url? | default ""
+
+        if not ($url | is-empty) {
+            print $"  HEAD ($url)"
+            let row = check-url $plugin_name $skill $name $url
+            if $row != null {
+                $rows = ($rows | append $row)
+            }
+        }
+
+        if not ($releases_url | is-empty) {
+            print $"  HEAD ($releases_url)"
+            let row = check-url $plugin_name $skill $"($name) [releases]" $releases_url
+            if $row != null {
+                $rows = ($rows | append $row)
+            }
+        }
+    }
+
+    $rows
+}
+
+def main [--plugin: string = ""] {
+    let repo = repo-root
+
+    print $"(ansi cyan_bold)Source URL Validation(ansi reset)"
+    print $"Repo root: ($repo)"
+    print ""
+
+    let marketplace = load-marketplace $repo
+    let plugins = $marketplace.plugins? | default []
+
+    let filtered = if ($plugin | is-empty) {
+        $plugins
+    } else {
+        $plugins | where name == $plugin
+    }
+
+    if ($filtered | is-empty) {
+        if not ($plugin | is-empty) {
+            print $"(ansi red)No plugin found with name: ($plugin)(ansi reset)"
+            exit 1
+        }
+        print $"(ansi yellow)No plugins found in marketplace.(ansi reset)"
+        exit 0
+    }
+
+    mut all_rows = []
+
+    for pl in $filtered {
+        let pl_name = $pl.name
+        let pl_dir  = resolve-plugin-path $repo $pl.source
+
+        if $pl_dir == null {
+            continue
+        }
+
+        let toml_path = $"($pl_dir)/skills/sources.toml"
+        if not ($toml_path | path exists) {
+            continue
+        }
+
+        print $"(ansi green)Plugin: ($pl_name)(ansi reset)"
+        let rows = process-sources-toml $toml_path $pl_name
+        $all_rows = ($all_rows | append $rows)
+    }
+
+    print ""
+
+    if ($all_rows | is-empty) {
+        print $"(ansi yellow)No sources.toml files found with URL entries.(ansi reset)"
+        exit 0
+    }
+
+    # Summary counts
+    let total    = $all_rows | length
+    let passing  = $all_rows | where status == "pass"     | length
+    let redirect = $all_rows | where status == "redirect" | length
+    let failing  = $all_rows | where status == "fail"     | length
+    let errors   = $all_rows | where status == "error"    | length
+
+    print $"(ansi cyan_bold)Summary:(ansi reset) ($total) URLs checked — (ansi green)($passing) pass(ansi reset) | (ansi yellow)($redirect) redirect(ansi reset) | (ansi red)($failing) fail  ($errors) error(ansi reset)"
+    print ""
+
+    # Full table
+    $all_rows | select plugin skill source url status notes
+}

--- a/plugins/tools/claude-code/skills/skill-update/templates/sources.toml
+++ b/plugins/tools/claude-code/skills/skill-update/templates/sources.toml
@@ -1,0 +1,123 @@
+# sources.toml - Machine-readable version tracking for skill dependencies
+# Place alongside sources.md in each plugin's skills/ directory
+# Run `mise sources:validate` to verify this file against the schema
+
+[meta]
+plugin = "plugin-name"           # Plugin name (must match plugin.json `name` field)
+last_full_check = "2026-03-25"   # Date of last comprehensive check across all sources
+
+# ----------------------------------------------------------------------------
+# Each [[sources]] block tracks one upstream dependency for one skill.
+# Add one block per source. A single skill may have multiple source blocks.
+# ----------------------------------------------------------------------------
+
+[[sources]]
+skill = "skill-name"             # Skill directory name (must match skills/<skill-name>/)
+name = "source-name"             # Human-readable source identifier (e.g., "apple-container")
+url = ""                         # Primary source URL (docs, homepage, or repo)
+releases_url = ""                # URL to browse release history (optional but recommended)
+
+# check_method controls how `mise sources:check` queries the latest version.
+# Values: github-releases | hex-pm | crates-io | manual
+check_method = "manual"
+
+# Uncomment and fill in the field matching your check_method:
+# github_repo = "owner/repo"    # Required for check_method = "github-releases"
+# hex_package = "package"       # Required for check_method = "hex-pm"
+# crate_name = "crate"          # Required for check_method = "crates-io"
+
+# The version currently documented in this skill's SKILL.md.
+# Must be an exact version string (e.g., "0.10.0") or "stable"/"rolling".
+# Set to "requires-check" when version is unknown.
+current_version = ""
+
+# version_constraint describes how this source is versioned:
+#   pre-1.0  - Actively developed, may have breaking changes in any release
+#   semver   - Follows Semantic Versioning (major.minor.patch)
+#   rolling  - No discrete versions; tracks a continuously updated source
+#   stable   - Stable release channel (e.g., Linux stable kernel)
+version_constraint = "semver"
+
+# Date this source was last manually or automatically verified.
+# Update after every check, even if no version change was found.
+last_checked = "2026-03-25"
+
+# update_priority signals how urgently stale updates should be addressed:
+#   high   - Critical tools or frequently-used features; update immediately
+#   medium - Important but not blocking; update in current cycle
+#   low    - Rarely-changed; update opportunistically
+update_priority = "medium"
+
+# Set to true when minor or patch bumps in this source commonly introduce
+# breaking changes (typical for pre-1.0 packages or aggressive deprecation).
+breaking_changes_likely = false
+
+# Optional free-form notes about this source, quirks, or migration context.
+notes = ""
+
+# ----------------------------------------------------------------------------
+# Example: CLI tool tracked via GitHub releases
+# ----------------------------------------------------------------------------
+# [[sources]]
+# skill = "container"
+# name = "apple-container"
+# url = "https://github.com/apple/container"
+# releases_url = "https://github.com/apple/container/releases"
+# check_method = "github-releases"
+# github_repo = "apple/container"
+# current_version = "0.10.0"
+# version_constraint = "pre-1.0"
+# last_checked = "2026-03-25"
+# update_priority = "high"
+# breaking_changes_likely = true
+# notes = "CLI commands change frequently; always create versioned template on update"
+
+# ----------------------------------------------------------------------------
+# Example: Hex.pm package
+# ----------------------------------------------------------------------------
+# [[sources]]
+# skill = "tidewave"
+# name = "tidewave"
+# url = "https://hex.pm/packages/tidewave"
+# releases_url = "https://github.com/phx-tools/tidewave/releases"
+# check_method = "hex-pm"
+# hex_package = "tidewave"
+# current_version = "0.5.6"
+# version_constraint = "semver"
+# last_checked = "2026-03-25"
+# update_priority = "medium"
+# breaking_changes_likely = false
+# notes = ""
+
+# ----------------------------------------------------------------------------
+# Example: crates.io package
+# ----------------------------------------------------------------------------
+# [[sources]]
+# skill = "wasm"
+# name = "wasmtime"
+# url = "https://wasmtime.dev"
+# releases_url = "https://github.com/bytecodealliance/wasmtime/releases"
+# check_method = "crates-io"
+# crate_name = "wasmtime"
+# current_version = "28.0.0"
+# version_constraint = "semver"
+# last_checked = "2026-03-25"
+# update_priority = "medium"
+# breaking_changes_likely = false
+# notes = ""
+
+# ----------------------------------------------------------------------------
+# Example: Documentation-based (manual check)
+# ----------------------------------------------------------------------------
+# [[sources]]
+# skill = "twelve-factor"
+# name = "12factor.net"
+# url = "https://12factor.net"
+# releases_url = "https://12factor.net"
+# check_method = "manual"
+# current_version = "stable"
+# version_constraint = "stable"
+# last_checked = "2026-03-25"
+# update_priority = "low"
+# breaking_changes_likely = false
+# notes = "No formal versioning; check for editorial updates annually"

--- a/plugins/tools/claude-code/skills/sources.md
+++ b/plugins/tools/claude-code/skills/sources.md
@@ -278,12 +278,38 @@ Create a modular Claude Code plugin marketplace that:
   - Capability assessment: detecting when base model outgrows a skill
 - **Used In**: skills/claude-skills/SKILL.md, skills/claude-skills/references/evaluation-guide.md, skills/claude-skills-benchmark/SKILL.md
 
+## Skill Update Skill
+
+### GitHub REST API - Releases
+- **URL**: https://docs.github.com/en/rest/releases/releases
+- **Purpose**: API reference for querying GitHub repository releases programmatically
+- **Date Accessed**: 2026-03-25
+- **Key Topics**: List releases, get latest release, release assets, tag names
+
+### Hex.pm API
+- **URL**: https://github.com/hexpm/hexpm/blob/main/guides/API.md
+- **Purpose**: API reference for querying Hex package versions
+- **Date Accessed**: 2026-03-25
+- **Key Topics**: Package metadata, release versions, dependency resolution
+
+### Crates.io API
+- **URL**: https://crates.io/policies
+- **Purpose**: API reference for querying Rust crate versions
+- **Date Accessed**: 2026-03-25
+- **Key Topics**: Crate metadata, max version, download counts
+
+### TOML Specification
+- **URL**: https://toml.io/en/v1.0.0
+- **Purpose**: TOML format specification for sources.toml schema design
+- **Date Accessed**: 2026-03-25
+- **Key Topics**: Array of tables, inline tables, key-value pairs
+
 ## Plugin Information
 
 - **Name**: claude-code
-- **Version**: 0.1.0
+- **Version**: 0.1.8
 - **Description**: Claude Code-specific skills for plugin marketplace management, validation, and component creation
-- **Skills**: 6 skills covering all aspects of Claude Code plugin development
+- **Skills**: 9 skills covering all aspects of Claude Code plugin development
   - plugin-marketplace: Marketplace.json validation and management
   - claude-plugins: Plugin.json validation and management
   - claude-commands: Creating custom slash commands


### PR DESCRIPTION
- Add skill-update skill with 6-phase workflow for keeping skills current with upstream sources
- Add 5 Nushell scripts: sources-check, sources-stale, sources-validate-urls, sources-report, sources-init
- Add sources.toml template and schema for machine-readable version tracking
- Add references: update-checklist (per-skill-type checklists), version-check-methods (API docs)
- Add mise tasks: sources:check, sources:stale, sources:validate, sources:report, sources:init
- Support github-releases, hex-pm, crates-io, and manual check methods
- Update claude-code plugin sources.md with skill-update source entries
- Bump claude-code 0.1.7 -> 0.1.8, all-skills 0.3.17 -> 0.3.18