### PR TITLE
feat(elixir): add ports and style skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,10 +49,10 @@
       "name": "elixir",
       "source": "./plugins/languages/elixir",
       "strict": true,
-      "description": "Elixir development skills: Phoenix, OTP, Tidewave MCP, testing, configuration",
-      "version": "0.1.5",
+      "description": "Elixir development skills: Phoenix, OTP, Ports, Tidewave MCP, testing, configuration, style",
+      "version": "0.1.7",
       "category": "language",
-      "keywords": ["elixir", "phoenix", "otp", "beam"]
+      "keywords": ["elixir", "phoenix", "otp", "ports", "style", "beam"]
     },
     {
       "name": "github",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -49,6 +49,8 @@
     "./plugins/languages/elixir/skills/otp",
     "./plugins/languages/elixir/skills/testing",
     "./plugins/languages/elixir/skills/config",
+    "./plugins/languages/elixir/skills/ports",
+    "./plugins/languages/elixir/skills/style",
     "./plugins/languages/elixir/skills/tidewave",
     "./plugins/tools/github/skills/actions",
     "./plugins/tools/github/skills/workflows",

--- a/plugins/languages/elixir/.claude-plugin/plugin.json
+++ b/plugins/languages/elixir/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "elixir",
-  "version": "0.1.5",
-  "description": "Elixir development skills: Phoenix, OTP, Tidewave MCP, testing, configuration, and anti-patterns",
+  "version": "0.1.7",
+  "description": "Elixir development skills: Phoenix, OTP, Ports, Tidewave MCP, testing, configuration, style, and anti-patterns",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["elixir", "phoenix", "otp", "beam", "erlang"],
+  "keywords": ["elixir", "phoenix", "otp", "ports", "style", "beam", "erlang"],
   "agents": [
     "./agents/tidewave.md"
   ],
@@ -17,6 +17,8 @@
     "./skills/otp",
     "./skills/testing",
     "./skills/config",
+    "./skills/ports",
+    "./skills/style",
     "./skills/tidewave"
   ]
 }

