### PR TITLE
feat(elixir): update version tracking for phoenix, liveview, elixir, otp

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.20",
+      "version": "0.3.21",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -50,7 +50,7 @@
       "source": "./plugins/languages/elixir",
       "strict": true,
       "description": "Elixir development skills: Phoenix, OTP, Tidewave MCP, testing, configuration",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "category": "language",
       "keywords": ["elixir", "phoenix", "otp", "beam"]
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/languages/elixir/.claude-plugin/plugin.json
+++ b/plugins/languages/elixir/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "elixir",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Elixir development skills: Phoenix, OTP, Tidewave MCP, testing, configuration, and anti-patterns",
   "author": {
     "name": "vinnie357"

--- a/plugins/languages/elixir/skills/phoenix/SKILL.md
+++ b/plugins/languages/elixir/skills/phoenix/SKILL.md
@@ -7,6 +7,8 @@ description: Guide for Phoenix web applications. Use when building Phoenix apps,
 
 This skill activates when working with Phoenix web applications, including setup, development, LiveView, contexts, controllers, and channels.
 
+**Current versions**: Phoenix 1.8.x (current: 1.8.5), Phoenix LiveView 1.1.x (current: 1.1.27). Requires Elixir 1.14+, Erlang/OTP 25+.
+
 ## When to Use This Skill
 
 Activate this skill when:

--- a/plugins/languages/elixir/skills/sources.md
+++ b/plugins/languages/elixir/skills/sources.md
@@ -42,6 +42,18 @@ This file documents the sources used to create the elixir plugin skills.
 - **Purpose**: Comprehensive guides for building Phoenix applications
 - **Key Topics**: Routing, controllers, views, templates, contexts, testing
 
+### Phoenix Hex Package
+- **URL**: https://hex.pm/packages/phoenix
+- **Purpose**: Phoenix framework package and version tracking
+- **Date Accessed**: 2026-03-25
+- **Key Topics**: Version 1.8.5 (current), release history, dependencies
+
+### Phoenix LiveView Hex Package
+- **URL**: https://hex.pm/packages/phoenix_live_view
+- **Purpose**: Phoenix LiveView package and version tracking
+- **Date Accessed**: 2026-03-25
+- **Key Topics**: Version 1.1.27 (current), release history
+
 ## Tidewave MCP Dev Tools (Phoenix Skill Extension)
 
 ### Tidewave Hex Package
@@ -85,6 +97,18 @@ This file documents the sources used to create the elixir plugin skills.
 - **URL**: https://www.erlang.org/doc/design_principles/des_princ.html
 - **Purpose**: Understanding OTP design patterns and principles
 - **Key Topics**: Behaviors, supervision trees, applications, releases
+
+### Elixir Language
+- **URL**: https://github.com/elixir-lang/elixir/releases
+- **Purpose**: Elixir language release tracking
+- **Date Accessed**: 2026-03-25
+- **Key Topics**: Version 1.19.5 (current), release notes, changelog
+
+### Erlang/OTP
+- **URL**: https://github.com/erlang/otp/releases
+- **Purpose**: Erlang/OTP release tracking
+- **Date Accessed**: 2026-03-25
+- **Key Topics**: Version 28.4.1 (current), release notes
 
 ## Testing Skill
 
@@ -133,7 +157,8 @@ This file documents the sources used to create the elixir plugin skills.
 ## Plugin Information
 
 - **Name**: elixir
-- **Version**: 0.1.0
-- **Description**: Elixir development skills: Phoenix, OTP, testing, configuration, and anti-patterns
-- **Skills**: 5 skills covering Elixir language, framework, and best practices
+- **Version**: 0.1.5
+- **Description**: Elixir development skills: Phoenix, OTP, testing, configuration, anti-patterns, and Tidewave MCP dev tools
+- **Skills**: 6 skills covering Elixir language, framework, and best practices
 - **Created**: 2025-11-15
+- **Updated**: 2026-03-25

--- a/plugins/languages/elixir/skills/tidewave/SKILL.md
+++ b/plugins/languages/elixir/skills/tidewave/SKILL.md
@@ -164,7 +164,7 @@ config :phoenix,
   debug_attributes: true
 ```
 
-Requires Phoenix LiveView v1.1+.
+Requires Phoenix LiveView v1.1+ (current: 1.1.27).
 
 ## Security
 


### PR DESCRIPTION
- Add Phoenix 1.8.5 and LiveView 1.1.27 version references to phoenix SKILL.md
- Update tidewave SKILL.md LiveView requirement to mention 1.1.27
- Add Phoenix, LiveView, Elixir 1.19.5, OTP 28.4.1 source entries to sources.md
- Update sources.md plugin info version and skills count
- Bump elixir 0.1.4 -> 0.1.5, all-skills 0.3.20 -> 0.3.21