### PR TITLE
feat(rust): update version tracking for rust 1.94.0, tokio, serde

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.21",
+      "version": "0.3.22",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -68,7 +68,7 @@
       "source": "./plugins/languages/rust",
       "strict": true,
       "description": "Rust programming skills: ownership, borrowing, async, best practices",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "category": "language",
       "keywords": ["rust", "systems-programming", "memory-safety"]
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/languages/rust/.claude-plugin/plugin.json
+++ b/plugins/languages/rust/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Rust programming skills: ownership, borrowing, lifetimes, async, and best practices",
   "author": {
     "name": "vinnie357"

--- a/plugins/languages/rust/skills/sources.md
+++ b/plugins/languages/rust/skills/sources.md
@@ -66,10 +66,29 @@ This file documents the sources used to create the rust plugin skills.
   - Testing and benchmarking
   - Publishing crates
 
+### Rust Stable Releases
+- **URL**: https://github.com/rust-lang/rust/releases
+- **Purpose**: Rust compiler release tracking
+- **Date Accessed**: 2026-03-25
+- **Key Topics**: Version 1.94.0 (current stable), edition 2021, release notes
+
+### Tokio Runtime
+- **URL**: https://crates.io/crates/tokio
+- **Purpose**: Async runtime version tracking
+- **Date Accessed**: 2026-03-25
+- **Key Topics**: Version 1.50.0 (current), async/await, task spawning
+
+### Serde Serialization
+- **URL**: https://crates.io/crates/serde
+- **Purpose**: Serialization framework version tracking
+- **Date Accessed**: 2026-03-25
+- **Key Topics**: Version 1.0.228 (current), derive macros, data formats
+
 ## Plugin Information
 
 - **Name**: rust
-- **Version**: 0.1.0
+- **Version**: 0.1.4
 - **Description**: Rust programming skills: ownership, borrowing, lifetimes, async, and best practices
-- **Skills**: 1 comprehensive Rust skill
+- **Skills**: 6 skills
 - **Created**: 2025-11-15
+- **Updated**: 2026-03-25

--- a/plugins/languages/rust/skills/testing/references/testing.md
+++ b/plugins/languages/rust/skills/testing/references/testing.md
@@ -78,10 +78,10 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
-reqwest = "0.11"
+reqwest = "0.12"
 
 [dev-dependencies]
-mockall = "0.11"
+mockall = "0.13"
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
- Add Rust 1.94.0 stable, tokio 1.50.0, serde 1.0.228 source entries to sources.md
- Update testing reference reqwest 0.11 -> 0.12, mockall 0.11 -> 0.13
- Update sources.md plugin info version and skills count
- Bump rust 0.1.3 -> 0.1.4, all-skills 0.3.21 -> 0.3.22