### PR TITLE
feat(linear): add linear project management skill with MCP, epic authoring, and audit commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "A curated collection of Claude skills for development workflows",
-    "version": "1.0.2"
+    "version": "1.0.3"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.24",
+      "version": "0.3.25",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -62,6 +62,16 @@
       "version": "0.1.3",
       "category": "tools",
       "keywords": ["github", "actions", "workflows", "ci-cd", "act", "testing", "community-health", "open-source"]
+    },
+    {
+      "name": "linear",
+      "source": "./plugins/tools/linear",
+      "strict": true,
+      "description": "Linear project management: MCP/GraphQL API, VantageEx epic authoring, auditing, and grooming",
+      "version": "0.1.0",
+      "category": "tools",
+      "keywords": ["linear", "project-management", "epics", "graphql", "vantageex", "mcp"],
+      "license": "MIT"
     },
     {
       "name": "runex",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -57,6 +57,7 @@
     "./plugins/tools/github/skills/workflows",
     "./plugins/tools/github/skills/act",
     "./plugins/tools/github/skills/community-health",
+    "./plugins/tools/linear/skills/linear",
     "./plugins/tools/runex/skills/runex",
     "./plugins/languages/rust/skills/rust",
     "./plugins/languages/rust/skills/ownership",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,5 @@
 @plugins/tools/claude-code/templates/CLAUDE.md
+When Spawning agents allways instruct them to load skills for their tasks as the frist step.
 # Claude Skills Project
 
 This repository contains modular, self-contained skills that extend Claude's capabilities with specialized knowledge, workflows, and tools.

--- a/plugins/tools/linear/.claude-plugin/plugin.json
+++ b/plugins/tools/linear/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "linear",
+  "version": "0.1.0",
+  "description": "Linear project management: MCP/GraphQL API, VantageEx epic authoring, auditing, and grooming",
+  "author": {
+    "name": "vinnie357"
+  },
+  "repository": "https://github.com/vinnie357/claude-skills",
+  "license": "MIT",
+  "keywords": ["linear", "project-management", "epics", "graphql", "vantageex", "mcp"],
+  "skills": [
+    "./skills/linear"
+  ]
+}

--- a/plugins/tools/linear/commands/audit-epics.md
+++ b/plugins/tools/linear/commands/audit-epics.md
@@ -1,0 +1,64 @@
+---
+description: "Audit Linear epics for VantageEx compatibility and produce a findings report"
+argument-hint: "[--project=<slug>] [--state=<state>] [--issue=<key>]"
+---
+
+Audit existing Linear epics for VantageEx compatibility.
+
+## Steps
+
+1. Load the `/linear` skill
+2. Read the audit checklist at `references/audit-checklist.md`
+3. Read the audit report template at `templates/0.1.0/audit-report.md`
+
+## Fetch Issues
+
+Determine scope from arguments:
+
+- `--issue=<key>`: Audit a single issue by key (e.g., MT-123)
+- `--project=<slug>`: Audit all issues in a project
+- `--state=<state>`: Filter by Linear state type (e.g., "started", "unstarted", "completed")
+- No arguments: Ask the user which project or issues to audit
+
+Use Linear MCP tools (preferred) or GraphQL to fetch issues with their full descriptions, states, labels, and attachments.
+
+## Run Checks
+
+For each issue, run every check from the audit checklist:
+
+### Structure Checks
+- Parse description for `## Objective`, `## Skills`, `## Repos` sections
+- Validate objective quality (2-3 sentences)
+- Validate skills exist in marketplace (read marketplace.json)
+- Check for core skills that should not be listed
+
+### Team Checks
+- Check for `## Team` section
+- Check for escalation policy
+
+### Naming Checks
+- Evaluate title quality (imperative statement)
+- Check slug derivability
+- Check branch naming convention if branch exists
+
+### State Consistency Checks
+- For completed/review issues: check for `## PR` section or GitHub PR attachment
+- For needs_help issues: check for blocker documentation
+- Use `gh pr list` and `gh pr view` to cross-reference PR URLs
+
+### Content Quality Checks
+- Check for implementation details (file paths, code blocks outside YAML)
+- Check that constraints are meaningful (not just defaults)
+
+## Generate Report
+
+Use the `templates/0.1.0/audit-report.md` format:
+
+1. Summary table with counts by severity
+2. Per-issue findings sorted by error count (most errors first)
+3. Each finding includes: check name, severity, status, detail
+4. Remediation actions for each failing check
+
+## Output
+
+Present the report to the user. Suggest running `/linear:groom-epics` to fix errors and warnings automatically.

--- a/plugins/tools/linear/commands/groom-epics.md
+++ b/plugins/tools/linear/commands/groom-epics.md
@@ -1,0 +1,73 @@
+---
+description: "Fix VantageEx compatibility issues found by audit-epics"
+argument-hint: "[--project=<slug>] [--issue=<key>] [--auto]"
+---
+
+Fix VantageEx compatibility issues found by the audit.
+
+## Steps
+
+1. Load the `/linear` skill
+2. Read the epic format spec at `references/epic-format.md`
+3. Read the team definition template at `templates/0.1.0/team-definition.md`
+
+## Get Audit Results
+
+Either:
+- Accept prior audit output if available in the conversation
+- Run a fresh audit (same as `/linear:audit-epics`) for the specified scope
+
+Only process findings with severity `error` or `warning`. Info-level findings are reported but not auto-fixed.
+
+## Fix Each Finding
+
+For each error/warning finding, apply the appropriate fix:
+
+### Missing Objective
+- If the title is descriptive, generate a 2-3 sentence objective from the title and any existing description content
+- Ask the user to confirm before applying
+
+### Missing Skills
+- Analyze the issue title and description to suggest relevant skills
+- Validate suggestions against marketplace.json
+- Ask the user to confirm the skill list
+
+### Missing Repos
+- Check if the issue mentions repository names in its description or comments
+- Ask the user to specify target repos if none can be inferred
+
+### Missing Team
+- Insert the default team definition: `lead: sonnet, default_model: haiku, escalation: haiku -> sonnet -> opus`
+- Apply without asking (this is a safe default)
+
+### Core Skills Listed
+- Remove core skills from the skills list automatically
+
+### Missing PR on Completed
+- Search for matching PRs using `gh pr list --search "<issue-identifier>"` and `gh pr list --search "<title>"`
+- If a matching PR is found, attach it via `attachmentLinkGitHubPR` and add `## PR` section
+- If no PR found, flag for manual resolution
+
+### Implementation Details in Description
+- Flag the specific content for user review
+- Do not auto-remove (user may have intentional content)
+
+## Apply Updates
+
+Use Linear MCP tools (preferred) or GraphQL to:
+1. Update issue descriptions with added/fixed sections
+2. Create/attach labels for skills
+3. Attach PR URLs where found
+
+## Verify
+
+After applying fixes:
+1. Re-run the audit checks on modified issues
+2. Report what was changed and what remains unfixed
+3. Present a before/after summary
+
+## Auto Mode
+
+If `--auto` is specified:
+- Apply all safe fixes without asking (team defaults, core skill removal)
+- Still ask for confirmation on content changes (objective, skills, repos)

