### PR TITLE
feat(playwright): add playwright MCP browser automation skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "A curated collection of Claude skills for development workflows",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "plugins": [
     {
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.25",
+      "version": "0.3.26",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -71,6 +71,16 @@
       "version": "0.1.0",
       "category": "tools",
       "keywords": ["linear", "project-management", "epics", "graphql", "vantageex", "mcp"],
+      "license": "MIT"
+    },
+    {
+      "name": "playwright",
+      "source": "./plugins/tools/playwright",
+      "strict": true,
+      "description": "Playwright MCP browser automation for Claude Code",
+      "version": "0.1.0",
+      "category": "tools",
+      "keywords": ["playwright", "mcp", "browser", "automation", "screenshots"],
       "license": "MIT"
     },
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -58,6 +58,7 @@
     "./plugins/tools/github/skills/act",
     "./plugins/tools/github/skills/community-health",
     "./plugins/tools/linear/skills/linear",
+    "./plugins/tools/playwright/skills/playwright",
     "./plugins/tools/runex/skills/runex",
     "./plugins/languages/rust/skills/rust",
     "./plugins/languages/rust/skills/ownership",

--- a/plugins/tools/playwright/.claude-plugin/plugin.json
+++ b/plugins/tools/playwright/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "playwright",
+  "version": "0.1.0",
+  "description": "Playwright MCP browser automation for Claude Code",
+  "author": {
+    "name": "vinnie357"
+  },
+  "repository": "https://github.com/vinnie357/claude-skills",
+  "license": "MIT",
+  "keywords": ["playwright", "mcp", "browser", "automation", "screenshots"],
+  "skills": [
+    "./skills/playwright"
+  ]
+}