--- a/plugins/languages/elixir/skills/ports/SKILL.md
+++ b/plugins/languages/elixir/skills/ports/SKILL.md
@@ -1,0 +1,444 @@
+---
+name: ports
+description: Guide for Elixir/Erlang Ports — communicating with external OS processes. Use when spawning external programs, implementing port protocols, wrapping ports in GenServer, or choosing between Port, NIF, System.cmd, and C Nodes.
+license: MIT
+---
+
+# Elixir Ports
+
+Ports are Elixir's mechanism for communicating with external OS programs via stdin/stdout. A Port is not a network port — it is a process-like entity that manages an external OS program, forwarding messages as bytes and delivering responses back to the owning Elixir process.
+
+## When to Use This Skill
+
+Activate when:
+- Spawning and communicating with external programs or scripts
+- Implementing binary protocols over stdin/stdout
+- Wrapping a port in a GenServer for lifecycle management
+- Deciding between Port, NIF, C Node, or `System.cmd`
+- Handling port crashes, exit status, or monitoring ports
+- Working with long-running external processes
+
+## Port Fundamentals
+
+Open a port with `Port.open/2`. The most common name forms are `{:spawn, command}` and `{:spawn_executable, path}`.
+
+```elixir
+# Spawn by shell command string (uses shell, PATH lookups apply)
+port = Port.open({:spawn, "cat"}, [:binary])
+
+# Spawn executable directly (no shell, preferred for security)
+port = Port.open({:spawn_executable, "/usr/bin/python3"}, [
+  :binary,
+  args: ["-u", "my_script.py"]
+])
+```
+
+Send data to the port and receive from it:
+
+```elixir
+# Send bytes to the external process's stdin
+Port.command(port, "hello\n")
+
+# Receive response — messages arrive in the process mailbox
+receive do
+  {^port, {:data, data}} ->
+    IO.puts("Got: #{data}")
+end
+```
+
+Close the port explicitly or let it close when the owner process exits:
+
+```elixir
+Port.close(port)
+# The port will reply {port, :closed} after the external process exits
+```
+
+## Port Options Reference
+
+| Option | Description |
+|--------|-------------|
+| `:binary` | Deliver data as binaries (recommended; default is charlists) |
+| `{:packet, N}` | Prefix each message with N-byte length header (N = 1, 2, or 4) |
+| `{:line, L}` | Deliver complete lines up to L bytes; partial lines flagged |
+| `:stream` | No framing — raw bytes delivered as received (default) |
+| `:exit_status` | Send `{port, {:exit_status, code}}` when the program exits |
+| `:use_stdio` | Use stdin/stdout for communication (default) |
+| `:stderr_to_stdout` | Merge stderr into stdout stream |
+| `{:cd, dir}` | Set working directory for the external process |
+| `{:env, env_list}` | Set environment variables (REPLACES the entire environment) |
+| `{:args, arg_list}` | Argument list when using `:spawn_executable` |
+| `{:arg0, string}` | Override argv[0] for the external process |
+| `:parallelism` | Hint to scheduler for improved throughput |
+
+**Note on `{:env, env_list}`**: This option completely replaces the OS environment, it does not merge with the current environment. To extend the current environment, merge explicitly before passing it.
+
+## Communication Patterns
+
+### Stream Mode (default)
+
+Bytes are delivered as they arrive with no framing. Use `:binary` to get binaries instead of charlists.
+
+```elixir
+port = Port.open({:spawn_executable, "/bin/cat"}, [:binary, :stream])
+
+Port.command(port, "some data")
+
+receive do
+  {^port, {:data, chunk}} -> IO.inspect(chunk)
+end
+```
+
+### Packet Mode
+
+Use `{:packet, N}` for message framing. The external program must also implement the same N-byte big-endian length prefix.
+
+```elixir
+# Elixir side
+port = Port.open({:spawn_executable, "/usr/local/bin/my_worker"}, [
+  :binary,
+  {:packet, 4}
+])
+
+Port.command(port, encode_message("hello"))
+
+receive do
+  {^port, {:data, response}} -> decode_message(response)
+end
+```
+
+The external program reads a 4-byte big-endian integer as the message length, then reads that many bytes. It writes responses with the same framing.
+
+### Line Mode
+
+```elixir
+port = Port.open({:spawn_executable, "/usr/bin/python3"}, [
+  :binary,
+  {:line, 4096},
+  args: ["script.py"]
+])
+
+receive do
+  {^port, {:data, {:eol, line}}} ->
+    IO.puts("Complete line: #{line}")
+
+  {^port, {:data, {:noeol, partial}}} ->
+    IO.puts("Partial line (too long): #{partial}")
+end
+```
+
+### Receiving Exit Status
+
+```elixir
+port = Port.open({:spawn, "false"}, [:binary, :exit_status])
+
+receive do
+  {^port, {:exit_status, code}} ->
+    IO.puts("Exited with code #{code}")
+end
+```
+
+## GenServer Port Wrapper
+
+Wrapping a port in a GenServer is the standard OTP pattern for managing external processes. The GenServer owns the port, handles messages, and exposes a clean API.
+
+```elixir
+defmodule MyApp.ExternalWorker do
+  use GenServer
+
+  @timeout 5_000
+
+  # Client API
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def call(payload) do
+    GenServer.call(__MODULE__, {:call, payload}, @timeout)
+  end
+
+  # Server Callbacks
+
+  @impl true
+  def init(_opts) do
+    executable = System.find_executable("my_worker") ||
+      raise "my_worker not found in PATH"
+
+    port =
+      Port.open({:spawn_executable, executable}, [
+        :binary,
+        {:packet, 4},
+        :exit_status
+      ])
+
+    ref = Port.monitor(port)
+
+    {:ok, %{port: port, ref: ref, caller: nil}}
+  end
+
+  @impl true
+  def handle_call({:call, payload}, from, %{port: port} = state) do
+    encoded = :erlang.term_to_binary(payload)
+    Port.command(port, encoded)
+    {:noreply, %{state | caller: from}}
+  end
+
+  @impl true
+  def handle_info({port, {:data, data}}, %{port: port, caller: caller} = state) do
+    response = :erlang.binary_to_term(data)
+    GenServer.reply(caller, {:ok, response})
+    {:noreply, %{state | caller: nil}}
+  end
+
+  @impl true
+  def handle_info({port, {:exit_status, code}}, %{port: port} = state) do
+    {:stop, {:port_exited, code}, state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, ref, :port, _port, reason}, %{ref: ref} = state) do
+    {:stop, {:port_down, reason}, state}
+  end
+
+  @impl true
+  def terminate(_reason, %{port: port}) do
+    if Port.info(port) != nil do
+      Port.close(port)
+    end
+
+    :ok
+  end
+end
+```
+
+Key points in this pattern:
+- Store the port in GenServer state
+- Monitor the port with `Port.monitor/1` to receive `:DOWN` messages
+- Use `{:packet, N}` for reliable message framing
+- Store the calling `from` pid when waiting for a response
+- Reply via `GenServer.reply/2` from `handle_info` when data arrives
+- Always check `Port.info(port)` before closing in `terminate/2`
+
+### Supervision
+
+Add the GenServer to a supervision tree:
+
+```elixir
+children = [
+  {MyApp.ExternalWorker, []},
+  # ...
+]
+
+Supervisor.start_link(children, strategy: :one_for_one)
+```
+
+When the external process crashes, the port sends an exit message, the GenServer stops, and the supervisor restarts it.
+
+## Port Lifecycle and Error Handling
+
+### Port Monitor
+
+Use `Port.monitor/1` (available since Elixir v1.6) to receive a `{:DOWN, ref, :port, object, reason}` message when a port closes:
+
+```elixir
+port = Port.open({:spawn, "my_cmd"}, [:binary])
+ref = Port.monitor(port)
+
+receive do
+  {:DOWN, ^ref, :port, _port, reason} ->
+    IO.puts("Port closed: #{inspect(reason)}")
+end
+```
+
+### Checking if a Port is Alive
+
+```elixir
+case Port.info(port) do
+  nil -> :port_closed
+  info -> {:alive, info}
+end
+```
+
+### Port Ownership Transfer
+
+Transfer ownership with `Port.connect/2`. The old owner receives `{port, :connected}`:
+
+```elixir
+Port.connect(port, new_owner_pid)
+```
+
+### Crash Semantics
+
+- When the port owner process terminates, the port closes automatically, and the external program receives SIGTERM.
+- When the external program exits, the port sends `{port, {:exit_status, code}}` (if `:exit_status` was set) and closes.
+- Ports are linked to their owning process by default.
+
+## Decision Guide: Port vs NIF vs C Node vs System.cmd
+
+| Aspect | Port | NIF | C Node | System.cmd |
+|--------|------|-----|--------|-----------|
+| Crash isolation | Yes — OS process | No — crashes the VM | Yes — OS process | Yes — subprocess |
+| Latency | IPC overhead | Near zero | Message passing | Blocking, high |
+| Complexity | Low–Medium | High | Very high | Very low |
+| Scheduler impact | None | Blocks (use dirty NIFs for >1ms) | None | Blocks caller only |
+| Security boundary | OS process isolation | Full VM access | OS process isolation | OS process isolation |
+| Best for | Long-running, streaming | Sub-millisecond sync calls | Legacy C integration | One-shot commands |
+
+**Use Port when**: the external program runs continuously, streams data, or must be isolated from VM crashes.
+
+**Use `System.cmd/3` when**: running a command once, synchronously, and the result is needed before proceeding. Returns `{output, exit_status}`.
+
+**Use NIF when**: calling a C function with sub-millisecond latency requirements. Use dirty NIFs (`ERL_NIF_DIRTY_JOB_CPU_BOUND` or `ERL_NIF_DIRTY_JOB_IO_BOUND`) for work exceeding ~1ms to avoid blocking schedulers.
+
+**Use C Node when**: integrating with an existing large C codebase that uses `erl_interface`/`ei`.
+
+### System.cmd Example
+
+```elixir
+{output, 0} = System.cmd("ls", ["-la", "/tmp"],
+  cd: "/",
+  stderr_to_stdout: true
+)
+```
+
+`System.cmd/3` blocks the calling process until the command completes. It does not stream data.
+
+## Security Considerations
+
+### Prefer `:spawn_executable` Over `:spawn`
+
+`{:spawn, command}` passes the command through a shell, which enables shell injection:
+
+```elixir
+# UNSAFE — shell injection risk
+user_input = "file.txt; rm -rf /"
+Port.open({:spawn, "cat #{user_input}"}, [:binary])
+
+# SAFE — no shell, arguments passed directly
+Port.open({:spawn_executable, "/bin/cat"}, [
+  :binary,
+  args: [user_input]
+])
+```
+
+Always use `{:spawn_executable, path}` with `args:` when any part of the command comes from user input or external data.
+
+### Validate Executable Paths
+
+```elixir
+# Find and validate the executable at startup, not per-request
+executable = System.find_executable("my_tool") ||
+  raise "my_tool executable not found in PATH"
+```
+
+Store the validated path in process state so it is resolved once at startup.
+
+### Environment Variable Replacement
+
+`{:env, env_list}` completely replaces the OS environment. To avoid accidentally stripping PATH or other required variables:
+
+```elixir
+# Merge with current environment
+base_env = System.get_env() |> Map.to_list()
+Port.open({:spawn_executable, executable}, [
+  :binary,
+  env: base_env ++ [{"MY_VAR", "value"}]
+])
+```
+
+Note: `{:env, env_list}` expects a list of `{charlist, charlist}` or `{binary, binary}` tuples. Use `String.to_charlist/1` if mixing types.
+
+### Windows Batch File Injection
+
+On Windows, spawning `.bat` or `.cmd` files via `:spawn` passes through `cmd.exe`, which has its own injection vectors. Use explicit executable paths and validate all arguments.
+
+## Testing Port-Based Code
+
+### Mock the Port Interaction
+
+Test the GenServer wrapper by sending fake port messages directly:
+
+```elixir
+defmodule MyApp.ExternalWorkerTest do
+  use ExUnit.Case, async: true
+
+  test "call sends to port and returns response" do
+    {:ok, pid} = MyApp.ExternalWorker.start_link([])
+
+    # Retrieve the port from state for inspection
+    %{port: port} = :sys.get_state(pid)
+
+    # Simulate the port sending a response
+    fake_response = :erlang.term_to_binary({:ok, "result"})
+    send(pid, {port, {:data, fake_response}})
+
+    # Verify state updated (caller cleared)
+    %{caller: nil} = :sys.get_state(pid)
+  end
+
+  test "handles port exit" do
+    {:ok, pid} = MyApp.ExternalWorker.start_link([])
+    ref = Process.monitor(pid)
+
+    %{port: port} = :sys.get_state(pid)
+    send(pid, {port, {:exit_status, 1}})
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, {:port_exited, 1}}
+  end
+end
+```
+
+### Integration Test with a Real Port
+
+For integration tests, use a real external program:
+
+```elixir
+test "communicates with cat process" do
+  port = Port.open({:spawn_executable, "/bin/cat"}, [:binary, :stream])
+
+  Port.command(port, "hello")
+
+  assert_receive {^port, {:data, "hello"}}, 1_000
+
+  Port.close(port)
+end
+```
+
+Use `assert_receive` with a timeout rather than bare `receive` in tests to avoid hanging on failure.
+
+## Common Pitfalls
+
+**Orphan processes on VM crash**: If the BEAM VM is killed with SIGKILL (not SIGTERM), external port processes may not receive SIGTERM and can persist. Design external programs to detect closed stdin and exit.
+
+**Charlists vs binaries**: Without `:binary`, data arrives as charlists (lists of integers). Always use `:binary` unless working with legacy code that expects charlists.
+
+**Environment replacement**: `{:env, list}` replaces the entire environment. See the Security section for how to merge with the current environment.
+
+**Blocking the GenServer**: A GenServer that sends a command and awaits a reply synchronously in `handle_call` will block the entire GenServer during the wait. The pattern above avoids this by storing the `from` and replying in `handle_info`.
+
+**Not monitoring the port**: Without `Port.monitor/1` or `:exit_status`, a silently exiting external process leaves the GenServer in a state where it will never receive a reply.
+
+**Packet mode mismatch**: If the Elixir side uses `{:packet, 4}` but the external program uses a different framing, all messages will be corrupted or silently dropped. Verify the framing protocol matches on both sides.
+
+## References
+
+See `references/erlang-ports.md` for:
+- Complete `open_port/2` Erlang option reference
+- Binary protocol wire format and byte calculations
+- `erl_interface` / `ei` C library overview
+- Port driver architecture (linked-in drivers)
+- ERTS scheduling and backpressure options
+
+## Anti-Fabrication
+
+Verify all port behavior claims through tool execution. Use `Port.info/1` to confirm port state before asserting properties. Run actual port commands and check exit statuses rather than assuming behavior. Reference `core:anti-fabrication` for the complete validation methodology.
+
+## Key Principles
+
+- **Use `:spawn_executable`**: Avoid shell injection by passing arguments directly
+- **Wrap ports in GenServer**: Follow OTP patterns for lifecycle management and supervision
+- **Monitor the port**: Use `Port.monitor/1` to detect unexpected port closure
+- **Use `{:packet, N}` for framing**: Stream mode requires external framing logic
+- **Design for orphan processes**: External programs should detect stdin closure and exit
+- **Test with `assert_receive`**: Avoid bare `receive` in tests to prevent hangs
+- **Prefer Port over NIF for isolation**: NIF crashes bring down the entire VM