--- a/plugins/tools/linear/commands/plan-epic.md
+++ b/plugins/tools/linear/commands/plan-epic.md
@@ -1,0 +1,51 @@
+---
+description: "Create a new VantageEx-compatible epic in Linear with proper structure and validation"
+argument-hint: "<title> [--project=<slug>] [--skills=<list>]"
+---
+
+Create a new VantageEx-compatible epic in Linear.
+
+## Steps
+
+1. Load the `/linear` skill
+2. Read the epic template at `templates/0.1.0/epic.md`
+3. Read the epic format spec at `references/epic-format.md`
+
+## Gather Information
+
+Interactively collect from the user:
+
+- **Title**: Clear, imperative statement of what gets built
+- **Slug**: Derive from title (kebab-case, max ~30 chars). Confirm with user.
+- **Objective**: 2-3 sentences defining success criteria
+- **Skills**: Domain-specific skills needed. Validate each against the marketplace at `https://github.com/vinnie357/claude-skills/blob/main/.claude-plugin/marketplace.json`. Warn if a skill is not found.
+- **Repos**: Target repositories
+- **Constraints**: Optional. Note that defaults apply (mise run ci, no attribution, squash merge, feature/<slug>)
+- **Team**: Optional. Default: lead=sonnet, default_model=haiku, escalation=haiku->sonnet->opus
+
+## Validate
+
+Before creating:
+
+- Confirm skills exist in the marketplace (read marketplace.json from the claude-skills repo)
+- Confirm core skills are NOT listed (anti-fabrication, git, tdd, twelve-factor, security, mise, nushell)
+- Confirm objective is 2-3 sentences
+- Confirm slug is kebab-case and under 30 chars
+- Confirm at least one repo is specified
+
+## Create in Linear
+
+Use the Linear MCP tools (preferred) or the GraphQL API to:
+
+1. Create the issue with the title
+2. Set the description using the template format with all gathered sections
+3. Apply skill names as labels (create labels if they do not exist)
+4. Set initial state to "Ready" or "Backlog" (the default unstarted state)
+
+## Report
+
+Output:
+- Linear issue URL
+- Issue identifier (e.g., MT-123)
+- Feature branch name: `feature/<slug>`
+- Summary of what was created