--- a/plugins/tools/playwright/skills/playwright/SKILL.md
+++ b/plugins/tools/playwright/skills/playwright/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: playwright
+description: "Playwright MCP server for Claude Code browser automation. Use when configuring Playwright MCP, automating browser interactions, taking screenshots, researching web content blocked by non-browser clients, testing web UI locally, or navigating web pages from Claude Code sessions."
+license: MIT
+---
+
+# Playwright MCP
+
+The Playwright MCP server gives Claude Code agents direct browser control through 50+ tools that operate on the accessibility tree rather than screenshots. This enables fast, structured web interaction — navigating pages, clicking elements, filling forms, extracting content, and taking screenshots — without requiring vision models.
+
+## When to Use
+
+Activate when:
+- Installing or configuring the Playwright MCP server for Claude Code
+- Browsing websites that reject non-browser HTTP clients (curl/wget blocked)
+- Taking screenshots of web applications or local dev servers
+- Automating browser interactions (clicking, typing, form submission)
+- Running local web UI tests through browser automation
+- Inspecting or extracting content from rendered web pages
+- Managing browser tabs, dialogs, or file uploads in automation workflows
+
+## Installation
+
+### Claude Code (recommended)
+
+```bash
+# Default: bunx (preferred)
+claude mcp add playwright -- bunx @playwright/mcp@latest
+
+# Fallback: npx
+claude mcp add playwright -- npx @playwright/mcp@latest
+```
+
+Verify the MCP server is connected by running `/mcp` in a Claude Code session.
+
+### Runtime Requirement
+
+Bun or Node.js 18+ must be available. Add to your project or global `mise.toml`:
+
+```toml
+[tools]
+bun = "latest"
+```
+
+See `templates/mise.toml` for the full template.
+
+## Configuration
+
+### Global (all sessions)
+
+Add to `~/.claude.json` to make Playwright available in every Claude Code session:
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "bunx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}
+```
+
+### Per-Project
+
+Add to `.mcp.json` in the project root for project-scoped configuration:
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "bunx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}
+```
+
+### Configuration Flags
+
+Pass flags after the package name in the `args` array or on the CLI:
+
+```bash
+claude mcp add playwright -- bunx @playwright/mcp@latest --headless --browser chromium
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--browser` | `chrome` | Browser engine: chrome, firefox, webkit, msedge |
+| `--headless` | off (headed) | Run without visible browser window |
+| `--allowed-origins` | none | Semicolon-separated trusted origins |
+| `--blocked-origins` | none | Semicolon-separated blocked origins |
+| `--proxy-server` | none | HTTP proxy (e.g., `http://proxy:3128`) |
+| `--viewport-size` | browser default | Window size (e.g., `1280x720`) |
+| `--device` | none | Emulate device (e.g., `iPhone 15`) |
+| `--timeout-action` | `5000` | Action timeout in ms |
+| `--timeout-navigation` | `60000` | Navigation timeout in ms |
+| `--user-data-dir` | none | Persistent browser profile path |
+| `--isolated` | off | Use in-memory profile only |
+| `--storage-state` | none | Load saved session state (cookies, localStorage) |
+| `--caps` | core only | Enable optional capabilities (see below) |
+| `--config` | none | Path to configuration file |
+| `--cdp-endpoint` | none | Connect to existing Chrome DevTools Protocol |
+
+All flags support environment variable alternatives (e.g., `PLAYWRIGHT_MCP_HEADLESS=true`).
+
+## Capabilities
+
+The MCP server provides core tools by default. Enable additional capabilities with `--caps`:
+
+```bash
+claude mcp add playwright -- bunx @playwright/mcp@latest --caps "network,vision,pdf,testing"
+```
+
+| Capability | Flag | Description |
+|------------|------|-------------|
+| **Core** | always on | Navigation, clicking, typing, snapshots, screenshots, tabs, dialogs |
+| **Network** | `network` | Monitor requests, set up routes, intercept traffic |
+| **Storage** | `storage` | Cookie/localStorage/sessionStorage CRUD, save/restore state |
+| **DevTools** | `devtools` | Tracing, video recording, console access |
+| **Vision** | `vision` | Coordinate-based mouse interaction (click/move/drag by x,y) |
+| **PDF** | `pdf` | Save pages as PDF files |
+| **Testing** | `testing` | Locator generation, element/text/value assertions |
+
+### JSON Configuration with Capabilities
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "bunx",
+      "args": [
+        "@playwright/mcp@latest",
+        "--headless",
+        "--caps",
+        "network,vision,pdf,testing"
+      ]
+    }
+  }
+}
+```
+
+## Common Use Cases
+
+### Web Research
+
+Navigate to a URL and extract content when curl or fetch would be blocked:
+
+```
+Use browser_navigate to go to the URL, then browser_snapshot to read the page content.
+```
+
+### Screenshot Capture
+
+Take screenshots of web applications or local dev servers:
+
+```
+Use browser_navigate to the target URL, then browser_take_screenshot to capture the page.
+For local dev servers, navigate to http://localhost:<port>.
+```
+
+### Form Automation
+
+Automate login flows, data entry, or form submission:
+
+```
+Use browser_snapshot to identify form elements, browser_click to focus inputs,
+browser_type to enter values, then browser_click to submit.
+```
+
+### Local Dev Testing
+
+Connect to a running local development server for UI verification:
+
+```
+Navigate to http://localhost:3000 (or your dev server port).
+Use browser_snapshot to inspect the rendered page structure.
+Use testing capability tools for assertions (requires --caps testing).
+```
+
+## Tool Categories
+
+Core tools are always available. Optional tools require `--caps` flags.
+
+| Category | Representative Tools | Capability |
+|----------|---------------------|------------|
+| **Navigation** | `browser_navigate`, `browser_navigate_back`, `browser_navigate_forward` | core |
+| **Interaction** | `browser_click`, `browser_type`, `browser_select_option`, `browser_hover`, `browser_drag` | core |
+| **Input** | `browser_press_key`, `browser_file_upload`, `browser_handle_dialog` | core |
+| **Inspection** | `browser_snapshot`, `browser_take_screenshot`, `browser_console_messages` | core |
+| **JavaScript** | `browser_evaluate` | core |
+| **Tabs** | `browser_tab_new`, `browser_tab_list`, `browser_tab_select`, `browser_tab_close` | core |
+| **Page** | `browser_resize`, `browser_wait_for`, `browser_close` | core |
+| **Network** | `browser_network_requests`, `browser_route`, `browser_unroute` | network |
+| **Storage** | cookie/localStorage/sessionStorage CRUD, `browser_storage_state` | storage |
+| **DevTools** | `browser_start_tracing`, `browser_stop_tracing`, `browser_start_video`, `browser_stop_video` | devtools |
+| **Vision** | `browser_mouse_click_xy`, `browser_mouse_move_xy`, `browser_mouse_drag_xy` | vision |
+| **PDF** | `browser_pdf_save` | pdf |
+| **Testing** | `browser_generate_locator`, `browser_verify_element_visible`, `browser_verify_text_visible` | testing |
+
+For the full tool catalog with parameters and descriptions, see `references/tools-reference.md`.
+
+## Troubleshooting
+
+### Browser Not Launching
+
+- Verify bun or node is available: `bun --version` or `node --version`
+- Try `--headless` flag for environments without a display
+- Check if Playwright browsers are installed: `bunx playwright install chromium`
+
+### Connection Issues
+
+- Run `/mcp` in Claude Code to verify the server is listed and connected
+- Check the MCP server logs for errors
+- Ensure the command path is correct in your configuration
+
+### Localhost Access
+
+- Use `--allowed-origins` to explicitly allow localhost: `--allowed-origins "http://localhost:*"`
+- Verify the dev server is running before navigating
+
+### Timeouts
+
+- Increase `--timeout-navigation` for slow-loading pages (default: 60000ms)
+- Increase `--timeout-action` for slow element interactions (default: 5000ms)
+
+### Vision Mode vs Structured Mode
+
+- Default structured mode uses accessibility tree (faster, deterministic)
+- Vision mode (`--caps vision`) adds coordinate-based interaction for elements not in the accessibility tree
+- Prefer structured mode; use vision only when selectors are insufficient
+
+## Anti-Fabrication
+
+- Verify MCP connection status with `/mcp` before claiming Playwright tools are available
+- Do not assume browser capabilities without checking `--caps` configuration
+- Report actual page content from `browser_snapshot` output, not expected content
+- When reporting test results from testing capability tools, include actual pass/fail output
+- Reference `core:anti-fabrication` for full validation requirements
+
+## Usage Rules
+
+- Prefer `--headless` for CI, automated contexts, and agent workflows
+- Use `--allowed-origins` to restrict navigation scope when working with sensitive applications
+- Use vision capability only when structured selectors are insufficient
+- Verify MCP connection with `/mcp` before attempting browser operations
+- Use `browser_snapshot` (accessibility tree) over `browser_take_screenshot` (image) when extracting text content
+- Close browser sessions when done to free resources
+- For persistent auth, use `--storage-state` to save and restore session cookies

--- a/plugins/tools/playwright/skills/playwright/references/tools-reference.md
+++ b/plugins/tools/playwright/skills/playwright/references/tools-reference.md
@@ -1,0 +1,155 @@
+# Playwright MCP Tools Reference
+
+Full catalog of tools provided by the Playwright MCP server, organized by category. Core tools are always available. Optional tools require the `--caps` flag.
+
+## Table of Contents
+
+- [Navigation](#navigation)
+- [Interaction](#interaction)
+- [Input](#input)
+- [Inspection](#inspection)
+- [JavaScript](#javascript)
+- [Tabs](#tabs)
+- [Page Control](#page-control)
+- [Network (--caps network)](#network)
+- [Storage (--caps storage)](#storage)
+- [DevTools (--caps devtools)](#devtools)
+- [Vision (--caps vision)](#vision)
+- [PDF (--caps pdf)](#pdf)
+- [Testing (--caps testing)](#testing)
+
+---
+
+## Navigation
+
+| Tool | Description |
+|------|-------------|
+| `browser_navigate` | Navigate to a URL. Parameters: `url` (required). |
+| `browser_navigate_back` | Go back to the previous page in history. |
+| `browser_navigate_forward` | Go forward to the next page in history. |
+
+## Interaction
+
+| Tool | Description |
+|------|-------------|
+| `browser_click` | Click an element on the page. Parameters: `element` (accessibility snapshot ref), `modifiers` (optional array of modifier keys). |
+| `browser_hover` | Hover over an element. Parameters: `element` (accessibility snapshot ref). |
+| `browser_drag` | Drag an element to a target location. Parameters: `startElement`, `endElement`. |
+| `browser_select_option` | Select an option from a dropdown. Parameters: `element`, `values` (array of values to select). |
+
+## Input
+
+| Tool | Description |
+|------|-------------|
+| `browser_type` | Type text into a focused element. Parameters: `text` (required), `submit` (optional, press Enter after typing). |
+| `browser_press_key` | Press a keyboard key or key combination. Parameters: `key` (e.g., `Enter`, `Control+c`, `ArrowDown`). |
+| `browser_file_upload` | Upload files to a file input. Parameters: `paths` (array of absolute file paths). |
+| `browser_handle_dialog` | Accept or dismiss a browser dialog (alert, confirm, prompt). Parameters: `accept` (boolean), `promptText` (optional). |
+
+## Inspection
+
+| Tool | Description |
+|------|-------------|
+| `browser_snapshot` | Capture the accessibility tree of the current page. Returns structured text representation of all visible elements with their refs. Primary tool for understanding page content. |
+| `browser_take_screenshot` | Take a screenshot of the current page. Returns a base64-encoded image. Use for visual verification. |
+| `browser_console_messages` | Retrieve console messages (log, warn, error) from the browser. |
+| `browser_network_requests` | List network requests made by the page. |
+
+## JavaScript
+
+| Tool | Description |
+|------|-------------|
+| `browser_evaluate` | Execute JavaScript in the browser context. Parameters: `expression` (JavaScript code to evaluate). Returns the result as JSON. |
+
+## Tabs
+
+| Tool | Description |
+|------|-------------|
+| `browser_tab_new` | Open a new browser tab. Parameters: `url` (optional, navigate to URL after opening). |
+| `browser_tab_list` | List all open browser tabs with their titles and URLs. |
+| `browser_tab_select` | Switch to a specific tab. Parameters: `index` (tab index from tab_list). |
+| `browser_tab_close` | Close a specific tab. Parameters: `index` (optional, closes current tab if omitted). |
+
+## Page Control
+
+| Tool | Description |
+|------|-------------|
+| `browser_close` | Close the browser and end the session. |
+| `browser_resize` | Resize the browser viewport. Parameters: `width`, `height`. |
+| `browser_wait_for` | Wait for a condition before proceeding. Parameters: `time` (ms to wait), `selector` (CSS selector to wait for), `state` (visible, hidden, attached, detached). |
+| `browser_install` | Install a browser engine for Playwright. Parameters: `browser` (chromium, firefox, webkit). |
+
+## Network
+
+Requires `--caps network`.
+
+| Tool | Description |
+|------|-------------|
+| `browser_network_state_set` | Enable or disable network. Parameters: `offline` (boolean). |
+| `browser_route` | Set up a route to intercept network requests. Parameters: `url` (URL pattern), `response` (mock response object). |
+| `browser_route_list` | List all active network routes. |
+| `browser_unroute` | Remove a previously set network route. Parameters: `url` (URL pattern to remove). |
+
+## Storage
+
+Requires `--caps storage`.
+
+| Tool | Description |
+|------|-------------|
+| `browser_cookies_get` | Get cookies for the current page or specified URLs. Parameters: `urls` (optional array). |
+| `browser_cookies_set` | Set cookies. Parameters: `cookies` (array of cookie objects with name, value, domain, path, etc.). |
+| `browser_cookies_clear` | Clear all cookies. Parameters: `domain` (optional, clear only for domain). |
+| `browser_cookies_delete` | Delete specific cookies. Parameters: `name`, `domain` (optional). |
+| `browser_local_storage_get` | Get localStorage values. Parameters: `key` (optional, returns all if omitted). |
+| `browser_local_storage_set` | Set a localStorage value. Parameters: `key`, `value`. |
+| `browser_local_storage_delete` | Delete a localStorage entry. Parameters: `key`. |
+| `browser_session_storage_get` | Get sessionStorage values. Parameters: `key` (optional). |
+| `browser_session_storage_set` | Set a sessionStorage value. Parameters: `key`, `value`. |
+| `browser_session_storage_delete` | Delete a sessionStorage entry. Parameters: `key`. |
+| `browser_storage_state` | Get the full storage state (cookies + localStorage) for saving. |
+| `browser_set_storage_state` | Restore a previously saved storage state. Parameters: `state` (storage state object). |
+
+## DevTools
+
+Requires `--caps devtools`.
+
+| Tool | Description |
+|------|-------------|
+| `browser_start_tracing` | Start collecting a performance trace. Parameters: `name` (optional trace name). |
+| `browser_stop_tracing` | Stop tracing and return the trace data. |
+| `browser_start_video` | Start recording a video of the browser. Parameters: `dir` (output directory). |
+| `browser_stop_video` | Stop video recording. Returns the video file path. |
+| `browser_video_chapter` | Add a chapter marker to the current video. Parameters: `title`. |
+| `browser_resume` | Resume page execution after pausing (e.g., after a breakpoint). |
+
+## Vision
+
+Requires `--caps vision`. Uses pixel coordinates instead of accessibility tree refs.
+
+| Tool | Description |
+|------|-------------|
+| `browser_mouse_click_xy` | Click at specific coordinates. Parameters: `x`, `y`, `button` (left, right, middle). |
+| `browser_mouse_move_xy` | Move mouse to coordinates. Parameters: `x`, `y`. |
+| `browser_mouse_drag_xy` | Drag from one coordinate to another. Parameters: `startX`, `startY`, `endX`, `endY`. |
+| `browser_mouse_button` | Press or release a mouse button. Parameters: `button`, `action` (press, release). |
+| `browser_mouse_wheel` | Scroll the mouse wheel. Parameters: `deltaX`, `deltaY`. |
+
+## PDF
+
+Requires `--caps pdf`.
+
+| Tool | Description |
+|------|-------------|
+| `browser_pdf_save` | Save the current page as a PDF file. Parameters: `path` (output file path), `format` (e.g., A4, Letter), `landscape` (boolean). |
+
+## Testing
+
+Requires `--caps testing`. Tools for generating locators and verifying page state.
+
+| Tool | Description |
+|------|-------------|
+| `browser_generate_locator` | Generate a Playwright locator for an element. Parameters: `element` (accessibility snapshot ref). Returns a locator string. |
+| `browser_verify_element_visible` | Assert that an element matching a locator is visible. Parameters: `locator` (Playwright locator string). |
+| `browser_verify_text_visible` | Assert that specific text is visible on the page. Parameters: `text`, `locator` (optional, scope to element). |
+| `browser_verify_list_visible` | Assert that a list of text values are all visible. Parameters: `expected` (array of strings), `locator` (optional). |
+| `browser_verify_value` | Assert that an input has a specific value. Parameters: `locator`, `value` (expected value). |

--- a/plugins/tools/playwright/skills/playwright/templates/mise.toml
+++ b/plugins/tools/playwright/skills/playwright/templates/mise.toml
@@ -1,0 +1,7 @@
+# Playwright MCP development environment
+# Copy to your project's mise.toml or ~/mise.toml
+
+[tools]
+bun = "latest"
+# Fallback: use node if bun is not preferred
+# node = "22"

--- a/plugins/tools/playwright/skills/sources.md
+++ b/plugins/tools/playwright/skills/sources.md
@@ -1,0 +1,26 @@
+# Playwright Plugin Sources
+
+## playwright skill
+
+### Playwright MCP GitHub Repository
+- **URL**: https://github.com/microsoft/playwright-mcp
+- **Purpose**: Official MCP server documentation, tool catalog, configuration options
+- **Key Topics**: Installation, capabilities, tool reference, configuration flags
+- **Date Accessed**: 2026-04-04
+
+### Playwright MCP npm Package
+- **URL**: https://www.npmjs.com/package/@playwright/mcp
+- **Purpose**: Version tracking and release notes
+- **Key Topics**: Latest version, changelog
+
+### Claude Code MCP Documentation
+- **URL**: https://docs.anthropic.com/en/docs/claude-code/mcp
+- **Purpose**: Claude Code MCP server configuration patterns
+- **Key Topics**: claude mcp add, ~/.claude.json, per-project config
+
+## Plugin Information
+- **Name**: playwright
+- **Version**: 0.1.0
+- **Description**: Playwright MCP browser automation for Claude Code
+- **Skills**: 1 skill
+- **Created**: 2026-04-04


### PR DESCRIPTION
- Add new plugins/tools/playwright plugin with single playwright skill
- SKILL.md covers installation (bunx default), configuration (global/per-project), capabilities, common use cases, troubleshooting
- References doc with full 50+ tool catalog organized by category
- Template mise.toml for bun runtime
- Sources documented
- Scores 11/11 on skill quality validation
- Marketplace version bumped to 1.0.4, all-skills to 0.3.26