### PR TITLE
feat(wasm): add wit skill and update sources

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.18",
+      "version": "0.3.20",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -106,9 +106,9 @@
       "source": "./plugins/wasm",
       "strict": true,
       "description": "WebAssembly skills: wasmtime runtime, component model, guest compilation, and host embedding",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "category": "language",
-      "keywords": ["wasm", "webassembly", "wasmtime", "wasi", "component-model"],
+      "keywords": ["wasm", "webassembly", "wasmtime", "wasi", "component-model", "wit"],
       "license": "MIT"
     },
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.18",
+  "version": "0.3.20",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -69,6 +69,7 @@
     "./plugins/tools/tweag/skills/nickel",
     "./plugins/ui/skills/daisyui",
     "./plugins/wasm/skills/wasmtime",
+    "./plugins/wasm/skills/wit",
     "./plugins/languages/zig/skills/zig",
     "./plugins/languages/zig/skills/language",
     "./plugins/languages/zig/skills/build",

--- a/plugins/wasm/.claude-plugin/plugin.json
+++ b/plugins/wasm/.claude-plugin/plugin.json
@@ -1,15 +1,16 @@
 {
   "name": "wasm",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "WebAssembly skills: wasmtime runtime, component model, guest compilation, and host embedding",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["wasm", "webassembly", "wasmtime", "wasi", "component-model"],
+  "keywords": ["wasm", "webassembly", "wasmtime", "wasi", "component-model", "wit"],
   "skills": [
-    "./skills/wasmtime"
+    "./skills/wasmtime",
+    "./skills/wit"
   ],
   "agents": [
     "./agents/wasm-inspector.md"

--- a/plugins/wasm/skills/sources.md
+++ b/plugins/wasm/skills/sources.md
@@ -69,10 +69,30 @@ This file documents the sources used to create the wasm plugin skills.
 - **Purpose**: Rust and WebAssembly integration guide
 - **Key Topics**: Wasm targets, wasm-pack, binary size optimization, debugging
 
+## WIT Skill
+
+### WIT Language Reference (Component Model)
+- **URL**: https://component-model.bytecodealliance.org/design/wit.html
+- **Purpose**: WIT syntax specification, type system, interfaces, and worlds
+- **Date Accessed**: 2026-03-25
+- **Key Topics**: Package naming, interfaces, worlds, type system (primitives, lists, options, results, records, variants, enums, flags, tuples), functions, resources
+
+### Component Model Worlds
+- **URL**: https://component-model.bytecodealliance.org/design/worlds.html
+- **Purpose**: World definition patterns and component composition
+- **Date Accessed**: 2026-03-25
+- **Key Topics**: Import and export declarations, world includes, component targets
+
+### Component Model Overview
+- **URL**: https://component-model.bytecodealliance.org/
+- **Purpose**: High-level overview of the WebAssembly Component Model
+- **Date Accessed**: 2026-03-25
+- **Key Topics**: Component architecture, interface-based composition, canonical ABI
+
 ## Plugin Information
 
 - **Name**: wasm
-- **Version**: 0.1.0
+- **Version**: 0.1.3
 - **Description**: WebAssembly skills: wasmtime runtime, component model, guest compilation, and host embedding
-- **Skills**: 1 skill (wasmtime)
+- **Skills**: 2 skills (wasmtime, wit)
 - **Created**: 2026-02-21

--- a/plugins/wasm/skills/wit/SKILL.md
+++ b/plugins/wasm/skills/wit/SKILL.md
@@ -1,0 +1,496 @@
+---
+name: wit
+description: Guide for WebAssembly Interface Type (WIT) language. Use when defining component interfaces, writing WIT files, designing worlds and interfaces, or working with the Component Model type system.
+license: MIT
+---
+
+# WIT (WebAssembly Interface Types)
+
+WIT is the Interface Definition Language (IDL) for the WebAssembly Component Model. It defines typed contracts between components in a language-agnostic way, enabling interoperability across programming languages at the wasm boundary.
+
+See also: [wasmtime skill](../wasmtime/SKILL.md) for runtime embedding and compilation details.
+
+## When to Use This Skill
+
+Activate when:
+- Writing `.wit` files to define component interfaces
+- Designing worlds for WebAssembly components
+- Understanding the Component Model type system
+- Using `cargo-component`, `wit-bindgen`, or `wasm-tools`
+- Mapping WIT types to host language types (Rust, Go, Python, JavaScript)
+- Structuring packages and namespaces for wasm components
+- Composing components via shared interfaces
+
+## WIT File Structure
+
+A WIT file contains one or more of: package declaration, interfaces, worlds, and use declarations.
+
+```wit
+package namespace:package-name@1.0.0;
+
+use wasi:io/streams@0.2.0.{input-stream, output-stream};
+
+interface my-interface {
+    // types and functions
+}
+
+world my-world {
+    import my-interface;
+    export my-interface;
+}
+```
+
+## Packages
+
+Every WIT file belongs to a package. The package declaration names the namespace, package, and optional semver version.
+
+```wit
+package my-org:my-lib@0.1.0;
+```
+
+- `namespace`: organization or project identifier (kebab-case)
+- `package`: library name (kebab-case)
+- `@version`: optional semver string
+
+Package names use kebab-case identifiers. Dots are not allowed in identifiers; use hyphens.
+
+## Identifiers
+
+WIT identifiers use kebab-case. Reserved words may be used as identifiers when prefixed with `%`:
+
+```wit
+interface example {
+    // 'type' is reserved — prefix with %
+    get-type: func() -> %type;
+    type %type = string;
+}
+```
+
+## Interfaces
+
+An interface groups related types and functions into a named, reusable unit.
+
+```wit
+interface geometry {
+    record point {
+        x: f64,
+        y: f64,
+    }
+
+    distance: func(a: point, b: point) -> f64;
+    translate: func(p: point, dx: f64, dy: f64) -> point;
+}
+```
+
+Interfaces can be imported by worlds or by other interfaces using `use`.
+
+## Worlds
+
+A world defines a complete component contract: what it imports (needs) and what it exports (provides). Worlds serve a dual role — they describe a component's requirements AND define the hosting environment that runs it. The only ways a component can interact with anything outside itself are by having its exports called or by calling its imports. A component cannot access resources it does not explicitly import, providing strong sandboxing boundaries.
+
+```wit
+world image-processor {
+    // Imports: capabilities the component requires from the host
+    import wasi:filesystem/preopens@0.2.0;
+    import log: func(msg: string);
+
+    // Exports: capabilities the component provides to callers
+    export process: func(input: list<u8>) -> result<list<u8>, string>;
+    export geometry;
+}
+```
+
+### World Items
+
+| Item | Syntax | Purpose |
+|------|--------|---------|
+| Import interface | `import name: interface { ... }` | Inline imported interface |
+| Import named | `import wasi:io/streams@0.2.0;` | Import by package path |
+| Import function | `import log: func(msg: string);` | Single function import |
+| Import type | `import wasi:io/streams.{input-stream};` | Import specific types |
+| Export interface | `export my-interface;` | Export a named interface |
+| Export function | `export run: func();` | Export a single function |
+| Include world | `include other-world;` | Inherit another world's items |
+
+### World Includes
+
+Worlds can include other worlds to inherit their imports and exports:
+
+```wit
+world base {
+    import wasi:cli/environment@0.2.0;
+}
+
+world extended {
+    include base;
+    export my-app: func();
+}
+```
+
+The `with` clause renames included items to avoid conflicts:
+
+```wit
+world combined {
+    include world-a with { run as run-a };
+    include world-b with { run as run-b };
+}
+```
+
+## Type System
+
+Full reference: [syntax-reference.md](references/syntax-reference.md)
+
+### Primitives
+
+| Type | Description |
+|------|-------------|
+| `bool` | Boolean |
+| `u8`, `u16`, `u32`, `u64` | Unsigned integers |
+| `s8`, `s16`, `s32`, `s64` | Signed integers |
+| `f32`, `f64` | IEEE 754 floats |
+| `char` | Unicode scalar value |
+| `string` | UTF-8 string |
+
+### Compound Types
+
+```wit
+interface types {
+    // List: variable-length sequence
+    type byte-array = list<u8>;
+
+    // Option: nullable value
+    type maybe-string = option<string>;
+
+    // Result: success or error
+    type parse-result = result<u32, string>;
+    type io-result = result<_, string>;   // ok with no payload
+    type check-result = result;           // both ok and err have no payload
+
+    // Tuple: fixed-length heterogeneous sequence
+    type pair = tuple<string, u32>;
+}
+```
+
+### Records
+
+Named field structs — equivalent to a `struct` in most languages.
+
+```wit
+record http-request {
+    method: string,
+    url: string,
+    headers: list<tuple<string, string>>,
+    body: option<list<u8>>,
+}
+```
+
+### Variants
+
+Tagged unions where each case may carry a payload.
+
+```wit
+variant ip-address {
+    ipv4(tuple<u8, u8, u8, u8>),
+    ipv6(string),
+}
+
+variant error-kind {
+    not-found,
+    permission-denied(string),
+    timeout(u32),
+    unknown,
+}
+```
+
+### Enums
+
+Variants without payloads — a simple discriminant.
+
+```wit
+enum color {
+    red,
+    green,
+    blue,
+}
+
+enum log-level {
+    trace,
+    debug,
+    info,
+    warn,
+    error,
+}
+```
+
+### Flags
+
+Bit-flag sets where multiple values can be active simultaneously.
+
+```wit
+flags permissions {
+    read,
+    write,
+    execute,
+}
+
+// Usage: a value can hold any combination of these flags
+```
+
+### Type Aliases
+
+```wit
+type bytes = list<u8>;
+type error-message = string;
+```
+
+## Functions
+
+Functions are defined in interfaces with named parameters and return types.
+
+```wit
+interface math {
+    // No return value
+    reset: func();
+
+    // Single return
+    add: func(a: s32, b: s32) -> s32;
+
+    // Named returns (multiple values)
+    div-rem: func(num: s32, denom: s32) -> (quotient: s32, remainder: s32);
+
+    // Result return
+    parse-int: func(s: string) -> result<s32, string>;
+
+    // Option return
+    find: func(haystack: list<string>, needle: string) -> option<u32>;
+}
+```
+
+Named return values appear as a named tuple: `-> (name: type, ...)`.
+
+## Resources
+
+Resources represent opaque handles to objects with identity — equivalent to objects or handles in host languages.
+
+```wit
+resource file-handle {
+    // Constructor: creates a new resource instance
+    constructor(path: string, mode: open-mode);
+
+    // Regular methods: take `self` implicitly
+    read: func(max-bytes: u32) -> result<list<u8>, io-error>;
+    write: func(data: list<u8>) -> result<u32, io-error>;
+    flush: func() -> result<_, io-error>;
+
+    // Static method: no implicit self
+    exists: static func(path: string) -> bool;
+}
+```
+
+Resource instances are automatically dropped when the handle goes out of scope in the host language. The Component Model tracks ownership.
+
+Resources can also be used as plain types in interfaces:
+
+```wit
+interface storage {
+    resource blob {
+        constructor(data: list<u8>);
+        size: func() -> u64;
+        slice: func(start: u64, end: u64) -> blob;
+    }
+
+    store: func(key: string, value: borrow<blob>) -> result<_, string>;
+    load: func(key: string) -> result<blob, string>;
+}
+```
+
+`borrow<T>` passes a resource by borrowed reference (no ownership transfer). Without `borrow`, the resource is moved (owned transfer).
+
+## Use Declarations
+
+Import types or interfaces from other packages or from within the same package.
+
+```wit
+// Import specific types from another package
+use wasi:io/streams@0.2.0.{input-stream, output-stream};
+
+// Import an entire interface
+use wasi:filesystem/types@0.2.0;
+
+// Alias an imported type
+use wasi:clocks/wall-clock@0.2.0.{datetime as wall-datetime};
+```
+
+Use declarations appear at the top of an interface or world, before other items.
+
+## Comments
+
+```wit
+// Single-line comment
+
+/*
+  Multi-line comment
+*/
+
+/// Documentation comment (attached to the next item)
+/// Appears in generated bindings as doc comments.
+interface documented {
+    /// Returns the current UTC timestamp in seconds.
+    now: func() -> u64;
+}
+```
+
+## Tooling
+
+### cargo-component
+
+Build Rust components targeting the Component Model:
+
+```bash
+# Install
+cargo install cargo-component
+
+# Create a new component project
+cargo component new my-component --lib
+
+# Build
+cargo component build
+
+# Build for release
+cargo component build --release
+```
+
+The generated `Cargo.toml` references WIT files via the `[package.metadata.component]` section:
+
+```toml
+[package.metadata.component]
+package = "my-org:my-component"
+```
+
+### wit-bindgen
+
+Generate language bindings from WIT files:
+
+```bash
+# Install CLI
+cargo install wit-bindgen-cli
+
+# Generate Rust bindings
+wit-bindgen rust wit/ --out-dir src/bindings
+
+# Generate C bindings
+wit-bindgen c wit/ --out-dir include/
+```
+
+In Rust guest code, use the macro:
+
+```rust
+wit_bindgen::generate!({
+    world: "my-world",
+    path: "wit/",
+});
+```
+
+### wasm-tools
+
+Inspect and manipulate WIT and wasm binaries:
+
+```bash
+# Validate a WIT package
+wasm-tools component wit wit/
+
+# Extract WIT from a compiled component
+wasm-tools component wit component.wasm
+
+# Compose components
+wasm-tools compose -d dependency.wasm main.wasm -o composed.wasm
+
+# Validate a component
+wasm-tools validate --features component-model component.wasm
+```
+
+## Common Patterns
+
+### Plugin Interface
+
+```wit
+package my-app:plugin@0.1.0;
+
+world plugin {
+    // Host provides these to the plugin
+    import log: func(level: string, msg: string);
+    import config: func(key: string) -> option<string>;
+
+    // Plugin must provide these
+    export init: func() -> result<_, string>;
+    export process: func(input: list<u8>) -> result<list<u8>, string>;
+    export shutdown: func();
+}
+```
+
+### Service Interface with Resources
+
+```wit
+package my-org:database@1.0.0;
+
+interface db {
+    resource connection {
+        constructor(url: string) -> result<connection, string>;
+        query: func(sql: string, params: list<string>) -> result<list<list<string>>, string>;
+        close: func();
+    }
+
+    resource transaction {
+        begin: static func(conn: borrow<connection>) -> result<transaction, string>;
+        commit: func() -> result<_, string>;
+        rollback: func() -> result<_, string>;
+    }
+}
+
+world database-client {
+    import db;
+}
+```
+
+### Shared Type Library
+
+```wit
+package my-org:types@0.1.0;
+
+interface common {
+    record timestamp {
+        seconds: u64,
+        nanos: u32,
+    }
+
+    variant status {
+        ok,
+        error(string),
+        pending,
+    }
+}
+```
+
+Then in another package:
+
+```wit
+package my-org:service@0.1.0;
+
+use my-org:types/common@0.1.0.{timestamp, status};
+
+interface service {
+    get-status: func() -> status;
+    last-updated: func() -> timestamp;
+}
+```
+
+## Common Pitfalls
+
+- **Kebab-case identifiers**: WIT requires `my-function`, not `myFunction` or `my_function`
+- **No dot in identifiers**: use `wasi:io/streams`, not `wasi.io.streams`; dots are not valid in names
+- **Result without payloads**: `result<_, E>` for ok-unit, `result<T, _>` for err-unit, `result` for both unit
+- **borrow vs owned resource**: pass `borrow<resource-type>` when not transferring ownership; plain `resource-type` transfers ownership
+- **Pin to WASI 0.2.0**: use `@0.2.0` for all WASI imports — this is the first stable WASI release and the recommended target for new components
+- **Version in use paths**: always include `@version` when referencing external packages to ensure deterministic resolution
+- **Package path in worlds**: `import wasi:io/streams@0.2.0` imports the `streams` interface from the `wasi:io` package
+- **Missing semicolons**: type alias definitions require a trailing semicolon: `type bytes = list<u8>;`

--- a/plugins/wasm/skills/wit/references/syntax-reference.md
+++ b/plugins/wasm/skills/wit/references/syntax-reference.md
@@ -1,0 +1,626 @@
+# WIT Syntax Reference
+
+Complete reference for the WebAssembly Interface Type (WIT) language syntax.
+
+Source: Component Model documentation at https://component-model.bytecodealliance.org/design/wit.html and https://component-model.bytecodealliance.org/design/worlds.html
+
+---
+
+## Grammar Overview
+
+A WIT document consists of:
+
+```
+wit-file ::= package-decl? (toplevel-use-item | interface-item | world-item)*
+
+package-decl ::= 'package' package-name ';'
+package-name ::= id ':' id ('@' semver)?
+
+toplevel-use-item ::= 'use' use-path '.' '{' use-names-list '}'  ';'
+```
+
+---
+
+## Package Declarations
+
+```wit
+// With version
+package my-org:my-package@1.2.3;
+
+// Without version (less common; version is recommended)
+package my-org:my-package;
+```
+
+Versioning follows semver. The version affects resolution when multiple versions of the same package coexist.
+
+---
+
+## Identifiers
+
+Valid identifier rules:
+- Lowercase ASCII letters, digits, hyphens
+- Must start with a letter
+- Cannot end with a hyphen
+- No consecutive hyphens
+
+Valid: `my-interface`, `http-client`, `wasi`, `v2-api`
+Invalid: `MyInterface`, `my_interface`, `2api`, `my--api`
+
+Reserved keywords used as identifiers require a `%` prefix:
+```wit
+%type, %use, %world, %interface, %record, %variant, %enum, %flags, %resource, %func
+```
+
+---
+
+## Interfaces
+
+```wit
+interface interface-name {
+    // use declarations (must come first)
+    use other-pkg:lib/types.{some-type};
+
+    // type definitions
+    type my-alias = string;
+    record my-record { ... }
+    variant my-variant { ... }
+    enum my-enum { ... }
+    flags my-flags { ... }
+    resource my-resource { ... }
+
+    // function declarations
+    my-func: func(param: type) -> return-type;
+}
+```
+
+Interfaces may not contain nested interfaces or worlds.
+
+---
+
+## Type Aliases
+
+```wit
+type identifier = wit-type;
+```
+
+Examples:
+```wit
+type bytes = list<u8>;
+type callback = func(data: bytes) -> result;
+type nullable-string = option<string>;
+```
+
+Type aliases can alias any WIT type including function types, though function type aliases are uncommon.
+
+---
+
+## Primitive Types
+
+| Keyword | Width | Range / Notes |
+|---------|-------|---------------|
+| `bool` | 1 bit logical | `true` / `false` |
+| `u8` | 8-bit | 0 to 255 |
+| `u16` | 16-bit | 0 to 65535 |
+| `u32` | 32-bit | 0 to 4,294,967,295 |
+| `u64` | 64-bit | 0 to 18,446,744,073,709,551,615 |
+| `s8` | 8-bit signed | -128 to 127 |
+| `s16` | 16-bit signed | -32768 to 32767 |
+| `s32` | 32-bit signed | -2,147,483,648 to 2,147,483,647 |
+| `s64` | 64-bit signed | -9,223,372,036,854,775,808 to max |
+| `f32` | 32-bit IEEE 754 | single precision float |
+| `f64` | 64-bit IEEE 754 | double precision float |
+| `char` | Unicode scalar | not a byte; full Unicode code point |
+| `string` | UTF-8 | length-prefixed, no null terminator |
+
+---
+
+## Compound Types
+
+### list
+
+```wit
+list<u8>          // byte array
+list<string>      // string array
+list<list<u8>>    // nested lists allowed
+```
+
+### option
+
+```wit
+option<string>       // Some(string) or None
+option<list<u8>>     // Some(bytes) or None
+```
+
+### result
+
+```wit
+result<ok-type, err-type>    // success or error, both with payload
+result<ok-type, _>           // error has no payload
+result<_, err-type>          // ok has no payload
+result                       // both ok and err have no payload
+result<_, _>                 // same as result
+```
+
+### tuple
+
+```wit
+tuple<string, u32>              // 2-element
+tuple<string, u32, bool>        // 3-element
+tuple<u8, u8, u8, u8>          // 4-element (e.g., IPv4)
+```
+
+Tuples are positional; elements have no names.
+
+---
+
+## Records
+
+```wit
+record record-name {
+    field-name: type,
+    another-field: type,
+    // trailing comma allowed
+}
+```
+
+Example:
+```wit
+record http-response {
+    status: u16,
+    headers: list<tuple<string, string>>,
+    body: option<list<u8>>,
+    content-type: option<string>,
+}
+```
+
+Records map to structs in most languages. All fields are present; no optional fields (use `option<T>` for nullable fields).
+
+---
+
+## Variants
+
+Tagged unions where each case may carry a distinct payload type.
+
+```wit
+variant variant-name {
+    case-name,                  // no payload
+    case-with-payload(type),    // with payload
+    another-case(other-type),
+}
+```
+
+Example:
+```wit
+variant json-value {
+    null,
+    bool-val(bool),
+    number(f64),
+    str(string),
+    array(list<json-value>),
+    object(list<tuple<string, json-value>>),
+}
+
+variant error {
+    parse-error(string),
+    io-error(u32),
+    timeout,
+    unknown,
+}
+```
+
+---
+
+## Enums
+
+Discriminant-only variants (no payload on any case).
+
+```wit
+enum enum-name {
+    case-one,
+    case-two,
+    case-three,
+}
+```
+
+Example:
+```wit
+enum http-method {
+    get,
+    post,
+    put,
+    delete,
+    patch,
+    head,
+    options,
+}
+
+enum compression {
+    none,
+    gzip,
+    zstd,
+    brotli,
+}
+```
+
+Enums are more efficient than variants when no payloads are needed.
+
+---
+
+## Flags
+
+A set of boolean flags; multiple can be active simultaneously.
+
+```wit
+flags flags-name {
+    flag-one,
+    flag-two,
+    flag-three,
+}
+```
+
+Example:
+```wit
+flags open-flags {
+    read,
+    write,
+    create,
+    truncate,
+    append,
+    exclusive,
+}
+
+flags event-types {
+    readable,
+    writable,
+    error,
+    hang-up,
+}
+```
+
+Flags map to bitfield types. The number of flags determines the underlying integer size used by the canonical ABI.
+
+---
+
+## Functions
+
+```wit
+function-name: func(param-list) -> return-type
+```
+
+Variations:
+```wit
+// No parameters, no return
+noop: func();
+
+// Parameters, no return
+log: func(level: u8, msg: string);
+
+// Single return (unnamed)
+add: func(a: s32, b: s32) -> s32;
+
+// Multiple named returns
+minmax: func(values: list<f64>) -> (min: f64, max: f64);
+
+// Result return
+open: func(path: string) -> result<resource, string>;
+
+// Option return
+find-first: func(items: list<string>, prefix: string) -> option<string>;
+```
+
+Named return values use the tuple syntax `-> (name: type, ...)`. The names appear in generated bindings as struct fields or variable names.
+
+---
+
+## Resources
+
+```wit
+resource resource-name {
+    // Default constructor (creates owned instance)
+    constructor(params);
+
+    // Named constructor (static factory method)
+    %new: static func(params) -> resource-name;
+
+    // Instance methods (implicit borrow of self)
+    method-name: func(params) -> return-type;
+
+    // Static methods (no self)
+    static-method: static func(params) -> return-type;
+
+    // Destructor: implicit (no syntax needed — auto-dropped when handle goes out of scope)
+}
+```
+
+Example:
+```wit
+resource tcp-socket {
+    constructor(address: string, port: u16) -> result<tcp-socket, string>;
+
+    send: func(data: list<u8>) -> result<u32, string>;
+    recv: func(max-bytes: u32) -> result<list<u8>, string>;
+    close: func();
+
+    local-address: func() -> string;
+    remote-address: func() -> string;
+
+    set-timeout: static func(sock: borrow<tcp-socket>, millis: u32);
+}
+```
+
+### Resource Ownership
+
+```wit
+interface storage {
+    resource blob {
+        constructor(data: list<u8>);
+        size: func() -> u64;
+    }
+
+    // Takes ownership of blob (moved in)
+    store: func(key: string, value: blob) -> result<_, string>;
+
+    // Borrows blob (no ownership transfer)
+    inspect: func(key: string, value: borrow<blob>) -> u64;
+
+    // Returns new owned blob
+    load: func(key: string) -> result<blob, string>;
+}
+```
+
+`borrow<T>` signals that the resource is borrowed for the duration of the call. Owned `T` transfers ownership to the callee.
+
+---
+
+## Use Declarations
+
+Import types or interfaces from other packages or the same package.
+
+```wit
+// Import specific types from an interface
+use wasi:io/streams@0.2.0.{input-stream, output-stream};
+
+// Import with alias
+use wasi:clocks/wall-clock@0.2.0.{datetime as wall-datetime};
+
+// Multiple imports
+use my-org:types/common@0.1.0.{
+    timestamp,
+    status,
+    error-kind,
+};
+```
+
+Use declarations must come before type definitions and function declarations within the same scope.
+
+### Use Path Syntax
+
+```
+package-name '/' interface-name ('@' version)?
+```
+
+Examples:
+- `wasi:io/streams@0.2.0` — interface `streams` from package `wasi:io` version 0.2.0
+- `my-org:utils/strings` — no version (latest or only version)
+
+---
+
+## Worlds
+
+```wit
+world world-name {
+    // use declarations
+    use some-pkg:lib/types.{some-type};
+
+    // import items
+    import item-name: func(...) -> ...;
+    import interface-name: interface { ... };
+    import pkg:name/iface@ver;
+    import pkg:name/iface@ver.{type-name};
+
+    // export items
+    export item-name: func(...) -> ...;
+    export interface-name: interface { ... };
+    export named-iface;
+
+    // includes
+    include other-world;
+    include other-world with { old-name as new-name };
+}
+```
+
+### Import Styles
+
+```wit
+world example {
+    // Import a function directly
+    import log: func(msg: string);
+
+    // Import an inline interface
+    import filesystem: interface {
+        read-file: func(path: string) -> result<list<u8>, string>;
+    };
+
+    // Import a named interface from the same package
+    import my-interface;
+
+    // Import an interface from another package
+    import wasi:filesystem/preopens@0.2.0;
+
+    // Import specific types only (not the whole interface)
+    import wasi:io/streams@0.2.0.{input-stream};
+}
+```
+
+### Export Styles
+
+```wit
+world example {
+    // Export a function
+    export run: func() -> result<_, string>;
+
+    // Export an interface by name (interface defined in same package)
+    export my-interface;
+
+    // Export an inline interface
+    export api: interface {
+        process: func(data: list<u8>) -> list<u8>;
+    };
+}
+```
+
+### World Includes
+
+```wit
+world base-cli {
+    import wasi:cli/stdin@0.2.0;
+    import wasi:cli/stdout@0.2.0;
+    export wasi:cli/run@0.2.0;
+}
+
+world extended-cli {
+    include base-cli;
+    import wasi:filesystem/preopens@0.2.0;
+    export my-app: func();
+}
+```
+
+The `with` clause renames items to avoid name conflicts:
+
+```wit
+world merged {
+    include world-a with {
+        process as process-a,
+        config as config-a,
+    };
+    include world-b with {
+        process as process-b,
+        config as config-b,
+    };
+}
+```
+
+---
+
+## Comments
+
+```wit
+// Single-line comment
+
+/*
+  Block comment (does not nest)
+*/
+
+/// Documentation comment.
+/// Attached to the immediately following item.
+/// Appears in generated bindings as doc comments/JSDoc/etc.
+interface well-documented {
+    /// Computes the factorial of n.
+    /// Returns error if n > 20 to avoid overflow.
+    factorial: func(n: u32) -> result<u64, string>;
+}
+```
+
+---
+
+## Full Example: HTTP Client Interface
+
+```wit
+package my-org:http-client@0.2.0;
+
+interface types {
+    record request {
+        method: http-method,
+        url: string,
+        headers: list<tuple<string, string>>,
+        body: option<list<u8>>,
+    }
+
+    record response {
+        status: u16,
+        headers: list<tuple<string, string>>,
+        body: list<u8>,
+    }
+
+    enum http-method {
+        get,
+        post,
+        put,
+        delete,
+        patch,
+        head,
+        options,
+    }
+
+    variant http-error {
+        connection-failed(string),
+        timeout(u32),
+        invalid-url,
+        tls-error(string),
+        server-error(u16),
+    }
+}
+
+interface client {
+    use types.{request, response, http-error};
+
+    resource http-client {
+        constructor(base-url: string);
+        send: func(req: request) -> result<response, http-error>;
+        set-timeout: func(millis: u32);
+        set-header: func(name: string, value: string);
+    }
+}
+
+world http-plugin {
+    import wasi:clocks/wall-clock@0.2.0;
+    export client;
+}
+```
+
+---
+
+## Canonical ABI Notes
+
+The Canonical ABI defines how WIT types are represented at the wasm binary level. Key points:
+
+- Strings are passed as (pointer, length) pairs in linear memory, encoded as UTF-8
+- Lists are (pointer, length) pairs
+- Options are lowered as a discriminant + value
+- Results are lowered as a discriminant + payload
+- Records are laid out field-by-field with alignment padding
+- Variants use a discriminant sized to fit the number of cases, plus the largest payload
+- Resources are represented as 32-bit handles (indices into a resource table)
+- `borrow<T>` resources have a different handle space than owned resources
+
+Tools like `wasm-tools component wit` show the ABI for any compiled component.
+
+---
+
+## WIT Package Layout on Disk
+
+A WIT package can span multiple files in a directory:
+
+```
+wit/
+├── my-package.wit        # package declaration and interfaces
+├── worlds.wit            # world definitions
+└── deps/                 # vendored dependencies
+    └── wasi:io@0.2.0/
+        ├── streams.wit
+        └── poll.wit
+```
+
+Reference a WIT directory with tools:
+```bash
+# cargo-component uses wit/ by default
+cargo component build
+
+# wasm-tools accepts a directory
+wasm-tools component wit wit/
+
+# wit-bindgen
+wit-bindgen rust wit/ --world my-world --out-dir src/bindings/
+```
+
+The `wit/deps/` directory holds vendored WIT packages fetched via `cargo component add` or manually.


### PR DESCRIPTION
- Add WIT (WebAssembly Interface Type) skill with syntax guide and reference
- Cover packages, interfaces, worlds, type system, functions, resources
- Add sandboxing security model and WASI 0.2.0 stability guidance
- Content verified against actual component-model.bytecodealliance.org docs
- Add WIT sources to wasm sources.md
- Add syntax-reference.md with full type system and grammar details
- Bump wasm 0.1.2 -> 0.1.3, all-skills 0.3.18 -> 0.3.20