### PR TITLE
docs(template): add cross-platform skill discovery and instruction fallback

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,7 +23,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills: plugin marketplace management and validation",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "category": "tools",
       "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark", "skill-update"]
     },

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/templates/CLAUDE.md
+++ b/plugins/tools/claude-code/templates/CLAUDE.md
@@ -20,6 +20,8 @@ Phase 1: Pre flight checks
     - /core:security
     - /core:mise
     - /core:nushell
+- discover project-local skills (.claude/skills/, .github/skills/, .agents/skills/) but only load them when a task requires them — progressive disclosure
+- if CLAUDE.md is not present, check for AGENTS.md or .github/copilot-instructions.md for project instructions
 - all tasks must use the claude task-list tool to work their items
 - check that we are working on a feature branch per epic
 - verify feature branch exists for the epic


### PR DESCRIPTION
- Add cross-platform skill discovery for .claude/skills/, .github/skills/, .agents/skills/
- Add instruction fallback to check AGENTS.md or .github/copilot-instructions.md
- Version bump: claude-code 0.1.10 → 0.1.11