--- a/plugins/languages/elixir/skills/ports/references/erlang-ports.md
+++ b/plugins/languages/elixir/skills/ports/references/erlang-ports.md
@@ -1,0 +1,422 @@
+# Erlang Ports — Deep Reference
+
+This reference covers the Erlang-level Port implementation, wire protocols, and low-level ERTS internals. Load this file when implementing binary protocol framing in C, writing port drivers, or investigating ERTS scheduling behavior.
+
+## Table of Contents
+
+1. [open_port/2 Complete Option Reference](#openport2-complete-option-reference)
+2. [Port Architecture](#port-architecture)
+3. [Binary Protocol Wire Format](#binary-protocol-wire-format)
+4. [erl_interface / ei Library](#erl_interface--ei-library)
+5. [Port Driver Architecture](#port-driver-architecture)
+6. [ERTS Scheduling and Ports](#erts-scheduling-and-ports)
+7. [Backpressure Options](#backpressure-options)
+8. [Port Message Protocol Reference](#port-message-protocol-reference)
+
+---
+
+## open_port/2 Complete Option Reference
+
+The Erlang BIF `open_port/2` is what `Port.open/2` calls. The complete set of `PortSettings` options:
+
+### Port Name Forms
+
+```erlang
+{spawn, Command}          % Shell command string
+{spawn_executable, Path}  % Absolute path, no shell
+{spawn_driver, Command}   % Linked-in driver (deprecated pattern)
+{fd, FdIn, FdOut}         % Wrap existing file descriptors
+```
+
+### Communication Options
+
+| Option | Description |
+|--------|-------------|
+| `{packet, N}` | N-byte length prefix framing. N must be 1, 2, or 4. |
+| `{line, L}` | Line-oriented mode. Max line length L bytes. |
+| `stream` | No framing, raw byte stream (default). |
+| `binary` | Deliver data as binaries instead of byte lists. |
+| `{parallelism, Bool}` | Hint to scheduler for parallel port I/O. |
+
+### I/O Channel Options
+
+| Option | Description |
+|--------|-------------|
+| `use_stdio` | Use stdin/stdout for port communication (default). |
+| `nouse_stdio` | Use file descriptors 3 and 4 instead of 0 and 1. |
+| `stderr_to_stdout` | Merge the external program's stderr into stdout. |
+| `in` | Port is read-only (input to Erlang only). |
+| `out` | Port is write-only (output from Erlang only). |
+
+### Process Options
+
+| Option | Description |
+|--------|-------------|
+| `exit_status` | Send `{Port, {exit_status, Status}}` when program exits. |
+| `{cd, Dir}` | Set working directory of the spawned process. |
+| `{env, Env}` | Set environment. `Env` is a list of `{Name, Val}` or `{Name, false}` to unset. Replaces the entire environment. |
+| `{args, ArgList}` | Argument list for `spawn_executable`. Each element is a string or binary. |
+| `{arg0, ArgString}` | Override `argv[0]` (the program name as seen by the process). |
+| `hide` | Windows only: start process with `STARTF_USESHOWWINDOW` + `SW_HIDE`. |
+
+### Busy Limits (Backpressure)
+
+| Option | Description |
+|--------|-------------|
+| `{busy_limits_port, {Low, High}}` | Busy-signal on the port when output queue exceeds `High` bytes; clear when below `Low`. |
+| `{busy_limits_msgq, {Low, High}}` | Busy-signal when the message queue of the port owner exceeds `High`; clear when below `Low`. |
+| `busy_limits_port` | Atom form: equivalent to `{busy_limits_port, {1024, 2048}}`. |
+| `busy_limits_msgq` | Atom form: equivalent to `{busy_limits_msgq, {1024, 2048}}`. |
+
+---
+
+## Port Architecture
+
+### External Ports
+
+An external port runs as a separate OS process. ERTS communicates with it via:
+- stdin (Erlang writes to the port → program's stdin)
+- stdout (program writes to stdout → Erlang receives data messages)
+
+The port process and ERTS run in separate OS processes with the OS providing memory isolation. A crash in the external program does not affect the ERTS VM.
+
+### Port Owner
+
+The process that calls `open_port/2` becomes the port owner. The port owner:
+- Receives all messages from the port
+- Is the only process that can send commands to the port (unless ownership is transferred)
+- When the owner terminates, the port is closed and the external program receives SIGTERM
+
+Ownership can be transferred with `port_connect(Port, NewPid)` (or `Port.connect/2` in Elixir).
+
+### Port Lifecycle
+
+```
+open_port/2
+    │
+    ▼
+OS fork/exec spawns external process
+    │
+    ▼
+Port is alive — owner sends/receives
+    │
+    ├── Owner terminates → port closes → external gets SIGTERM
+    ├── External exits → {Port, {exit_status, N}} → port closes
+    └── port_close(Port) → {Port, closed} → external gets EOF on stdin
+```
+
+When `:exit_status` is not set, the port closes silently when the external program exits without notifying the owner.
+
+---
+
+## Binary Protocol Wire Format
+
+### packet Mode Framing
+
+`{packet, N}` prepends each message with a big-endian unsigned integer of N bytes representing the message length. The external program must implement the same framing.
+
+#### Packet 1 (N=1)
+
+- Header: 1 byte, unsigned, big-endian
+- Maximum message size: 255 bytes
+- Wire format: `[length_byte][payload_bytes...]`
+
+```
+Byte 0:        length (0-255)
+Bytes 1..N:    payload
+```
+
+#### Packet 2 (N=2)
+
+- Header: 2 bytes, unsigned, big-endian
+- Maximum message size: 65,535 bytes (64 KB)
+- Wire format: `[high_byte][low_byte][payload_bytes...]`
+
+```
+Byte 0:        length >> 8 (high byte)
+Byte 1:        length & 0xFF (low byte)
+Bytes 2..N+1:  payload
+```
+
+#### Packet 4 (N=4)
+
+- Header: 4 bytes, unsigned, big-endian
+- Maximum message size: 4,294,967,295 bytes (4 GB)
+- Wire format: `[byte3][byte2][byte1][byte0][payload_bytes...]`
+
+```
+Bytes 0-3:     length in big-endian (network byte order)
+Bytes 4..N+3:  payload
+```
+
+#### C Implementation Example (packet 2)
+
+```c
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+/* Read a 2-byte length-prefixed message from stdin */
+ssize_t read_packet2(uint8_t *buf, size_t buf_size) {
+    uint8_t header[2];
+    if (fread(header, 1, 2, stdin) != 2) return -1;
+
+    uint16_t len = ((uint16_t)header[0] << 8) | header[1];
+    if (len > buf_size) return -1;
+
+    return fread(buf, 1, len, stdin);
+}
+
+/* Write a 2-byte length-prefixed message to stdout */
+void write_packet2(const uint8_t *buf, uint16_t len) {
+    uint8_t header[2];
+    header[0] = (len >> 8) & 0xFF;
+    header[1] = len & 0xFF;
+    fwrite(header, 1, 2, stdout);
+    fwrite(buf, 1, len, stdout);
+    fflush(stdout);
+}
+```
+
+#### Python Implementation Example (packet 4)
+
+```python
+import sys
+import struct
+
+def read_packet4():
+    header = sys.stdin.buffer.read(4)
+    if len(header) < 4:
+        return None
+    length = struct.unpack(">I", header)[0]
+    return sys.stdin.buffer.read(length)
+
+def write_packet4(data: bytes):
+    header = struct.pack(">I", len(data))
+    sys.stdout.buffer.write(header + data)
+    sys.stdout.buffer.flush()
+```
+
+### Line Mode Wire Format
+
+With `{line, MaxLineLength}`, the port delivers complete lines (including the newline stripped) as:
+```erlang
+{Port, {data, {eol, Line}}}
+```
+
+Lines exceeding `MaxLineLength` bytes are split and the first chunk arrives as:
+```erlang
+{Port, {data, {noeol, PartialLine}}}
+```
+
+---
+
+## erl_interface / ei Library
+
+`erl_interface` (and its successor `ei`) is a C library that allows external C programs to encode and decode Erlang External Term Format (ETF), enabling them to speak Erlang's native term protocol.
+
+### When to Use ei
+
+Use `ei` in external port programs when you want to pass Erlang terms (atoms, tuples, lists, binaries) directly rather than inventing a custom binary encoding. This is common when combined with `{packet, 2}` or `{packet, 4}`.
+
+### Key ei Functions
+
+```c
+#include "ei.h"
+
+/* Encoding */
+ei_x_buff buf;
+ei_x_new(&buf);
+ei_x_encode_tuple_header(&buf, 2);
+ei_x_encode_atom(&buf, "ok");
+ei_x_encode_binary(&buf, data, data_len);
+
+/* Decoding */
+int index = 0;
+int type, size;
+ei_get_type(buf, &index, &type, &size);
+
+char atom[MAXATOMLEN];
+ei_decode_atom(buf, &index, atom);
+
+long long_val;
+ei_decode_long(buf, &index, &long_val);
+```
+
+### Erlang External Term Format
+
+The full ETF specification is available at: https://www.erlang.org/doc/apps/erts/erl_ext_dist
+
+Key tags:
+- `131` — version magic byte (always first byte)
+- `100` (`ATOM_EXT`) — atom
+- `104` (`SMALL_TUPLE_EXT`) — tuple up to 255 elements
+- `105` (`LARGE_TUPLE_EXT`) — tuple with more elements
+- `108` (`LIST_EXT`) — proper list
+- `109` (`BINARY_EXT`) — binary
+- `97`  (`SMALL_INTEGER_EXT`) — integer 0–255
+- `98`  (`INTEGER_EXT`) — 32-bit integer
+
+In Elixir/Erlang: `:erlang.term_to_binary/1` encodes, `:erlang.binary_to_term/1` decodes. The external C program uses `ei` for the same encoding.
+
+---
+
+## Port Driver Architecture
+
+### What Port Drivers Are
+
+Port drivers (also called linked-in drivers) are shared libraries loaded into the ERTS VM process. They are accessed via `open_port({spawn_driver, Name}, Options)`.
+
+Unlike external ports, port drivers:
+- Run inside the ERTS VM process (no OS process isolation)
+- Can crash the entire VM on a bug (no memory isolation)
+- Have lower latency than external ports (no IPC)
+- Are loaded with `erl_ddll:load/2`
+
+### Deprecation Status
+
+Port drivers occupy an awkward position:
+- Lower latency than external ports but higher crash risk than NIFs
+- NIFs (with dirty NIF support) largely supersede port drivers for in-process native code
+- The Erlang/OTP team recommends new code use NIFs or external ports rather than port drivers
+- Port driver support remains for backward compatibility but receives minimal new development
+
+### Port Driver Callbacks
+
+A port driver implements a `ErlDrvEntry` struct with function pointers:
+
+```c
+static ErlDrvEntry my_driver_entry = {
+    .init         = my_init,
+    .start        = my_start,
+    .stop         = my_stop,
+    .output       = my_output,    /* called when Erlang sends data */
+    .ready_input  = my_ready_input,
+    .ready_output = my_ready_output,
+    .driver_name  = "my_driver",
+    .finish       = my_finish,
+    .call         = my_call,      /* synchronous call from port_call/3 */
+    .extended_marker = ERL_DRV_EXTENDED_MARKER,
+    .major_version   = ERL_DRV_EXTENDED_MAJOR_VERSION,
+    .minor_version   = ERL_DRV_EXTENDED_MINOR_VERSION,
+    .driver_flags    = ERL_DRV_FLAG_USE_PORT_LOCKING
+};
+```
+
+---
+
+## ERTS Scheduling and Ports
+
+### Port I/O Threads
+
+By default, ERTS uses a thread pool for port I/O operations (reads and writes). The pool size defaults to the number of CPU threads and is configurable with `+A` VM flag:
+
+```sh
+erl +A 16    # 16 async threads
+```
+
+External port I/O is performed in these threads, meaning port I/O does not block ERTS schedulers.
+
+### Port Scheduling
+
+Each port has its own run queue entry. When a port has pending I/O or messages to deliver, it is scheduled like a process. ERTS interleaves port execution with process execution on the same scheduler threads.
+
+The `{parallelism, true}` option hints to the scheduler that the port can benefit from being scheduled on a separate thread, useful for high-throughput ports.
+
+### Impact on Reduction Budget
+
+Sending a message to a port or receiving from a port consumes reductions from the calling process's budget, similar to other operations. Very high-frequency port messaging can affect the reduction balance of the calling process.
+
+---
+
+## Backpressure Options
+
+### busy_limits_port
+
+Controls when `port_command/2` returns `false` (port is busy) or raises `{error, busy}`:
+
+```erlang
+%% Port signals busy when output queue exceeds 8192 bytes,
+%% clears when it drops below 4096 bytes.
+Port = open_port({spawn_executable, Exe}, [
+    binary,
+    {packet, 4},
+    {busy_limits_port, {4096, 8192}}
+]).
+```
+
+When the port is busy, `Port.command(port, data, [:nosuspend])` returns `false` instead of blocking.
+
+### busy_limits_msgq
+
+Controls when the port signals busy based on the message queue length of the port owner:
+
+```erlang
+Port = open_port({spawn_executable, Exe}, [
+    binary,
+    {packet, 4},
+    {busy_limits_msgq, {100, 200}}
+]).
+```
+
+This prevents the port from producing messages faster than the owner process can consume them.
+
+### Using nosuspend with Port.command
+
+`Port.command(port, data, [:nosuspend])` returns `false` immediately if the port is busy, instead of suspending the caller. Use this for non-blocking sends:
+
+```elixir
+case Port.command(port, data, [:nosuspend]) do
+  true  -> :sent
+  false -> :port_busy  # handle backpressure
+end
+```
+
+`Port.command(port, data, [:force])` forces the send even when the port is busy, bypassing the busy signal. Use with caution as it can overflow the output queue.
+
+---
+
+## Port Message Protocol Reference
+
+### Messages Sent TO a Port
+
+These are the raw Erlang messages the port receives (Elixir `Port.command/2` and `Port.close/1` send these internally):
+
+```erlang
+{PortOwnerPid, {command, IoData}}   % Send data to external program
+{PortOwnerPid, close}               % Close the port
+{PortOwnerPid, {connect, NewPid}}   % Transfer ownership
+```
+
+### Messages Received FROM a Port
+
+```erlang
+{Port, {data, Data}}               % Data from external program
+{Port, closed}                     % Port closed (after close command)
+{Port, connected}                  % Ownership transfer confirmed (old owner receives this)
+{Port, {exit_status, Status}}      % External program exited (requires exit_status option)
+{'EXIT', Port, Reason}             % Port linked exit signal
+{'DOWN', Ref, port, Port, Reason}  % Port monitor DOWN message
+```
+
+### Port.info/1 Fields
+
+`Port.info(port)` returns a keyword list with:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `:registered_name` | atom | Registered name if any |
+| `:id` | integer | Port ID |
+| `:connected` | pid | Current owner PID |
+| `:links` | [pid] | Linked processes |
+| `:name` | charlist | Port name (e.g., `'cat'`) |
+| `:input` | integer | Total bytes received from program |
+| `:output` | integer | Total bytes sent to program |
+| `:os_pid` | integer \| `:undefined` | OS PID of the external process |
+
+`Port.info(port, :os_pid)` returns `{:os_pid, pid_integer}` — useful for sending OS signals from Elixir:
+
+```elixir
+{:os_pid, os_pid} = Port.info(port, :os_pid)
+System.cmd("kill", ["-SIGTERM", "#{os_pid}"])
+```

--- a/plugins/languages/elixir/skills/sources.md
+++ b/plugins/languages/elixir/skills/sources.md
@@ -154,11 +154,81 @@ This file documents the sources used to create the elixir plugin skills.
   - Best practices for library vs application configuration
   - Configuration access patterns and anti-patterns
 
+## Ports Skill
+
+### Elixir Port Module
+- **URL**: https://hexdocs.pm/elixir/Port.html
+- **Purpose**: Elixir Port module documentation — wraps Erlang port functionality
+- **Date Accessed**: 2026-03-28
+- **Key Topics**: Port.open/2, Port.command/3, Port.close/1, Port.connect/2, Port.info/1, Port.monitor/1, message protocols
+
+### Erlang Ports Reference Manual
+- **URL**: https://www.erlang.org/doc/reference_manual/ports.html
+- **Purpose**: Erlang port concepts, communication protocol, port owner semantics
+- **Date Accessed**: 2026-03-28
+- **Key Topics**: Port as byte-oriented interface, spawn types, port drivers vs external programs, crash semantics
+
+### Erlang open_port/2 Function Reference
+- **URL**: https://www.erlang.org/doc/apps/erts/erlang.html#open_port-2
+- **Purpose**: Complete open_port/2 option reference with all PortSettings
+- **Date Accessed**: 2026-03-28
+- **Key Topics**: spawn/spawn_executable/spawn_driver/fd, packet modes, line mode, binary, env, cd, args, exit_status, parallelism, busy_limits
+
+### Elixir System.cmd/3
+- **URL**: https://hexdocs.pm/elixir/System.html#cmd/3
+- **Purpose**: System.cmd documentation for comparison with Port
+- **Date Accessed**: 2026-03-28
+- **Key Topics**: Synchronous command execution, argument passing, :into option, :lines option
+
+### Erlang C Nodes Documentation
+- **URL**: https://www.erlang.org/doc/system/c_nodes.html
+- **Purpose**: C Nodes as alternative to Ports for native code integration
+- **Date Accessed**: 2026-03-28
+- **Key Topics**: erl_interface library, EPMD registration, distributed messaging, RPC
+
+### Erlang NIFs Documentation
+- **URL**: https://www.erlang.org/doc/system/nif.html
+- **Purpose**: NIFs as alternative to Ports for native code integration
+- **Date Accessed**: 2026-03-28
+- **Key Topics**: Native Implemented Functions, dirty schedulers, crash risk, microsecond latency
+
+## Style Skill
+
+### Elixir Naming Conventions
+- **URL**: https://hexdocs.pm/elixir/naming-conventions.html
+- **Purpose**: Official naming conventions including trailing bang (!) for raising functions
+- **Date Accessed**: 2026-03-29
+- **Key Topics**: Bang functions convention, foo vs foo! pattern, when to raise vs return tuples
+
+### Elixir with Special Form
+- **URL**: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#with/1
+- **Purpose**: with expression for chaining operations returning tagged tuples
+- **Date Accessed**: 2026-03-29
+- **Key Topics**: Pattern matching chains, early exit on mismatch, else clauses
+
+### Elixir Code Anti-Patterns
+- **URL**: https://hexdocs.pm/elixir/code-anti-patterns.html
+- **Purpose**: Official anti-patterns related to style conventions
+- **Date Accessed**: 2026-03-29
+- **Key Topics**: Non-assertive pattern matching, complex else clauses, alternative return types
+
+### Ecto Changeset Documentation
+- **URL**: https://hexdocs.pm/ecto/Ecto.Changeset.html
+- **Purpose**: Changeset as single validation layer for data shape
+- **Date Accessed**: 2026-03-29
+- **Key Topics**: cast/4, validate_required/3, validate_format/3, cast_assoc/3, cast_embed/3, schemaless changesets
+
+### Ecto Schema Documentation
+- **URL**: https://hexdocs.pm/ecto/Ecto.Schema.html
+- **Purpose**: Schema types including embedded_schema for non-DB data
+- **Date Accessed**: 2026-03-29
+- **Key Topics**: schema/2, embedded_schema/1, field types, associations
+
 ## Plugin Information
 
 - **Name**: elixir
-- **Version**: 0.1.5
-- **Description**: Elixir development skills: Phoenix, OTP, testing, configuration, anti-patterns, and Tidewave MCP dev tools
-- **Skills**: 6 skills covering Elixir language, framework, and best practices
+- **Version**: 0.1.7
+- **Description**: Elixir development skills: Phoenix, OTP, Ports, Style, testing, configuration, anti-patterns, and Tidewave MCP dev tools
+- **Skills**: 8 skills covering Elixir language, framework, and best practices
 - **Created**: 2025-11-15
-- **Updated**: 2026-03-25
+- **Updated**: 2026-03-29

--- a/plugins/languages/elixir/skills/style/SKILL.md
+++ b/plugins/languages/elixir/skills/style/SKILL.md
@@ -1,0 +1,500 @@
+---
+name: style
+description: Elixir coding style and conventions. Use when writing idiomatic Elixir, avoiding bang functions in business logic, using pattern matching for error handling, or designing Ecto schemas as the single source of truth for data validation.
+license: MIT
+---
+
+# Elixir Style and Conventions
+
+## When to Activate
+
+Activate when:
+- Writing or reviewing Elixir code for idiomatic style
+- Deciding between bang (`!`) and non-bang function variants
+- Handling errors from external APIs, user input, or DB operations
+- Designing Ecto schemas and changesets for validation
+- Building Phoenix forms connected to changeset validation
+- Chaining multi-step operations with `with` or `case`
+- Choosing between `map.key` and `map[:key]` access patterns
+- Implementing non-DB data structures (search forms, filter params)
+
+This skill complements `elixir:anti-patterns` — that skill covers what to avoid; this one covers what to do instead.
+
+## Tagged Tuples and Return Conventions
+
+Elixir functions signal success or failure through return values, not exceptions.
+
+**Standard return shapes:**
+
+```elixir
+# Two-element ok/error tuples (most common)
+{:ok, result}
+{:error, reason}
+
+# Bare atoms for side-effect operations
+:ok
+:error
+
+# Richer error tuples for typed failures
+{:error, :not_found}
+{:error, :unauthorized}
+{:error, %Ecto.Changeset{}}
+```
+
+**Why this convention matters:**
+
+Pattern matching on tagged tuples is the foundation of Elixir error handling. When every function in a call chain returns `{:ok, _}` or `{:error, _}`, `with` expressions can thread success values through and exit early on the first failure — without nested `if` or `try/rescue`.
+
+```elixir
+# Callers can match exhaustively
+case fetch_user(id) do
+  {:ok, user} -> render_profile(user)
+  {:error, :not_found} -> send_resp(conn, 404, "Not found")
+  {:error, reason} -> send_resp(conn, 500, inspect(reason))
+end
+```
+
+## Bang Functions: When to Avoid
+
+### The Convention
+
+Every standard library function with a `!` variant follows this contract:
+
+| Non-bang | Bang |
+|---|---|
+| `File.read/1` → `{:ok, content}` or `{:error, reason}` | `File.read!/1` → `content` or raises |
+| `Map.fetch/2` → `{:ok, value}` or `:error` | `Map.fetch!/2` → `value` or raises `KeyError` |
+| `Repo.insert/1` → `{:ok, struct}` or `{:error, changeset}` | `Repo.insert!/1` → `struct` or raises |
+| `Repo.get/2` → `struct` or `nil` | `Repo.get!/2` → `struct` or raises `Ecto.NoResultsError` |
+
+### When Bangs Are Appropriate
+
+Use bang functions when failure represents a programming error or an invalid system state that should crash loudly:
+
+```elixir
+# Application startup — missing config is a bug, not a user error
+def start(_type, _args) do
+  api_key = Application.fetch_env!(:my_app, :stripe_api_key)
+  # ...
+end
+
+# Seeds and migrations — invalid data is a developer error
+Repo.insert!(%User{email: "admin@example.com", role: :admin})
+
+# Pipelines operating on already-validated, known-good data
+"hello world"
+|> String.split()
+|> Enum.map(&String.capitalize/1)
+|> Enum.join(" ")
+
+# Tests asserting expected state
+user = Repo.get!(User, user_id)
+```
+
+### When to Avoid Bangs
+
+Avoid bang functions wherever failure is a normal, expected outcome:
+
+```elixir
+# BAD: user input can always fail validation
+def create_user(conn, %{"user" => params}) do
+  user = Repo.insert!(%User{email: params["email"]})  # raises on validation failure
+  json(conn, %{id: user.id})
+end
+
+# GOOD: handle the error path explicitly
+def create_user(conn, %{"user" => params}) do
+  case %User{} |> User.changeset(params) |> Repo.insert() do
+    {:ok, user} -> json(conn, %{id: user.id})
+    {:error, changeset} -> conn |> put_status(422) |> json(changeset_errors(changeset))
+  end
+end
+```
+
+```elixir
+# BAD: external APIs can return 404, 500, network errors
+def fetch_payment(payment_id) do
+  Stripe.PaymentIntent.retrieve!(payment_id)  # raises on API error
+end
+
+# GOOD: return a tagged tuple, let the caller decide
+def fetch_payment(payment_id) do
+  case Stripe.PaymentIntent.retrieve(payment_id) do
+    {:ok, payment} -> {:ok, payment}
+    {:error, %{code: "resource_missing"}} -> {:error, :not_found}
+    {:error, reason} -> {:error, reason}
+  end
+end
+```
+
+**Rule of thumb:** if a user action, external service, or DB constraint could cause the failure, use the non-bang variant and handle it.
+
+## Pattern Matching for Error Handling
+
+### `with` for Chaining Dependent Operations
+
+Use `with` when multiple steps must all succeed, and any failure should short-circuit to an error response:
+
+```elixir
+def register_user(params) do
+  with {:ok, validated} <- validate_registration_params(params),
+       {:ok, user} <- create_user(validated),
+       {:ok, _profile} <- create_default_profile(user),
+       {:ok, _email} <- send_welcome_email(user) do
+    {:ok, user}
+  else
+    {:error, %Ecto.Changeset{} = cs} -> {:error, {:validation_failed, cs}}
+    {:error, :email_unavailable} -> {:error, :email_taken}
+    {:error, reason} -> {:error, reason}
+  end
+end
+```
+
+The `else` block is optional. Without it, unmatched patterns in `with` clauses propagate the first failing value as the return value of the entire expression.
+
+**Keep `with` flat.** Nesting `with` inside `with` is a sign the function is doing too much:
+
+```elixir
+# BAD: nested with — hard to follow
+with {:ok, user} <- fetch_user(id) do
+  with {:ok, order} <- fetch_order(user, order_id) do
+    {:ok, {user, order}}
+  end
+end
+
+# GOOD: flat with
+with {:ok, user} <- fetch_user(id),
+     {:ok, order} <- fetch_order(user, order_id) do
+  {:ok, {user, order}}
+end
+```
+
+### `case` for Single-Expression Branching
+
+Use `case` when branching on one expression with multiple outcomes:
+
+```elixir
+def handle_webhook(event_type, payload) do
+  case event_type do
+    "payment.succeeded" -> handle_payment_succeeded(payload)
+    "payment.failed" -> handle_payment_failed(payload)
+    "customer.created" -> handle_customer_created(payload)
+    unknown -> Logger.warning("Unhandled webhook: #{unknown}")
+  end
+end
+```
+
+### Multi-Clause Function Heads
+
+Use multi-clause functions for structural dispatch — matching on the shape or value of arguments:
+
+```elixir
+defmodule MyApp.Notifier do
+  def notify(%User{email: nil} = user, _message) do
+    Logger.warning("No email for user #{user.id}, skipping notification")
+    {:error, :no_email}
+  end
+
+  def notify(%User{} = user, message) do
+    Mailer.deliver(to: user.email, body: message)
+  end
+
+  def notify({:admin, email}, message) do
+    Mailer.deliver(to: email, subject: "[ADMIN] " <> message.subject, body: message)
+  end
+end
+```
+
+### Avoid `try/rescue` for Expected Errors
+
+`try/rescue` is reserved for exceptions from code outside your control (third-party libraries that raise instead of returning error tuples). It is not idiomatic for expected application errors:
+
+```elixir
+# BAD: using rescue for control flow
+def parse_integer(str) do
+  try do
+    {:ok, String.to_integer(str)}
+  rescue
+    ArgumentError -> {:error, :invalid_integer}
+  end
+end
+
+# GOOD: use functions that return ok/error tuples
+def parse_integer(str) do
+  case Integer.parse(str) do
+    {value, ""} -> {:ok, value}
+    _ -> {:error, :invalid_integer}
+  end
+end
+```
+
+## Ecto as Data Shape Gatekeeper
+
+### The Principle
+
+Validate data once, at the changeset layer. Do not duplicate validation logic in controllers, LiveView callbacks, or service modules.
+
+```
+Schema defines shape → Changeset validates → Repo uses same changeset → Forms display errors
+```
+
+### Schema Defines the Shape
+
+```elixir
+defmodule MyApp.Accounts.User do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "users" do
+    field :email, :string
+    field :name, :string
+    field :role, Ecto.Enum, values: [:user, :admin], default: :user
+    field :password, :string, virtual: true
+    field :hashed_password, :string
+
+    has_one :profile, MyApp.Accounts.Profile
+    timestamps()
+  end
+
+  @required [:email, :name, :password]
+  @optional [:role]
+
+  def changeset(user, attrs) do
+    user
+    |> cast(attrs, @required ++ @optional)
+    |> validate_required(@required)
+    |> validate_format(:email, ~r/^[^\s]+@[^\s]+$/, message: "must be a valid email")
+    |> validate_length(:password, min: 8, max: 72)
+    |> validate_inclusion(:role, [:user, :admin])
+    |> unique_constraint(:email)
+    |> put_password_hash()
+  end
+
+  defp put_password_hash(%Ecto.Changeset{valid?: true, changes: %{password: pw}} = cs) do
+    put_change(cs, :hashed_password, Bcrypt.hash_pwd_salt(pw))
+  end
+  defp put_password_hash(cs), do: cs
+end
+```
+
+### Context Module and Controller
+
+The context function applies the changeset and returns `{:ok, user}` or `{:error, changeset}`. The controller routes on that result — no extra validation:
+
+```elixir
+defmodule MyApp.Accounts do
+  def register_user(attrs) do
+    %User{} |> User.changeset(attrs) |> Repo.insert()
+  end
+end
+```
+
+### Phoenix Controller Uses the Same Changeset
+
+```elixir
+defmodule MyAppWeb.RegistrationController do
+  use MyAppWeb, :controller
+  alias MyApp.Accounts
+
+  def new(conn, _params) do
+    changeset = Accounts.User.changeset(%Accounts.User{}, %{})
+    render(conn, :new, changeset: to_form(changeset))
+  end
+
+  def create(conn, %{"user" => user_params}) do
+    case Accounts.register_user(user_params) do
+      {:ok, _user} ->
+        conn
+        |> put_flash(:info, "Account created!")
+        |> redirect(to: ~p"/login")
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, :new, changeset: to_form(changeset))
+    end
+  end
+end
+```
+
+### Template Renders Changeset Errors Directly
+
+```heex
+<.simple_form for={@changeset} action={~p"/register"}>
+  <.input field={@changeset[:email]} label="Email" />
+  <.input field={@changeset[:name]} label="Name" />
+  <.input field={@changeset[:password]} type="password" label="Password" />
+  <:actions><.button>Create account</.button></:actions>
+</.simple_form>
+```
+
+The changeset carries both current values and errors — no separate validation layer.
+
+### Anti-Pattern: Duplicating Validation
+
+```elixir
+# BAD: validation in both controller and changeset
+def create(conn, %{"user" => params}) do
+  if String.length(params["password"]) < 8 do  # duplicated from changeset
+    conn |> put_flash(:error, "Password too short") |> render(:new)
+  else
+    case Accounts.register_user(params) do
+      {:ok, _} -> redirect(conn, to: ~p"/login")
+      {:error, cs} -> render(conn, :new, changeset: to_form(cs))
+    end
+  end
+end
+```
+
+Let the changeset own all validation. The controller's only job is to call the context function and route based on `{:ok, _}` or `{:error, changeset}`.
+
+### `cast` vs `change`
+
+```elixir
+# cast/4 — external/untrusted data: filters fields, type-converts
+user |> cast(params, [:email, :name])
+
+# change/2 — internal/already-valid data: no filtering
+user |> change(last_login_at: DateTime.utc_now())
+```
+
+## Embedded Schemas for Non-DB Data
+
+Not all data needs a DB table. Use embedded schemas for search forms, filter panels, and API query params — they get full changeset validation.
+
+```elixir
+defmodule MyApp.Search.UserFilter do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  embedded_schema do
+    field :query, :string
+    field :role, Ecto.Enum, values: [:user, :admin]
+    field :created_after, :date
+    field :page, :integer, default: 1
+    field :per_page, :integer, default: 20
+  end
+
+  def changeset(filter \\ %__MODULE__{}, attrs) do
+    filter
+    |> cast(attrs, [:query, :role, :created_after, :page, :per_page])
+    |> validate_number(:page, greater_than: 0)
+    |> validate_inclusion(:per_page, [10, 20, 50, 100])
+  end
+end
+```
+
+```elixir
+# In a LiveView or controller
+def handle_event("filter", %{"user_filter" => params}, socket) do
+  case UserFilter.changeset(socket.assigns.filter, params) do
+    %{valid?: true} = cs ->
+      filter = Ecto.Changeset.apply_changes(cs)
+      users = Accounts.list_users(filter)
+      {:noreply, assign(socket, users: users, filter: filter)}
+
+    changeset ->
+      {:noreply, assign(socket, filter_changeset: changeset)}
+  end
+end
+```
+
+**Schemaless changesets** handle one-off validation without a module:
+
+```elixir
+def validate_search_params(params) do
+  types = %{query: :string, limit: :integer}
+
+  {%{}, types}
+  |> Ecto.Changeset.cast(params, Map.keys(types))
+  |> Ecto.Changeset.validate_required([:query])
+  |> Ecto.Changeset.validate_number(:limit, greater_than: 0, less_than_or_equal_to: 100)
+end
+```
+
+## Pipe Operator Conventions
+
+### When to Pipe
+
+Pipe when chaining data transformations where each step passes its result to the next:
+
+```elixir
+# Good use of pipe: transforming a value through a sequence of steps
+def normalize_email(email) do
+  email
+  |> String.trim()
+  |> String.downcase()
+  |> String.replace(~r/\+.*@/, "@")
+end
+```
+
+### When Not to Pipe
+
+Avoid piping a single function call — it adds visual noise without clarity benefit:
+
+```elixir
+# BAD: unnecessary pipe
+result = value |> some_function()
+
+# GOOD: direct call
+result = some_function(value)
+```
+
+Avoid piping side effects that don't transform data:
+
+```elixir
+# BAD: pipe into a side effect
+user |> send_welcome_email()
+
+# GOOD: explicit call
+send_welcome_email(user)
+```
+
+## Map and Struct Access
+
+Elixir provides two access patterns with different semantics:
+
+```elixir
+# Dot access — raises KeyError if key missing
+# Use for required fields on known structs
+user.email        # raises if :email key not present
+config.timeout    # use when the field must exist
+
+# Bracket access — returns nil if key missing
+# Use for optional fields on dynamic maps
+params[:email]    # returns nil if missing, no crash
+opts[:timeout]    # safe for optional config keys
+```
+
+**Struct fields always use dot access** — structs enforce their shape at compile time, so a missing key is a programming error:
+
+```elixir
+# Always use dot access for structs
+%User{} = user
+user.email   # correct
+user[:email] # valid but unusual — prefer dot for structs
+```
+
+**Dynamic maps from external sources use bracket access** for optional fields:
+
+```elixir
+def build_query(filters) do
+  base_query = from(u in User)
+
+  base_query
+  |> maybe_filter_role(filters[:role])
+  |> maybe_filter_after(filters[:created_after])
+end
+```
+
+## Anti-Fabrication
+
+Apply `core:anti-fabrication` when generating code examples or making claims about library behavior. Verify function signatures and return types against actual documentation. Do not fabricate error codes, changeset validator names, or Ecto API details.
+
+## Key Principles
+
+- Return `{:ok, result}` / `{:error, reason}` tuples to enable exhaustive pattern matching
+- Use bang functions only when failure indicates a programming error or invalid system state
+- Use `with` for multi-step operations where each step depends on the previous
+- Let the Ecto changeset own all data validation — do not duplicate it in controllers or LiveView
+- Use `embedded_schema` or schemaless changesets for non-DB data that still needs validation
+- Pipe for transformation chains; call directly for single operations and side effects
+- Reserve `try/rescue` for third-party code that raises; use tagged tuples for your own error paths


### PR DESCRIPTION
- Add ports skill (444 lines, 11/11 quality) for Elixir/Erlang Port communication with external OS processes
- Add ports references/erlang-ports.md for deep Erlang port internals (progressive disclosure)
- Add style skill (500 lines, 11/11 quality) covering bang function avoidance, pattern matching error handling, Ecto as data shape gatekeeper
- Bump elixir plugin version 0.1.5 to 0.1.7
- Update marketplace.json, all-skills meta-plugin (61 total skills), and sources.md