--- a/plugins/tools/linear/skills/linear/SKILL.md
+++ b/plugins/tools/linear/skills/linear/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: linear
+description: "Linear project management via MCP or GraphQL API: issue queries, state transitions, epic authoring for VantageEx agent teams, and epic auditing. Use when interacting with Linear issues, creating or auditing epics, querying workflow states, or managing Linear project data."
+license: MIT
+---
+
+# Linear
+
+Manage Linear issues, author VantageEx-compatible epics, and interact with the Linear API via MCP or direct GraphQL.
+
+## When to Use
+
+Activate when:
+- Querying, creating, or updating Linear issues
+- Authoring epics for VantageEx agent consumption
+- Auditing existing epics for VantageEx compatibility
+- Grooming epics to fix audit findings
+- Transitioning issue workflow states
+- Attaching GitHub PRs to Linear issues
+- Working with Linear comments or description sections
+
+## MCP Setup (Preferred)
+
+The Linear MCP server provides tool-based access to Linear. Set up once:
+
+```bash
+claude mcp add --transport http linear-server https://mcp.linear.app/mcp
+```
+
+Then run `/mcp` in a Claude Code session to complete OAuth authentication (opens browser).
+
+After setup, use MCP tools directly for all Linear operations. The MCP server handles authentication and provides structured tool interfaces.
+
+For full setup details, troubleshooting, and alternative client configurations, read `references/mcp-setup.md`.
+
+## GraphQL Fallback
+
+When MCP is unavailable (headless environments, scripting, CI), use the GraphQL API directly.
+
+**Endpoint**: `https://api.linear.app/graphql`
+**Auth**: Bearer token via `LINEAR_API_KEY` environment variable
+
+```bash
+# Test connectivity
+curl -s -H "Authorization: Bearer $LINEAR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ viewer { id name email } }"}' \
+  https://api.linear.app/graphql
+```
+
+For the full query catalog, read `references/graphql-api.md`.
+
+The nushell client at `scripts/0.1.0/linear.nu` wraps common GraphQL operations.
+
+## Common Operations
+
+### Query an Issue
+
+By key (e.g., `MT-686`):
+
+```graphql
+query IssueByKey($key: String!) {
+  issue(id: $key) {
+    id identifier title url description
+    state { id name type }
+    project { id name }
+    labels { nodes { name } }
+    attachments { nodes { title url sourceType } }
+  }
+}
+```
+
+### Create an Issue
+
+```graphql
+mutation CreateIssue($teamId: String!, $title: String!, $description: String, $stateId: String, $labelIds: [String!]) {
+  issueCreate(input: {
+    teamId: $teamId
+    title: $title
+    description: $description
+    stateId: $stateId
+    labelIds: $labelIds
+  }) {
+    success
+    issue { id identifier url }
+  }
+}
+```
+
+### Update Issue State
+
+Always fetch team workflow states first to get the exact `stateId`:
+
+```graphql
+query IssueTeamStates($id: String!) {
+  issue(id: $id) {
+    team {
+      states { nodes { id name type } }
+    }
+  }
+}
+```
+
+Then transition:
+
+```graphql
+mutation MoveIssue($id: String!, $stateId: String!) {
+  issueUpdate(id: $id, input: { stateId: $stateId }) {
+    success
+    issue { id identifier state { name } }
+  }
+}
+```
+
+### Add a Comment
+
+```graphql
+mutation CreateComment($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) {
+    success
+    comment { id url }
+  }
+}
+```
+
+### Attach a GitHub PR
+
+Prefer the GitHub-specific mutation for PR metadata:
+
+```graphql
+mutation AttachPR($issueId: String!, $url: String!, $title: String) {
+  attachmentLinkGitHubPR(issueId: $issueId, url: $url, title: $title, linkKind: links) {
+    success
+    attachment { id title url }
+  }
+}
+```
+
+### List Workflow States
+
+```graphql
+query TeamStates($teamId: String!) {
+  team(id: $teamId) {
+    states { nodes { id name type position } }
+  }
+}
+```
+
+## Introspection
+
+When an unfamiliar mutation or type is needed, query the schema:
+
+```graphql
+query ListMutations {
+  __type(name: "Mutation") { fields { name } }
+}
+
+query InspectInput($typeName: String!) {
+  __type(name: $typeName) {
+    inputFields { name type { kind name ofType { kind name } } }
+  }
+}
+```
+
+## VantageEx Epic Format
+
+VantageEx epics follow a three-level hierarchy: **Epic** (user-authored) -> **Issues** (team leader creates) -> **Tasks** (agents create).
+
+The user authors the epic description in Linear. The epic body uses markdown sections that VantageEx parses.
+
+### Required Sections
+
+| Section | Purpose | Author |
+|---------|---------|--------|
+| `## Objective` | 2-3 sentences defining success criteria | User (immutable) |
+| `## Skills` | Domain-specific skills needed (core skills implicit) | User (immutable) |
+| `## Repos` | Target repositories | User (immutable) |
+
+### Optional Sections
+
+| Section | Purpose | Author |
+|---------|---------|--------|
+| `## Instructions` | User guidance added at re-queue (ADR-027) | User or dashboard |
+| `## Constraints` | Boundaries (defaults: `mise run ci`, no attribution, squash merge) | User |
+| `## Team` | Lead model, default model, escalation policy | User |
+| `## Escalation` | Failure and ambiguity policies | User |
+| `## PR` | Pull request URL when submitted | Agent |
+
+### Title and Slug
+
+- **Title**: Imperative statement ("Implement OAuth2 PKCE flow for API gateway")
+- **Slug**: kebab-case, max ~30 chars, URL-safe (`oauth-pkce-flow`)
+- **Branch**: `feature/<epic-slug>`
+
+For the full epic specification with examples and anti-patterns, read `references/epic-format.md`.
+
+## Workflow States
+
+Linear uses typed workflow states. VantageEx maps these to its lifecycle:
+
+| VantageEx Status | Linear State | Meaning |
+|-----------------|--------------|---------|
+| `ready` | Backlog / Ready | Epic in backlog, all fields present |
+| `up_next` | Up Next | User approved for agent work |
+| `in_progress` | In Progress | Agent actively working |
+| `needs_help` | Needs Help | Agent exhausted fix cycles |
+| `review` | In Review | CI passed, PR created |
+| `complete` | Done | PR merged |
+| `archived` | Archived | Hidden from dashboard |
+
+Key transitions:
+- `ready` -> `up_next`: **User only** (the gate)
+- `up_next` -> `in_progress`: EpicPickerWorker (automatic)
+- `in_progress` -> `needs_help`: ValidateWorker (after 3 fix cycles)
+- `needs_help` -> `up_next`: User re-queues with `## Instructions`
+- `in_progress` -> `review`: Agent submits PR
+- `review` -> `complete`: User merges PR
+
+For the full state machine and cross-system mapping, read `references/workflow-states.md`.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/linear:plan-epic` | Create a new VantageEx-compatible epic in Linear |
+| `/linear:audit-epics` | Audit existing epics for VantageEx compatibility |
+| `/linear:groom-epics` | Fix issues found by audit |
+
+## References
+
+| File | Content |
+|------|---------|
+| `references/mcp-setup.md` | Linear MCP server setup and troubleshooting |
+| `references/graphql-api.md` | Full GraphQL query catalog |
+| `references/epic-format.md` | VantageEx epic specification |
+| `references/audit-checklist.md` | Epic validation checks |
+| `references/workflow-states.md` | State machine and cross-system mapping |
+
+## Templates
+
+| File | Content |
+|------|---------|
+| `templates/0.1.0/epic.md` | Epic description template |
+| `templates/0.1.0/audit-report.md` | Audit output format |
+| `templates/0.1.0/team-definition.md` | Team section template |
+
+## Scripts
+
+| File | Content |
+|------|---------|
+| `scripts/0.1.0/linear.nu` | Nushell GraphQL client for non-MCP use |
+
+## Usage Rules
+
+- Prefer MCP tools over raw GraphQL when the Linear MCP server is configured
+- For state transitions, always fetch team states first — never hardcode `stateId` values
+- Prefer `attachmentLinkGitHubPR` over `attachmentLinkURL` when linking GitHub PRs
+- Keep queries narrow — request only the fields needed
+- Treat top-level `errors` array in GraphQL responses as failures
+- When writing epic descriptions, follow the section format exactly — VantageEx parses these programmatically

--- a/plugins/tools/linear/skills/linear/references/audit-checklist.md
+++ b/plugins/tools/linear/skills/linear/references/audit-checklist.md
@@ -1,0 +1,116 @@
+# Epic Audit Checklist
+
+Structured validation checks for VantageEx epic compatibility. Each check has a severity level and remediation guidance.
+
+## Severity Levels
+
+| Level | Meaning |
+|-------|---------|
+| **error** | Epic cannot be consumed by VantageEx. Must fix before moving to `up_next`. |
+| **warning** | Epic is consumable but may cause suboptimal results. Should fix. |
+| **info** | Style or convention suggestion. Fix when convenient. |
+
+## Structure Checks
+
+### Objective Present
+- **Severity**: error
+- **Check**: Description contains `## Objective` section
+- **Remediation**: Add a `## Objective` section with 2-3 sentences defining success criteria
+
+### Objective Quality
+- **Severity**: warning
+- **Check**: Objective is 2-3 sentences (not a one-liner or a paragraph)
+- **Remediation**: Rewrite to be concise but specific. Define what "done" looks like.
+
+### Skills Present
+- **Severity**: error
+- **Check**: Description contains `## Skills` section
+- **Remediation**: Add a `## Skills` section listing domain-specific skills needed
+
+### Skills Valid
+- **Severity**: warning
+- **Check**: Each skill listed exists in the marketplace (https://github.com/vinnie357/claude-skills/blob/main/.claude-plugin/marketplace.json) or in the project's local skills directory
+- **Remediation**: Replace unknown skills with valid marketplace skill names, or create the skill if it does not exist
+
+### Skills Not Listing Core
+- **Severity**: info
+- **Check**: Skills list does not include core skills (anti-fabrication, git, tdd, twelve-factor, security, mise, nushell)
+- **Remediation**: Remove core skills from the list — they are always loaded
+
+### Repos Present
+- **Severity**: error
+- **Check**: Description contains `## Repos` section with at least one repository
+- **Remediation**: Add a `## Repos` section listing target repositories
+
+## Team Checks
+
+### Team Defined
+- **Severity**: warning
+- **Check**: Description contains `## Team` section with lead model and default model
+- **Remediation**: Add a `## Team` section. Use template: `lead: sonnet`, `default_model: haiku`, `escalation: haiku -> sonnet -> opus`
+
+### Escalation Policy
+- **Severity**: info
+- **Check**: Team section or `## Escalation` section defines escalation policy
+- **Remediation**: Add escalation line to Team section or separate `## Escalation` section
+
+## Naming Checks
+
+### Title Quality
+- **Severity**: warning
+- **Check**: Title is an imperative statement (not vague like "Fix stuff" or "Updates")
+- **Remediation**: Rewrite title as a clear imperative statement of what gets built
+
+### Slug Present
+- **Severity**: warning
+- **Check**: Epic has a slug or the title can derive a clean kebab-case slug
+- **Remediation**: Ensure the title produces a slug under 30 chars in kebab-case
+
+### Branch Convention
+- **Severity**: warning
+- **Check**: If a branch exists for this epic, it follows `feature/<slug>` pattern
+- **Remediation**: Rename branch to `feature/<epic-slug>`
+
+## State Consistency Checks
+
+### PR on Completed
+- **Severity**: error
+- **Check**: If epic status is Done/Complete/In Review, description contains `## PR` section with a URL or the issue has a GitHub PR attachment
+- **Remediation**: Attach the PR URL via `attachmentLinkGitHubPR` mutation and add `## PR` section
+
+### PR URL Valid
+- **Severity**: warning
+- **Check**: If `## PR` section exists, the URL points to a valid GitHub pull request
+- **Remediation**: Update the PR URL. Use `gh pr view <url>` to verify.
+
+### Needs Help Has Summary
+- **Severity**: warning
+- **Check**: If epic status is Needs Help, there is a comment or description section explaining the blocker
+- **Remediation**: Add a comment documenting what failed and what was attempted
+
+## Content Quality Checks
+
+### No Implementation Details
+- **Severity**: warning
+- **Check**: Description does not contain file paths, code blocks (outside skill/constraint YAML), or step-by-step instructions
+- **Remediation**: Remove implementation details. The team leader handles decomposition.
+
+### No Core Skills Listed
+- **Severity**: info
+- **Check**: Same as "Skills Not Listing Core" above
+- **Remediation**: Remove core skills from skills list
+
+### Constraints Are Real
+- **Severity**: info
+- **Check**: Constraints section (if present) contains meaningful boundaries, not just defaults
+- **Remediation**: Remove constraint section if it only restates defaults (mise run ci, no attribution, squash merge)
+
+## Running an Audit
+
+1. Fetch issues from Linear (by project, state, or specific key)
+2. Parse each issue's description into sections
+3. Run each check against the parsed sections
+4. For state consistency checks, cross-reference with GitHub PRs via `gh` CLI
+5. For skills validation, read marketplace.json
+6. Generate report using `templates/0.1.0/audit-report.md` format
+7. Sort findings by severity (errors first, then warnings, then info)

--- a/plugins/tools/linear/skills/linear/references/epic-format.md
+++ b/plugins/tools/linear/skills/linear/references/epic-format.md
@@ -1,0 +1,235 @@
+# VantageEx Epic Format Specification
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Three-Level Hierarchy](#three-level-hierarchy)
+- [Required Sections](#required-sections)
+- [Optional Sections](#optional-sections)
+- [Title and Slug](#title-and-slug)
+- [Description Sections (ADR-027)](#description-sections-adr-027)
+- [Instructions Flow](#instructions-flow)
+- [Anti-Patterns](#anti-patterns)
+- [Example Epic](#example-epic)
+
+## Overview
+
+VantageEx parses Linear issue descriptions programmatically. The epic body uses markdown `## Section` headers that VantageEx reads at pick time and on every poll. Sections must use exact header names — the parser matches on these strings.
+
+Source: ADR-027 (Epic Messaging), ADR-016 (Layered Tasking), ADR-025 (Epic Lifecycle).
+
+## Three-Level Hierarchy
+
+| Level | Created By | Purpose |
+|-------|-----------|---------|
+| **Epic** | User | Assignment: objective, skills, constraints. No implementation details. |
+| **Issues** | Team leader | Independently deliverable slices with acceptance criteria |
+| **Tasks** | Agents | Granular implementation steps, invisible to the user |
+
+The user's job is to write a great epic. The team leader handles decomposition. Agents create their own tasks.
+
+## Required Sections
+
+### `## Objective`
+
+2-3 sentences defining what success looks like. The team leader uses this to validate completion and decompose the epic into issues.
+
+- Immutable after creation (user-written)
+- Read at pick time and every poll
+- Must define acceptance criteria at a high level
+
+Good: "Users can authenticate via Google/GitHub OAuth2 with PKCE. Tokens refresh automatically. All auth endpoints pass OWASP top-10 checks."
+
+Bad: "Make auth work better"
+
+### `## Skills`
+
+Domain-specific skills needed for this epic. Listed as a comma-separated list or YAML array.
+
+Core skills are always loaded and must NOT be listed:
+- anti-fabrication, git, tdd, twelve-factor, security, mise, nushell
+
+Only list domain-specific extras:
+
+```yaml
+skills: [elixir, oauth, security]
+```
+
+Skills must exist in the marketplace at: https://github.com/vinnie357/claude-skills/blob/main/.claude-plugin/marketplace.json
+
+### `## Repos`
+
+Target repositories this epic touches:
+
+```
+- vinnie357/vantageex
+- vinnie357/runex
+```
+
+May be a single repo or multiple. ADR-023 supports multi-repo epics with parallel execution.
+
+## Optional Sections
+
+### `## Instructions` (ADR-027)
+
+User guidance added when re-queuing an epic from `needs_help` state. Takes priority over general conventions.
+
+- Written by the user via dashboard text area or manually in Linear
+- VantageEx writes back to Linear idempotently
+- Agents receive as `EPIC_INSTRUCTIONS` environment variable
+- Agent prompt: "If the epic has a ## Instructions section, read it carefully. These take priority over general conventions."
+- Separate from objective for historical preservation
+
+### `## Constraints`
+
+Real boundaries that apply to the entire epic. Defaults if omitted:
+
+```yaml
+constraints:
+  - All code must pass `mise run ci`
+  - No attribution in commits
+  - Feature branch: feature/<epic-slug>
+  - Squash merge only
+```
+
+Only include constraints that differ from defaults or add specific boundaries.
+
+### `## Team`
+
+Team composition and model assignments:
+
+```yaml
+team:
+  lead: sonnet
+  default_model: haiku
+  escalation: haiku -> sonnet -> opus
+```
+
+If omitted, the system infers team shape from epic complexity.
+
+### `## Escalation`
+
+Failure and ambiguity policies:
+
+```yaml
+escalation:
+  on_agent_failure: promote_model
+  on_ambiguity: ask_user
+  on_dependency_conflict: ask_user
+```
+
+Model promotion follows: haiku -> sonnet -> opus (max 2 promotions per agent).
+
+### `## PR`
+
+Written by the agent when a PR is submitted. Contains the pull request URL.
+
+- Not user-authored
+- VantageEx reads this section to track PR state
+- Written once at submission time
+
+## Title and Slug
+
+### Title
+
+A clear, imperative statement of what gets built.
+
+- Good: "Implement OAuth2 PKCE flow for API gateway"
+- Bad: "Auth stuff" / "Fix login"
+
+### Slug
+
+Short, URL-safe identifier used in session names and branch names.
+
+- Format: kebab-case
+- Max ~30 characters
+- Good: `oauth-pkce-flow`
+- Bad: `implement-the-full-oauth2-pkce-flow-for-our-api-gateway`
+
+The slug determines the feature branch name: `feature/<epic-slug>`
+
+Max 80 characters when combined with role prefix: `<epic-slug>/_team/leader-<model>`
+
+## Description Sections (ADR-027)
+
+Two communication channels:
+
+### Channel 1: Description Sections (Structured Configuration)
+
+| Section | Who Writes | Who Reads | Lifecycle |
+|---------|-----------|----------|-----------|
+| `## Objective` | User (immutable) | Poller, agents | Read at pick time and every poll |
+| `## Skills` | User (immutable) | Poller | Matched against agent capabilities |
+| `## Repos` | User (immutable) | Poller | May be multiple |
+| `## Instructions` | User/dashboard | Agents | Optional; present only if user provided guidance |
+| `## PR` | Agent | User via dashboard | Written once at submission |
+
+### Channel 2: Comments (Conversational Messaging)
+
+- Append-only conversation threads in Linear
+- Polled only for `in_progress` epics (minimize overhead)
+- Incremental polling via `last_comment_check_at` cursor
+- Users, agents, and VantageEx can post comments
+- Broadcast via PubSub for real-time dashboard updates
+
+## Instructions Flow
+
+When an epic lands in `needs_help`:
+
+1. Agent posts comment with blocker details
+2. User reads comment, provides guidance
+3. User moves epic to `up_next` via dashboard with "Re-queue Guidance" text
+4. VantageEx writes `## Instructions` section to Linear (idempotent)
+5. VantageEx sets `epic.user_instructions` field
+6. New agent picked, receives `EPIC_INSTRUCTIONS` env var
+7. Agent reads instructions, implements with corrected approach
+
+Previous instructions are visible in the comment thread for history.
+
+## Anti-Patterns
+
+Do NOT include in epics:
+
+- **Implementation details** — let agents decide HOW
+- **File paths** — let agents discover the codebase
+- **Step-by-step instructions** — that is what skills are for
+- **Acceptance criteria per issue** — the team leader writes those during decomposition
+- **Model assignments per task** — the system optimizes this
+- **Core skills in the skills list** — they are always loaded
+
+## Example Epic
+
+### Title
+Implement OAuth2 PKCE flow for API gateway
+
+### Slug
+`oauth-pkce-flow`
+
+### Description (Linear issue body)
+
+```markdown
+## Objective
+
+Users can authenticate via Google/GitHub OAuth2 with PKCE. Tokens refresh
+automatically. All auth endpoints pass OWASP top-10 checks.
+
+## Skills
+
+skills: [elixir, oauth, security]
+
+## Repos
+
+- vinnie357/vantageex
+
+## Constraints
+
+- Must support both Google and GitHub providers
+- Token refresh must be transparent to the user
+- Rate limit auth endpoints to 10 req/min per IP
+
+## Team
+
+- lead: sonnet
+- default_model: haiku
+- escalation: haiku -> sonnet -> opus
+```

--- a/plugins/tools/linear/skills/linear/references/graphql-api.md
+++ b/plugins/tools/linear/skills/linear/references/graphql-api.md
@@ -1,0 +1,430 @@
+# Linear GraphQL API Reference
+
+## Table of Contents
+
+- [Authentication](#authentication)
+- [Issue Queries](#issue-queries)
+- [Issue Mutations](#issue-mutations)
+- [Comment Operations](#comment-operations)
+- [Attachment Operations](#attachment-operations)
+- [Workflow States](#workflow-states)
+- [Label Operations](#label-operations)
+- [Project and Team Queries](#project-and-team-queries)
+- [Pagination](#pagination)
+- [Introspection](#introspection)
+- [File Uploads](#file-uploads)
+
+## Authentication
+
+All requests use Bearer token auth against `https://api.linear.app/graphql`:
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $LINEAR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "...", "variables": {...}}' \
+  https://api.linear.app/graphql
+```
+
+Rate limits: 1,500 requests/hour, 250,000 complexity points/hour.
+
+## Issue Queries
+
+### By Key
+
+Use when you have a ticket key like `MT-686`:
+
+```graphql
+query IssueByKey($key: String!) {
+  issue(id: $key) {
+    id identifier title url description
+    state { id name type }
+    project { id name }
+    team { id key name }
+    labels { nodes { id name } }
+    branchName
+    attachments { nodes { id title url sourceType } }
+    comments { nodes { id body createdAt user { name } } }
+    updatedAt
+  }
+}
+```
+
+### By Identifier Filter
+
+Use for search-style lookups:
+
+```graphql
+query IssueByIdentifier($identifier: String!) {
+  issues(filter: { identifier: { eq: $identifier } }, first: 1) {
+    nodes {
+      id identifier title url description
+      state { id name type }
+      project { id name }
+    }
+  }
+}
+```
+
+### By Project
+
+List issues in a project with optional state filter:
+
+```graphql
+query ProjectIssues($projectId: String!, $stateType: String) {
+  issues(
+    filter: {
+      project: { id: { eq: $projectId } }
+      state: { type: { eq: $stateType } }
+    }
+    first: 50
+    orderBy: updatedAt
+  ) {
+    nodes {
+      id identifier title url
+      state { id name type }
+      labels { nodes { name } }
+      description
+    }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+```
+
+### Viewer (Test Connectivity)
+
+```graphql
+query Viewer {
+  viewer { id name email }
+}
+```
+
+## Issue Mutations
+
+### Create Issue
+
+```graphql
+mutation CreateIssue(
+  $teamId: String!
+  $title: String!
+  $description: String
+  $stateId: String
+  $labelIds: [String!]
+  $projectId: String
+) {
+  issueCreate(input: {
+    teamId: $teamId
+    title: $title
+    description: $description
+    stateId: $stateId
+    labelIds: $labelIds
+    projectId: $projectId
+  }) {
+    success
+    issue { id identifier url title }
+  }
+}
+```
+
+### Update Issue
+
+```graphql
+mutation UpdateIssue(
+  $id: String!
+  $stateId: String
+  $description: String
+  $title: String
+  $labelIds: [String!]
+) {
+  issueUpdate(id: $id, input: {
+    stateId: $stateId
+    description: $description
+    title: $title
+    labelIds: $labelIds
+  }) {
+    success
+    issue { id identifier state { id name } }
+  }
+}
+```
+
+### Delete Issue
+
+```graphql
+mutation DeleteIssue($id: String!) {
+  issueDelete(id: $id) { success }
+}
+```
+
+## Comment Operations
+
+### Create Comment
+
+```graphql
+mutation CreateComment($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) {
+    success
+    comment { id url body }
+  }
+}
+```
+
+### Update Comment
+
+```graphql
+mutation UpdateComment($id: String!, $body: String!) {
+  commentUpdate(id: $id, input: { body: $body }) {
+    success
+    comment { id body }
+  }
+}
+```
+
+### List Comments on an Issue
+
+```graphql
+query IssueComments($issueId: String!, $after: String) {
+  issue(id: $issueId) {
+    comments(first: 50, after: $after, orderBy: createdAt) {
+      nodes {
+        id body createdAt updatedAt
+        user { id name }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}
+```
+
+## Attachment Operations
+
+### Attach GitHub PR
+
+Prefer this for GitHub PRs — preserves GitHub metadata:
+
+```graphql
+mutation AttachGitHubPR($issueId: String!, $url: String!, $title: String) {
+  attachmentLinkGitHubPR(
+    issueId: $issueId
+    url: $url
+    title: $title
+    linkKind: links
+  ) {
+    success
+    attachment { id title url }
+  }
+}
+```
+
+### Attach Generic URL
+
+Use when the URL is not a GitHub PR:
+
+```graphql
+mutation AttachURL($issueId: String!, $url: String!, $title: String) {
+  attachmentLinkURL(issueId: $issueId, url: $url, title: $title) {
+    success
+    attachment { id title url }
+  }
+}
+```
+
+### List Attachments
+
+```graphql
+query IssueAttachments($issueId: String!) {
+  issue(id: $issueId) {
+    attachments {
+      nodes { id title url sourceType metadata }
+    }
+  }
+}
+```
+
+## Workflow States
+
+### List Team States
+
+```graphql
+query TeamStates($teamId: String!) {
+  team(id: $teamId) {
+    states {
+      nodes { id name type position }
+    }
+  }
+}
+```
+
+### Get States via Issue
+
+Use when you have an issue ID and need the team's states:
+
+```graphql
+query IssueTeamStates($id: String!) {
+  issue(id: $id) {
+    team {
+      states { nodes { id name type } }
+    }
+  }
+}
+```
+
+### State Types
+
+Linear workflow states have a `type` field:
+
+| Type | Meaning |
+|------|---------|
+| `triage` | Needs triage |
+| `backlog` | In backlog |
+| `unstarted` | Ready but not started |
+| `started` | In progress |
+| `completed` | Done |
+| `canceled` | Cancelled |
+
+Custom state names map to these types. Always match on `type` for automation, use `name` for display.
+
+## Label Operations
+
+### List Labels
+
+```graphql
+query Labels($teamId: String) {
+  issueLabels(
+    filter: { team: { id: { eq: $teamId } } }
+    first: 100
+  ) {
+    nodes { id name color }
+  }
+}
+```
+
+### Create Label
+
+```graphql
+mutation CreateLabel($teamId: String!, $name: String!, $color: String) {
+  issueLabelCreate(input: { teamId: $teamId, name: $name, color: $color }) {
+    success
+    issueLabel { id name }
+  }
+}
+```
+
+## Project and Team Queries
+
+### List Projects
+
+```graphql
+query Projects {
+  projects(first: 50) {
+    nodes { id name slug state }
+  }
+}
+```
+
+### Get Project by Slug
+
+```graphql
+query ProjectBySlug {
+  projects(filter: { slugId: { eq: "my-project" } }, first: 1) {
+    nodes { id name slug }
+  }
+}
+```
+
+### List Teams
+
+```graphql
+query Teams {
+  teams {
+    nodes { id key name }
+  }
+}
+```
+
+## Pagination
+
+Linear uses cursor-based pagination:
+
+```graphql
+query PaginatedIssues($after: String) {
+  issues(first: 50, after: $after) {
+    nodes { id identifier title }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+```
+
+Loop until `hasNextPage` is `false`, passing `endCursor` as `after` for each page.
+
+## Introspection
+
+### List All Mutations
+
+```graphql
+query ListMutations {
+  __type(name: "Mutation") { fields { name } }
+}
+```
+
+### List All Queries
+
+```graphql
+query ListQueries {
+  __type(name: "Query") { fields { name } }
+}
+```
+
+### Inspect Input Type
+
+```graphql
+query InspectInput($typeName: String!) {
+  __type(name: $typeName) {
+    inputFields {
+      name
+      type { kind name ofType { kind name } }
+    }
+  }
+}
+```
+
+Use `"IssueCreateInput"`, `"CommentCreateInput"`, etc. as `$typeName`.
+
+### Inspect Object Type
+
+```graphql
+query InspectType($typeName: String!) {
+  __type(name: $typeName) {
+    fields {
+      name
+      type { kind name ofType { kind name } }
+      args { name type { kind name } }
+    }
+  }
+}
+```
+
+## File Uploads
+
+For attaching files (images, videos) to comments:
+
+1. Request upload URL:
+
+```graphql
+mutation FileUpload($filename: String!, $contentType: String!, $size: Int!) {
+  fileUpload(filename: $filename, contentType: $contentType, size: $size) {
+    success
+    uploadFile {
+      uploadUrl
+      assetUrl
+      headers { key value }
+    }
+  }
+}
+```
+
+2. Upload file bytes to `uploadUrl` with the returned headers
+3. Reference `assetUrl` in comment body markdown

--- a/plugins/tools/linear/skills/linear/references/mcp-setup.md
+++ b/plugins/tools/linear/skills/linear/references/mcp-setup.md
@@ -1,0 +1,153 @@
+# Linear MCP Server Setup
+
+## Table of Contents
+
+- [Claude Code Setup](#claude-code-setup)
+- [Authentication](#authentication)
+- [Alternative Clients](#alternative-clients)
+- [Bearer Token Fallback](#bearer-token-fallback)
+- [Troubleshooting](#troubleshooting)
+- [OAuth Endpoints](#oauth-endpoints)
+
+## Claude Code Setup
+
+Add the Linear MCP server:
+
+```bash
+claude mcp add --transport http linear-server https://mcp.linear.app/mcp
+```
+
+Complete authentication:
+
+1. Start a Claude Code session
+2. Run `/mcp` to list connected servers
+3. The first connection opens a browser for OAuth authorization
+4. Authorize Linear access
+5. The MCP server is now available for the session
+
+After setup, Linear MCP tools are available directly in Claude Code conversations. Use them for all Linear operations (query issues, create issues, update states, add comments).
+
+## Authentication
+
+The Linear MCP server uses **OAuth 2.1 with Dynamic Client Registration**.
+
+Flow:
+1. Client registers dynamically at the registration endpoint
+2. User authorizes via browser (PKCE supported, S256)
+3. Access token and refresh token returned
+4. Refresh tokens maintain long-lived sessions
+
+No manual API key configuration is needed for MCP — OAuth handles everything.
+
+## Alternative Clients
+
+### Claude Desktop
+
+Settings > Connectors > Add Linear connector (built-in support).
+
+### Claude.ai (Team/Enterprise)
+
+Connectors page in settings.
+
+### VS Code
+
+Use `mcp-remote` for clients that do not natively support streamable HTTP:
+
+```json
+{
+  "mcpServers": {
+    "linear": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://mcp.linear.app/mcp"]
+    }
+  }
+}
+```
+
+### Cursor
+
+One-click install from MCP tools directory, or manual configuration with the URL above.
+
+### WSL on Windows
+
+Use the SSE transport endpoint:
+
+```json
+{
+  "mcpServers": {
+    "linear": {
+      "command": "wsl",
+      "args": ["npx", "-y", "mcp-remote", "https://mcp.linear.app/sse", "--transport sse-only"]
+    }
+  }
+}
+```
+
+### Zed
+
+Add to settings under `context_servers`:
+
+```json
+{
+  "context_servers": {
+    "linear": {
+      "url": "https://mcp.linear.app/mcp"
+    }
+  }
+}
+```
+
+## Bearer Token Fallback
+
+For headless environments, CI pipelines, or scripting where OAuth is not available, use a Linear API key directly:
+
+1. Generate a personal API key in Linear: Settings > API > Personal API Keys
+2. Set the environment variable: `export LINEAR_API_KEY=lin_api_...`
+3. Use the GraphQL API directly (see `graphql-api.md`) or the nushell client (`scripts/0.1.0/linear.nu`)
+
+The MCP server also accepts Bearer token auth via the `Authorization` header, bypassing the interactive OAuth flow.
+
+## Troubleshooting
+
+### "Internal Server Error" on authentication
+
+Clear cached OAuth state:
+
+```bash
+rm -rf ~/.mcp-auth
+```
+
+Then retry the connection.
+
+### Node.js version issues
+
+The `mcp-remote` proxy requires a recent Node.js version. Update Node.js if you encounter errors with the npx-based configurations.
+
+### MCP server not responding
+
+Verify the endpoint is reachable:
+
+```bash
+curl -I https://mcp.linear.app/mcp
+```
+
+Expected: HTTP 401 (requires authentication). If you get a network error, check your internet connection and any proxy settings.
+
+### OAuth flow does not open browser
+
+Ensure your default browser is set and accessible. In headless environments, use the Bearer token fallback instead.
+
+## OAuth Endpoints
+
+For custom integrations or debugging:
+
+| Endpoint | URL |
+|----------|-----|
+| Authorization | `https://mcp.linear.app/authorize` |
+| Token | `https://mcp.linear.app/token` |
+| Registration | `https://mcp.linear.app/register` |
+| MCP (Streamable HTTP) | `https://mcp.linear.app/mcp` |
+| SSE (Legacy) | `https://mcp.linear.app/sse` |
+
+Supported grant types: `authorization_code`, `refresh_token`
+Code challenge methods: `plain`, `S256`

--- a/plugins/tools/linear/skills/linear/references/workflow-states.md
+++ b/plugins/tools/linear/skills/linear/references/workflow-states.md
@@ -1,0 +1,119 @@
+# Linear Workflow States and VantageEx Mapping
+
+## Linear State Types
+
+Linear workflow states have a `type` field that categorizes them:
+
+| Type | Meaning | Default States |
+|------|---------|---------------|
+| `triage` | Needs triage | Triage |
+| `backlog` | In backlog | Backlog |
+| `unstarted` | Ready but not started | Todo |
+| `started` | In progress | In Progress |
+| `completed` | Done | Done |
+| `canceled` | Cancelled | Canceled |
+
+Teams can create custom state names that map to these types. Always match on `type` for automation and use `name` for display.
+
+## VantageEx Status Workflow (ADR-025)
+
+Six user-facing statuses displayed as kanban columns:
+
+```
+Ready -> Up Next -> In Progress -> In Review -> Done -> Archived
+                        |
+                   Needs Help
+                        |
+                   Up Next (re-queued)
+```
+
+### Status Definitions
+
+| VantageEx | Meaning | Who Transitions | Next |
+|-----------|---------|-----------------|------|
+| `ready` | All required fields present. Backlog. | Linear poller or manual creation | User moves to `up_next` |
+| `up_next` | User approved for agent work. The gate. | User (dashboard or Linear) | Picker worker moves to `in_progress` |
+| `in_progress` | Agent assigned and actively working | EpicPickerWorker | Agent completes -> `review`, or fails -> `needs_help` |
+| `needs_help` | Agent exhausted 3 fix cycles. Summary stored in `last_failure_output`. | ValidateWorker | User re-queues to `up_next` with instructions |
+| `review` | CI passed, PR created. PR URL on epic. | PRWorker | User merges -> `complete` |
+| `complete` | PR merged, work done | User (post-merge) or webhook | Auto-archive or manual |
+| `archived` | Hidden from dashboard | User or auto | Terminal |
+
+### Internal Sub-States
+
+Displayed under "In Progress" on the kanban board:
+
+- `validating` — ValidateWorker running `mise run ci`
+- `fixing` — FixWorker running with escalated model
+- `paused` — User paused the validation-fix loop
+
+## Cross-System Mapping
+
+| VantageEx | Linear State | Bees | Dashboard Column |
+|-----------|-------------|------|-----------------|
+| `ready` | Backlog / Ready | open | Ready |
+| `up_next` | Up Next | open | Up Next |
+| `in_progress` | In Progress | in_progress | In Progress |
+| `validating` | In Progress | in_progress | In Progress |
+| `fixing` | In Progress | in_progress | In Progress |
+| `paused` | In Progress | in_progress | In Progress |
+| `needs_help` | Needs Help | open | Needs Help |
+| `review` | In Review | open | In Review |
+| `complete` | Done | closed | Done |
+| `archived` | Archived | closed | (hidden) |
+
+## Linear State Setup
+
+VantageEx requires custom workflow states in Linear that do not exist by default:
+
+- **Up Next** (type: `unstarted`) — the user-approval gate
+- **Needs Help** (type: `started`) — failure escalation
+
+Create these in Linear: Settings > Teams > [Team] > Workflow > Add State.
+
+## State Transitions
+
+### The Gate: Up Next
+
+The `EpicPickerWorker` (Oban cron, every 60 seconds):
+
+1. Query: any epic with status = `up_next`?
+2. Query: any epic with status in (`in_progress`, `validating`, `fixing`)?
+3. If `up_next` exists AND nothing in progress: pick oldest, set to `in_progress`
+4. Otherwise: do nothing
+
+Only user-approved epics get worked. Only 1 epic at a time.
+
+### Needs Help Flow
+
+1. FixWorker fails on cycle 3 (opus model)
+2. ValidateWorker sets status = `needs_help`
+3. Summary written to `last_failure_output` (what failed, what was attempted, which models used, root cause assessment)
+4. PubSub broadcasts update to dashboard
+5. User reads summary, edits epic, moves to `up_next` with `## Instructions`
+
+### Re-Queue with Instructions (ADR-027)
+
+1. User provides guidance text in dashboard "Re-queue Guidance" field
+2. VantageEx writes `## Instructions` to Linear description
+3. VantageEx sets `epic.user_instructions` field
+4. Epic moved from `needs_help` to `up_next`
+5. New agent receives `EPIC_INSTRUCTIONS` env var
+
+### Querying States for Transitions
+
+Always fetch the exact `stateId` before transitioning:
+
+```graphql
+query IssueTeamStates($id: String!) {
+  issue(id: $id) {
+    team {
+      states {
+        nodes { id name type }
+      }
+    }
+  }
+}
+```
+
+Match by `name` to find the target state, then use the `id` in the `issueUpdate` mutation. Never hardcode state IDs — they vary per team.

--- a/plugins/tools/linear/skills/linear/scripts/0.1.0/linear.nu
+++ b/plugins/tools/linear/skills/linear/scripts/0.1.0/linear.nu
@@ -1,0 +1,185 @@
+#!/usr/bin/env nu
+
+# Linear GraphQL API client for Nushell
+# Fallback for environments where MCP is unavailable.
+# Requires: LINEAR_API_KEY environment variable
+
+const LINEAR_API = "https://api.linear.app/graphql"
+
+# Execute a GraphQL query against the Linear API
+def graphql [query: string, variables: record = {}] {
+  let api_key = ($env | get -o LINEAR_API_KEY | default "")
+  if ($api_key | is-empty) {
+    error make {
+      msg: "LINEAR_API_KEY not set. Generate a key at Linear > Settings > API > Personal API Keys"
+    }
+  }
+
+  let body = { query: $query, variables: $variables } | to json
+
+  let response = (
+    http post $LINEAR_API
+      --content-type "application/json"
+      --headers ["Authorization" $"Bearer ($api_key)"]
+      $body
+  )
+
+  if ($response | get -o errors | default [] | length) > 0 {
+    let errs = ($response.errors | each { |e| $e.message } | str join ", ")
+    error make { msg: $"GraphQL error: ($errs)" }
+  }
+
+  $response.data
+}
+
+# Test API connectivity
+def "linear health" [] {
+  let data = (graphql "{ viewer { id name email } }")
+  print $"Connected as: ($data.viewer.name) <($data.viewer.email)>"
+  $data.viewer
+}
+
+# List issues in a project
+def "linear issues" [
+  project_id: string    # Linear project ID
+  --state: string = ""  # Filter by state type (e.g., "started", "unstarted")
+  --limit: int = 50     # Max results
+] {
+  mut filter = $"project: { id: { eq: \"($project_id)\" } }"
+  if ($state | is-not-empty) {
+    $filter = $"($filter), state: { type: { eq: \"($state)\" } }"
+  }
+
+  let query = $"query { issues\(filter: { ($filter) }, first: ($limit), orderBy: updatedAt\) { nodes { id identifier title url state { name type } labels { nodes { name } } description } pageInfo { hasNextPage endCursor } } }"
+
+  let data = (graphql $query)
+  $data.issues.nodes
+}
+
+# Get a single issue by key (e.g., MT-686)
+def "linear issue" [key: string] {
+  let query = 'query($key: String!) { issue(id: $key) { id identifier title url description state { id name type } project { id name } team { id key name } labels { nodes { id name } } branchName attachments { nodes { id title url sourceType } } comments { nodes { id body createdAt user { name } } } updatedAt } }'
+
+  let data = (graphql $query { key: $key })
+  $data.issue
+}
+
+# Create an issue
+def "linear create-issue" [
+  title: string          # Issue title
+  --team-id: string      # Team ID (required)
+  --description: string = ""  # Issue description (markdown)
+  --state-id: string = ""     # Initial state ID
+  --project-id: string = ""   # Project ID
+  --label-ids: list<string> = []  # Label IDs
+] {
+  mut input = $"teamId: \"($team_id)\", title: \"($title)\""
+  if ($description | is-not-empty) {
+    let desc_escaped = ($description | str replace --all '"' '\"')
+    $input = $"($input), description: \"($desc_escaped)\""
+  }
+  if ($state_id | is-not-empty) {
+    $input = $"($input), stateId: \"($state_id)\""
+  }
+  if ($project_id | is-not-empty) {
+    $input = $"($input), projectId: \"($project_id)\""
+  }
+  if ($label_ids | length) > 0 {
+    let ids = ($label_ids | each { |id| $"\"($id)\"" } | str join ", ")
+    $input = $"($input), labelIds: [($ids)]"
+  }
+
+  let query = $"mutation { issueCreate\(input: { ($input) }\) { success issue { id identifier url title } } }"
+
+  let data = (graphql $query)
+  if $data.issueCreate.success {
+    print $"Created: ($data.issueCreate.issue.identifier) - ($data.issueCreate.issue.url)"
+  }
+  $data.issueCreate.issue
+}
+
+# Update an issue
+def "linear update-issue" [
+  id: string             # Issue ID
+  --state-id: string = ""     # New state ID
+  --description: string = ""  # New description
+  --title: string = ""        # New title
+] {
+  mut input = ""
+  if ($state_id | is-not-empty) {
+    $input = $"stateId: \"($state_id)\""
+  }
+  if ($description | is-not-empty) {
+    let desc_escaped = ($description | str replace --all '"' '\"')
+    if ($input | is-not-empty) { $input = $"($input), " }
+    $input = $"($input)description: \"($desc_escaped)\""
+  }
+  if ($title | is-not-empty) {
+    if ($input | is-not-empty) { $input = $"($input), " }
+    $input = $"($input)title: \"($title)\""
+  }
+
+  if ($input | is-empty) {
+    error make { msg: "No update fields provided. Use --state-id, --description, or --title." }
+  }
+
+  let query = $"mutation { issueUpdate\(id: \"($id)\", input: { ($input) }\) { success issue { id identifier state { name } } } }"
+
+  let data = (graphql $query)
+  $data.issueUpdate.issue
+}
+
+# List workflow states for a team
+def "linear states" [team_id: string] {
+  let query = 'query($teamId: String!) { team(id: $teamId) { states { nodes { id name type position } } } }'
+
+  let data = (graphql $query { teamId: $team_id })
+  $data.team.states.nodes | sort-by position
+}
+
+# Add a comment to an issue
+def "linear comment" [
+  issue_id: string  # Issue ID
+  body: string      # Comment body (markdown)
+] {
+  let query = 'mutation($issueId: String!, $body: String!) { commentCreate(input: { issueId: $issueId, body: $body }) { success comment { id url } } }'
+
+  let data = (graphql $query { issueId: $issue_id, body: $body })
+  if $data.commentCreate.success {
+    print $"Comment created: ($data.commentCreate.comment.url)"
+  }
+  $data.commentCreate.comment
+}
+
+# Attach a GitHub PR URL to an issue
+def "linear attach-pr" [
+  issue_id: string  # Issue ID
+  pr_url: string    # GitHub PR URL
+  --title: string = ""  # Attachment title
+] {
+  mut vars = { issueId: $issue_id, url: $pr_url }
+  if ($title | is-not-empty) {
+    $vars = ($vars | merge { title: $title })
+  }
+
+  let query = 'mutation($issueId: String!, $url: String!, $title: String) { attachmentLinkGitHubPR(issueId: $issueId, url: $url, title: $title, linkKind: links) { success attachment { id title url } } }'
+
+  let data = (graphql $query $vars)
+  if $data.attachmentLinkGitHubPR.success {
+    print $"PR attached: ($pr_url)"
+  }
+  $data.attachmentLinkGitHubPR.attachment
+}
+
+# List teams
+def "linear teams" [] {
+  let data = (graphql "{ teams { nodes { id key name } } }")
+  $data.teams.nodes
+}
+
+# List projects
+def "linear projects" [--limit: int = 50] {
+  let query = $"{ projects\(first: ($limit)\) { nodes { id name slugId state } } }"
+  let data = (graphql $query)
+  $data.projects.nodes
+}

--- a/plugins/tools/linear/skills/linear/templates/0.1.0/audit-report.md
+++ b/plugins/tools/linear/skills/linear/templates/0.1.0/audit-report.md
@@ -1,0 +1,49 @@
+# Epic Audit Report
+
+**Generated**: [DATE]
+**Project**: [PROJECT-SLUG]
+**Issues Audited**: [COUNT]
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Error    | [N]   |
+| Warning  | [N]   |
+| Info     | [N]   |
+| Pass     | [N]   |
+
+## Findings
+
+### [ISSUE-IDENTIFIER]: [TITLE]
+
+**Status**: [LINEAR-STATE]
+**URL**: [LINEAR-URL]
+
+| Check | Severity | Status | Detail |
+|-------|----------|--------|--------|
+| Objective present | error | pass/fail | |
+| Objective quality | warning | pass/fail | |
+| Skills present | error | pass/fail | |
+| Skills valid | warning | pass/fail | Unknown: [list] |
+| Skills not listing core | info | pass/fail | Core listed: [list] |
+| Repos present | error | pass/fail | |
+| Team defined | warning | pass/fail | |
+| PR on completed | error | pass/fail/n-a | |
+| Branch convention | warning | pass/fail/n-a | |
+| No implementation details | warning | pass/fail | |
+
+**Remediation**:
+- [Action item 1]
+- [Action item 2]
+
+---
+
+> Repeat the findings section for each audited issue.
+> Sort issues by number of errors (most errors first).
+
+## Next Steps
+
+1. Run `/linear:groom-epics` to fix errors and warnings automatically
+2. Review info-level findings manually
+3. Re-run `/linear:audit-epics` to verify fixes

--- a/plugins/tools/linear/skills/linear/templates/0.1.0/epic.md
+++ b/plugins/tools/linear/skills/linear/templates/0.1.0/epic.md
@@ -1,0 +1,73 @@
+# Epic: [TITLE]
+
+> A clear, imperative statement of what gets built.
+> - Good: "Implement OAuth2 PKCE flow for API gateway"
+> - Bad: "Auth stuff" / "Fix login"
+
+## Slug
+
+> Short, URL-safe identifier. kebab-case, max ~30 chars.
+> Used in branch names: `feature/<slug>`
+
+```
+slug: [epic-slug]
+```
+
+## Objective
+
+> 2-3 sentences. What does success look like?
+> The team leader uses this to validate completion and decompose into issues.
+
+[Write objective here]
+
+## Skills
+
+> Domain-specific skills only.
+> Core skills (anti-fabrication, git, tdd, twelve-factor, security, mise, nushell) are always loaded.
+
+```yaml
+skills: [skill-1, skill-2]
+```
+
+## Repos
+
+> Target repositories this epic touches.
+
+- org/repo-name
+
+## Constraints (Optional)
+
+> Real boundaries only. Defaults apply if omitted:
+> mise run ci, no attribution, squash merge, feature/<slug> branch.
+
+```yaml
+constraints:
+  - Constraint 1
+  - Constraint 2
+```
+
+## Team (Optional)
+
+> Team composition. Inferred from epic complexity if omitted.
+
+```yaml
+team:
+  lead: sonnet
+  default_model: haiku
+  escalation: haiku -> sonnet -> opus
+```
+
+## Escalation (Optional)
+
+> Failure and ambiguity policies.
+
+```yaml
+escalation:
+  on_agent_failure: promote_model
+  on_ambiguity: ask_user
+```
+
+---
+
+> **That's it.** The team leader handles decomposition into issues and task assignment.
+> Do not add acceptance criteria, implementation steps, file paths, or model assignments per task.

--- a/plugins/tools/linear/skills/linear/templates/0.1.0/team-definition.md
+++ b/plugins/tools/linear/skills/linear/templates/0.1.0/team-definition.md
@@ -1,0 +1,53 @@
+# Team Definition Template
+
+Add this as the `## Team` section in a VantageEx epic description.
+
+## Minimal (Recommended Default)
+
+```yaml
+team:
+  lead: sonnet
+  default_model: haiku
+  escalation: haiku -> sonnet -> opus
+```
+
+## With Role-Based Workers
+
+```yaml
+team:
+  lead: sonnet
+  default_model: haiku
+  escalation: haiku -> sonnet -> opus
+  workers:
+    - role: implementation
+      skills: [elixir, phoenix]
+      model: haiku
+    - role: validation
+      skills: [tdd, security]
+      model: haiku
+    - role: documentation
+      skills: [documentation]
+      model: haiku
+```
+
+## With Custom Escalation
+
+```yaml
+team:
+  lead: sonnet
+  default_model: haiku
+  escalation: haiku -> sonnet -> opus
+
+escalation:
+  on_agent_failure: promote_model
+  on_ambiguity: ask_user
+  on_dependency_conflict: ask_user
+```
+
+## Guidelines
+
+- **lead**: Use `sonnet` for most epics. Use `opus` only for architecturally complex work.
+- **default_model**: Start with `haiku`. The escalation policy promotes on failure.
+- **escalation**: Standard is `haiku -> sonnet -> opus` with max 2 promotions per agent.
+- **workers**: Optional. The team leader assigns roles during decomposition if omitted.
+- **skills**: Per-worker skills are in addition to the epic's skill list.

--- a/plugins/tools/linear/skills/sources.md
+++ b/plugins/tools/linear/skills/sources.md
@@ -1,0 +1,54 @@
+# Linear Plugin Sources
+
+## Linear Skill
+
+### Linear MCP Documentation
+- **URL**: https://linear.app/docs/mcp
+- **Purpose**: MCP server setup, OAuth flow, client configurations
+- **Key Topics**: Streamable HTTP transport, OAuth 2.1, Claude Code integration
+- **Date Accessed**: 2026-04-04
+
+### Linear GraphQL API Documentation
+- **URL**: https://developers.linear.app/docs/graphql/working-with-the-graphql-api
+- **Purpose**: GraphQL API reference for fallback operations
+- **Key Topics**: Authentication, queries, mutations, pagination, introspection
+
+### Symphony Linear Skill
+- **Path**: ~/github/symphony/.codex/skills/linear/SKILL.md
+- **Purpose**: Existing Linear GraphQL skill with query patterns
+- **Key Topics**: Issue queries, state transitions, comments, attachments, introspection
+
+### VantageEx Linear Client
+- **Path**: ~/github/vantageex/lib/vantageex/linear/client.ex
+- **Purpose**: Production Linear GraphQL client implementation
+- **Key Topics**: Issue polling, state management, description parsing
+
+### VantageEx ADR-027: Epic Messaging
+- **Path**: ~/github/vantage_ex/architecture/decisions/027-epic-messaging.md
+- **Purpose**: Description sections and comment channels specification
+- **Key Topics**: Instructions section, PR section, comment polling, re-queue flow
+
+### VantageEx ADR-025: Epic Lifecycle and Status Workflow
+- **Path**: ~/github/vantage_ex/architecture/decisions/025-epic-lifecycle-and-status-workflow.md
+- **Purpose**: Status workflow and kanban gating
+- **Key Topics**: ready/up_next/in_progress/needs_help/review/complete/archived states
+
+### VantageEx ADR-016: Layered Tasking Structure
+- **Path**: ~/github/vantage_ex/architecture/decisions/016-layered-tasking-structure.md
+- **Purpose**: Three-level hierarchy (Epic -> Issue -> Task)
+- **Key Topics**: Decomposition model, responsibility boundaries
+
+### VantageEx Epic Authoring Guide
+- **Path**: ~/github/vantage_ex/architecture/prompts/EPIC-AUTHORING.md
+- **Purpose**: User guide for writing machine-executable epics
+- **Key Topics**: Required fields, optional fields, anti-patterns
+
+### VantageEx Epic Template
+- **Path**: ~/github/vantage_ex/epics/TEMPLATE.md
+- **Purpose**: Epic description template with field definitions
+- **Key Topics**: Title, slug, objective, skills, constraints
+
+### CLAUDE.md Template
+- **Path**: ~/github/claude-skills/plugins/tools/claude-code/templates/CLAUDE.md
+- **Purpose**: Standard project workflow template (4-phase)
+- **Key Topics**: Pre-flight checks, working items, validation, submit loop


### PR DESCRIPTION
- Add linear plugin at plugins/tools/linear/ (v0.1.0)
- SKILL.md with MCP setup, GraphQL API, VantageEx epic format, workflow states
- References: mcp-setup, graphql-api, epic-format (ADR-027/016/025), audit-checklist, workflow-states
- Templates: epic description, audit report, team definition (versioned 0.1.0)
- Nushell GraphQL client script with 10 commands (health, issues, create, update, states, comments, attach-pr)
- Commands: plan-epic, audit-epics, groom-epics
- Register in marketplace.json, update all-skills to 0.3.25