### PR TITLE
feat(nushell): add version tracking and mise.toml template for nushell 0.111.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.22",
+      "version": "0.3.23",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -32,7 +32,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "category": "development",
       "keywords": ["git", "documentation", "code-review", "tools", "beads", "bees", "container", "tdd"]
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/nushell/SKILL.md
+++ b/plugins/core/skills/nushell/SKILL.md
@@ -19,6 +19,8 @@ Activate when:
 
 ## What is Nushell?
 
+Current stable: 0.111.0 (pre-1.0, breaking changes possible between minor versions)
+
 Nushell is a modern shell that:
 - Treats **data as structured** (not just text streams)
 - Works **cross-platform** (Windows, macOS, Linux)
@@ -37,6 +39,12 @@ cargo install nu
 
 # Windows
 winget install nushell
+
+# Via mise (recommended for project-level management)
+# Add to mise.toml:
+# [tools]
+# "github:nushell/nushell" = "latest"
+mise install github:nushell/nushell
 
 # Or download from https://www.nushell.sh/
 ```

--- a/plugins/core/skills/nushell/templates/mise.toml
+++ b/plugins/core/skills/nushell/templates/mise.toml
@@ -1,0 +1,9 @@
+# mise.toml - Install Nushell via mise
+# Copy to your project root or ~/.config/mise/config.toml for global install
+
+[tools]
+# Install Nushell from GitHub releases
+"github:nushell/nushell" = "latest"
+
+# Pin to a specific version
+# "github:nushell/nushell" = "0.111.0"

--- a/plugins/core/skills/sources.md
+++ b/plugins/core/skills/sources.md
@@ -28,8 +28,14 @@ This file documents the sources used to create the core plugin skills.
 ### Nushell Book
 - **URL**: https://www.nushell.sh/book/
 - **Purpose**: Modern, structured data shell with pipeline support
-- **Date Accessed**: 2025-11-15
+- **Date Accessed**: 2026-03-25
 - **Key Topics**: Shell commands, data pipelines, structured data handling
+
+### Nushell GitHub Releases
+- **URL**: https://github.com/nushell/nushell/releases
+- **Purpose**: Nushell release tracking and changelog
+- **Date Accessed**: 2026-03-25
+- **Key Topics**: Version 0.111.0 (current), release notes, breaking changes
 
 ## Documentation Skill
 


### PR DESCRIPTION
- Add Nushell 0.111.0 version reference to SKILL.md
- Add mise installation method to SKILL.md installation section
- Add templates/mise.toml for installing nushell via mise (github:nushell/nushell)
- Add Nushell GitHub releases source entry to sources.md
- Bump core 0.1.19 -> 0.1.20, all-skills 0.3.22 -> 0.3.23