### PR TITLE
feat(mise): add version tracking and nushell install example for mise v2026.3.15

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.23",
+      "version": "0.3.24",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -32,7 +32,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "category": "development",
       "keywords": ["git", "documentation", "code-review", "tools", "beads", "bees", "container", "tdd"]
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/mise/SKILL.md
+++ b/plugins/core/skills/mise/SKILL.md
@@ -19,6 +19,8 @@ Activate when:
 
 ## What is mise?
 
+Current stable: v2026.3.15
+
 mise is a polyglot runtime manager and development environment tool that combines:
 - **Tool version management** - Install and manage multiple versions of dev tools
 - **Environment configuration** - Set environment variables per project
@@ -206,6 +208,7 @@ terraform = "latest"
 "cargo:ripgrep" = "latest"        # Requires rust installed
 "ubi:sharkdp/fd" = "latest"       # GitHub releases
 "npm:typescript" = "latest"       # Requires node installed
+"github:nushell/nushell" = "latest"  # Nushell (structured shell)
 
 # Version from file
 node = { version = "lts", resolve = "latest-lts" }

--- a/plugins/core/skills/mise/templates/multi-arch.md
+++ b/plugins/core/skills/mise/templates/multi-arch.md
@@ -5,3 +5,7 @@ version = "latest"
 linux-x64 = { asset_pattern = "beads_*_linux_amd64.tar.gz" }
 macos-arm64 = { asset_pattern = "beads_*_darwin_arm64.tar.gz" }
 
+# Nushell - no platform-specific config needed (single binary)
+[tools]
+"github:nushell/nushell" = "latest"
+

--- a/plugins/core/skills/sources.md
+++ b/plugins/core/skills/sources.md
@@ -20,8 +20,14 @@ This file documents the sources used to create the core plugin skills.
 ### mise Documentation
 - **URL**: https://mise.jdx.dev/
 - **Purpose**: Development environment management and tool version control
-- **Date Accessed**: 2025-11-15
+- **Date Accessed**: 2026-03-25
 - **Key Topics**: Runtime management, environment configuration, task running
+
+### mise GitHub Releases
+- **URL**: https://github.com/jdx/mise/releases
+- **Purpose**: mise release tracking and changelog
+- **Date Accessed**: 2026-03-25
+- **Key Topics**: Version v2026.3.15 (current), calver versioning, release notes
 
 ## Nushell Skill
 


### PR DESCRIPTION
- Add mise v2026.3.15 version reference to SKILL.md
- Add nushell installation example (github:nushell/nushell) to SKILL.md tools section
- Add nushell example to multi-arch.md template
- Add mise GitHub releases source entry to sources.md
- Bump core 0.1.20 -> 0.1.21, all-skills 0.3.23 -> 0.3.24