### PR TITLE
feat(claude-code): add claude-output-styles skill with response-contract assets

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.28",
+      "version": "0.3.29",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -33,9 +33,9 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills: plugin marketplace management and validation",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "category": "tools",
-      "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark", "skill-update"]
+      "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark", "skill-update", "output-styles"]
     },
     {
       "name": "core",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -26,6 +26,7 @@
     "./plugins/tools/claude-code/skills/claude-skills",
     "./plugins/tools/claude-code/skills/claude-hooks",
     "./plugins/tools/claude-code/skills/claude-teams",
+    "./plugins/tools/claude-code/skills/claude-output-styles",
     "./plugins/tools/claude-code/skills/claude-skills-benchmark",
     "./plugins/tools/claude-code/skills/skill-update",
     "./plugins/core/skills/git",

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "claude-code",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["claude-code", "marketplace", "validation", "plugin-management", "commands", "agents", "skills", "hooks", "teams"],
+  "keywords": ["claude-code", "marketplace", "validation", "plugin-management", "commands", "agents", "skills", "hooks", "teams", "output-styles"],
   "skills": [
     "./skills/plugin-marketplace",
     "./skills/claude-plugins",
@@ -16,6 +16,7 @@
     "./skills/claude-skills",
     "./skills/claude-hooks",
     "./skills/claude-teams",
+    "./skills/claude-output-styles",
     "./skills/claude-skills-benchmark",
     "./skills/skill-update"
   ]

--- a/plugins/tools/claude-code/skills/claude-output-styles/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-output-styles/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: claude-output-styles
+description: Guide for creating Claude Code output styles and reusable response-format contracts. Use when creating, shipping, or customizing an output style for a session; defining the response shape an agent, command, or team worker must produce; standardizing worker reports so a team lead can parse them; or deciding between an output style, a skill, and a CLAUDE.md entry.
+license: MIT
+---
+
+# Claude Code Output Styles
+
+Guide for the native Claude Code output style feature and for applying the same response-contract pattern to agents, slash commands, teams, and skills.
+
+## When to Use This Skill
+
+Activate this skill when:
+
+- Creating a custom output style for a session or plugin
+- Shipping output styles from a plugin via the `output-styles/` directory
+- Deciding whether a need is best served by an output style, a skill, CLAUDE.md, or `--append-system-prompt`
+- Standardizing the response shape a worker agent must return so a team lead can filter and parse it
+- Writing reusable response-format contracts that multiple agents, commands, or skills reference
+- Debugging why a subagent is not honoring the session's output style
+
+## Two Things This Skill Covers
+
+1. **The Claude Code feature**: a session-level system prompt modification selected via `/config`, shipped as Markdown files, optionally bundled in plugins.
+2. **The pattern**: a reusable *response-format contract* authored once and referenced from agents, commands, teams, or skills when consistent, parseable output is needed.
+
+The feature affects the main agent loop only. The pattern is portable to anywhere a system prompt or instruction block is authored.
+
+## Part 1: The Claude Code Feature
+
+### What Output Styles Do
+
+Output styles modify Claude Code's system prompt at session start. They can:
+
+- Replace the default software-engineering instructions with a different role/tone/format
+- Preserve core capabilities (file I/O, running scripts, TODO tracking)
+- Keep or remove coding-specific instructions via `keep-coding-instructions`
+
+Output styles are **always active** once selected, for the whole session. They are set at session start — changes take effect next session so prompt caching stays stable.
+
+### Built-In Styles
+
+| Style | Behavior |
+| :--- | :--- |
+| **Default** | Standard software-engineering system prompt |
+| **Explanatory** | Adds educational "Insights" during task completion |
+| **Learning** | Collaborative mode — Claude inserts `TODO(human)` markers for the user to fill in |
+
+### Custom Style File Format
+
+```markdown
+---
+name: My Custom Style
+description: A brief description shown in the /config picker
+keep-coding-instructions: false
+---
+
+# Custom Style Instructions
+
+You are an interactive CLI tool that helps users with [domain].
+
+## Specific Behaviors
+
+- Respond in [tone]
+- Structure output as [format]
+- When [condition], do [action]
+```
+
+### Frontmatter Fields
+
+| Field | Purpose | Default |
+| :--- | :--- | :--- |
+| `name` | Display name (inherits from filename if omitted) | filename |
+| `description` | Shown in `/config` picker | none |
+| `keep-coding-instructions` | Retain Claude Code's coding-specific system prompt sections | `false` |
+
+Set `keep-coding-instructions: true` when the custom style *augments* coding behavior rather than replacing it.
+
+### File Locations
+
+| Scope | Path |
+| :--- | :--- |
+| User-level | `~/.claude/output-styles/` |
+| Project-level | `.claude/output-styles/` |
+| Plugin-shipped | `<plugin-root>/output-styles/` |
+
+### Selecting a Style
+
+- Interactive: `/config` → **Output style** → pick from menu
+- Direct: edit `outputStyle` in `.claude/settings.local.json`:
+
+```json
+{
+  "outputStyle": "Explanatory"
+}
+```
+
+Selection is written to `.claude/settings.local.json` at the local project level.
+
+### Shipping Output Styles in a Plugin
+
+Place style files under `<plugin-root>/output-styles/`. They are discovered when the plugin is installed and appear alongside built-in and user styles in `/config`.
+
+```
+my-plugin/
+├── .claude-plugin/
+│   └── plugin.json
+├── skills/
+└── output-styles/
+    ├── terse-reviewer.md
+    └── verbose-tutor.md
+```
+
+No additional `plugin.json` field is required — the `output-styles/` directory is discovered by convention.
+
+### Token Usage Considerations
+
+- Output styles add to the input token count via system prompt expansion, but **prompt caching** amortizes this after the first request per session
+- Built-in **Explanatory** and **Learning** styles produce longer output by design — higher output token cost
+- Custom styles' output cost is driven by what the instructions ask Claude to produce
+
+## Part 2: The Pattern — Response Contracts for Agents, Commands, and Teams
+
+The shape of an output style — a set of instructions controlling response format, tone, and structure — is portable. You can apply the same pattern anywhere a system prompt or instruction block is authored.
+
+### Important: Subagents Do Not Inherit Output Style
+
+The session-level output style modifies the **main agent loop's** system prompt. It does **not** propagate to:
+
+- Subagents spawned via the `Agent` tool
+- Slash command execution contexts
+- Skills loaded within a subagent
+
+If you need a subagent to produce output in a specific shape, encode the contract in the agent's own definition or reference a shared contract file.
+
+### Where to Place a Contract
+
+| Target | Where the contract goes |
+| :--- | :--- |
+| Agent (`.claude/agents/<name>.md`) | Body of the agent markdown, under a `## Response Format` heading |
+| Slash command (`.claude/commands/<name>.md`) | Body of the command markdown |
+| Team worker | Prompt template passed to the worker when spawned |
+| Skill | Dedicated section in `SKILL.md`, or a referenced file in `assets/` |
+| Plugin-wide | Shared file in `assets/contracts/` that components link to |
+
+### Why Standardize Worker Output
+
+When a team lead spawns multiple workers and must parse their results, inconsistent output shapes force the lead to write bespoke parsing for each worker. A shared contract lets the lead:
+
+- Extract specific fields (e.g., `PR_URL`, `STATUS`) with one parser
+- Filter worker reports for pass/fail without reading prose
+- Compare two workers' results reliably
+
+### Writing a Contract
+
+A contract specifies:
+
+- **Sections the response must contain** (fixed headings)
+- **Field formats** inside sections (literal strings, enums, lengths)
+- **What must not appear** (e.g., no prose preamble, no trailing summaries)
+
+Use imperative language. Example contract body:
+
+```markdown
+Respond using exactly these sections, in this order:
+
+## SUMMARY
+One sentence describing what was done. No preamble.
+
+## EVIDENCE
+Verbatim output from `mise run ci`. Paste the tail if too long,
+marked with `[truncated]`.
+
+## STATUS
+One of: `passed` | `failed` | `blocked`.
+
+## NEXT
+One sentence — what the team lead should do with this report.
+
+Do not add sections. Do not summarize at the end.
+```
+
+### Referencing a Shared Contract
+
+From an agent definition:
+
+```markdown
+---
+name: ci-validator
+description: Runs mise run ci and returns a structured report
+---
+
+# CI Validator
+
+Run `mise run ci`. Report using the contract in
+`assets/contracts/ci-evidence-format.md` — copy the section headings
+exactly.
+```
+
+From a team prompt template (pseudocode):
+
+```
+Spawn worker with prompt:
+  "Fix the failing test in src/foo.ex.
+   Report using {{contract: worker-report-format}}."
+```
+
+### When to Use a Contract vs. an Output Style
+
+| Need | Use |
+| :--- | :--- |
+| Session-level persona for the human user | Output style |
+| Consistent shape from a specific agent role | Contract in the agent definition |
+| Parseable reports from N parallel workers | Shared contract referenced by each worker |
+| Reusable response shape across a plugin | Contract in `assets/contracts/` |
+| One-off format for a single prompt | Inline instructions, no contract needed |
+
+## Output Styles vs. Related Features
+
+| Feature | Scope | Loaded When | Modifies |
+| :--- | :--- | :--- | :--- |
+| Output style | Main agent loop only | Session start (after `/config`) | System prompt (replaces coding sections) |
+| CLAUDE.md | Main agent loop | Session start | Appended as user message after system prompt |
+| `--append-system-prompt` | Main agent loop | Session start | Appended to system prompt |
+| Skill | Main loop and subagents | On-demand (invoke or auto) | Adds procedural knowledge |
+| Agent | Spawned subagent | When `Agent` tool invoked | Independent system prompt |
+| Response contract (pattern) | Wherever embedded | When the host component loads | The host's instructions |
+
+## Anti-Fabrication
+
+Do not fabricate output-style behavior or frontmatter fields not documented at https://code.claude.com/docs/en/output-styles. When authoring contracts, verify referenced files exist with `Read` or `Glob` before claiming they do. Do not claim an agent honors the session output style — it does not. For the full anti-fabrication ruleset, see `core:anti-fabrication`.
+
+## Common Pitfalls
+
+- **Assuming subagents inherit the style.** They do not. Encode the contract in the agent definition.
+- **Editing `outputStyle` and expecting mid-session effect.** Output style is fixed at session start for cache stability.
+- **Mixing session persona and agent response format.** A session-level output style for a reviewer persona is not the right tool for "all my workers must emit structured reports."
+- **Over-constraining.** A contract that dictates every word produces fragile output across model versions. Specify structure, not phrasing.
+- **Missing `keep-coding-instructions`.** Custom styles default to stripping coding instructions — if the style is meant to augment coding, set this to `true`.
+
+## Assets
+
+Reference response-format contracts in `assets/`:
+
+- `assets/worker-report-format.md` — structured report for team workers (SUMMARY / EVIDENCE / STATUS / NEXT)
+- `assets/ci-evidence-format.md` — verbatim CI-output contract for validation agents
+- `assets/review-findings-format.md` — findings-list contract for code review agents
+
+Copy, reference, or adapt these when defining agents, commands, or team workers.
+
+## References
+
+- Claude Code Output Styles: https://code.claude.com/docs/en/output-styles
+- Claude Code Plugins Reference: https://code.claude.com/docs/en/plugins-reference
+- Settings: https://code.claude.com/docs/en/settings
+- CLAUDE.md memory: https://code.claude.com/docs/en/memory

--- a/plugins/tools/claude-code/skills/claude-output-styles/assets/ci-evidence-format.md
+++ b/plugins/tools/claude-code/skills/claude-output-styles/assets/ci-evidence-format.md
@@ -1,0 +1,57 @@
+# CI Evidence Format
+
+Contract for validation agents that must prove CI passed with verbatim output rather than a claim.
+
+## Contract Body
+
+```markdown
+Respond using exactly these three sections. Do not paraphrase CI
+output — paste it verbatim.
+
+## COMMAND
+The exact command executed. One line, no prefix.
+
+## OUTPUT
+Verbatim stdout/stderr from the command. Wrap in a fenced code block.
+If output exceeds 200 lines, paste the first 20 and the last 50,
+separated by `[truncated: N lines]`.
+
+## EXIT
+The process exit code on its own line. Examples: `exit: 0`, `exit: 1`.
+```
+
+## When to Use
+
+- CI-gating agents whose output determines whether a commit proceeds
+- Deployment validation where false-positive "CI passed" claims have caused incidents
+- Any workflow where the user's project CLAUDE.md requires verbatim evidence
+
+## Rationale
+
+Paraphrased CI output hides failures. A team lead cannot distinguish "all tests passed" from "the agent claimed all tests passed." Verbatim output plus an exit code is the minimum trustworthy evidence.
+
+## Example Output
+
+```
+## COMMAND
+mise run ci
+
+## OUTPUT
+```
+Running: mix format --check-formatted
+Running: mix compile --warnings-as-errors
+Running: mix test --warnings-as-errors --max-failures=1
+..................
+Finished in 3.4 seconds
+18 tests, 0 failures
+```
+
+## EXIT
+exit: 0
+```
+
+## Anti-Patterns to Reject
+
+- "All tests passed" without OUTPUT section — reject and re-run the agent
+- OUTPUT section containing agent commentary instead of raw tool output
+- Missing EXIT line — without it, "output looks fine" is unverifiable

--- a/plugins/tools/claude-code/skills/claude-output-styles/assets/review-findings-format.md
+++ b/plugins/tools/claude-code/skills/claude-output-styles/assets/review-findings-format.md
@@ -1,0 +1,57 @@
+# Review Findings Format
+
+Contract for code review agents. Produces a prioritized findings list that a team lead or user can act on without re-reading the diff.
+
+## Contract Body
+
+```markdown
+Respond using exactly these two sections.
+
+## SCOPE
+One sentence naming the files or PR reviewed and the review lens
+(e.g., "security", "correctness", "style").
+
+## FINDINGS
+A numbered list. Each finding uses this exact shape:
+
+N. [SEVERITY] file:line — one-sentence description.
+   Fix: one sentence describing the change.
+
+SEVERITY is one of: `blocker` | `major` | `minor` | `nit`.
+- `blocker`: must be fixed before merge (correctness, security)
+- `major`: should be fixed before merge (design, reliability)
+- `minor`: nice to fix (clarity, minor performance)
+- `nit`: optional (style, naming)
+
+If no findings, write exactly: `No findings.`
+Do not include prose commentary between or after findings.
+```
+
+## When to Use
+
+- Code review agents whose output feeds a team lead or reviewer dashboard
+- Reviews where the user wants an actionable list, not a narrative
+- Situations where severity-based filtering is needed (e.g., "show blockers only")
+
+## Example Output
+
+```
+## SCOPE
+Security review of lib/auth/session.ex in PR #203.
+
+## FINDINGS
+1. [blocker] lib/auth/session.ex:42 — session token stored without
+   HMAC, allowing tampering.
+   Fix: sign the token with `Phoenix.Token.sign/3` before storage.
+2. [major] lib/auth/session.ex:67 — session lookup is not constant-time,
+   enabling user enumeration via timing.
+   Fix: use `Plug.Crypto.secure_compare/2` for the lookup comparison.
+3. [nit] lib/auth/session.ex:15 — module doc missing.
+   Fix: add a `@moduledoc` describing the session lifecycle.
+```
+
+## Design Notes
+
+- `file:line` refs let the reviewer jump directly in an editor
+- Severity enum is small on purpose — expanding it dilutes signal
+- "Fix:" sentence forces the agent to propose an action, not just describe a problem

--- a/plugins/tools/claude-code/skills/claude-output-styles/assets/worker-report-format.md
+++ b/plugins/tools/claude-code/skills/claude-output-styles/assets/worker-report-format.md
@@ -1,0 +1,63 @@
+# Worker Report Format
+
+Contract for team workers reporting back to a team lead. Produces structured, parseable output.
+
+## Contract Body
+
+Copy the block below into an agent definition, team worker prompt, or skill body.
+
+```markdown
+Respond using exactly these four sections, in this order. Use literal
+section headings. Do not add preamble, do not add a trailing summary.
+
+## SUMMARY
+One sentence describing what was done.
+
+## EVIDENCE
+Verbatim tool output proving the work. For CI or test runs, paste
+output from the command. If output exceeds 50 lines, paste the tail
+and mark earlier content with `[truncated: N lines]`.
+
+## STATUS
+Exactly one of: `passed` | `failed` | `blocked`.
+- `passed`: work completed and verified
+- `failed`: work attempted but verification failed
+- `blocked`: work not attempted due to missing input or dependency
+
+## NEXT
+One sentence stating what the team lead should do with this report
+(e.g., "merge PR", "retry with sonnet", "ask user for credentials").
+```
+
+## When to Use
+
+- Team leads parsing multiple worker reports in parallel
+- Workflows where STATUS must be machine-extractable
+- Situations where prose narrative would obscure the result
+
+## When Not to Use
+
+- Conversational back-and-forth with the user
+- Open-ended research tasks where the shape of findings is unknown
+- Single-step tasks that do not warrant ceremony
+
+## Example Output
+
+```
+## SUMMARY
+Fixed the failing credo warning in lib/foo.ex by pattern-matching
+on the expected shape instead of using case.
+
+## EVIDENCE
+$ mise run ci
+...
+Finished in 2.1 seconds
+0 failures, 0 warnings
+[truncated: 87 lines]
+
+## STATUS
+passed
+
+## NEXT
+Merge PR #142.
+```

--- a/plugins/tools/claude-code/skills/claude-plugins/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-plugins/SKILL.md
@@ -79,6 +79,9 @@ All plugin manifests must be located at `.claude-plugin/plugin.json` within the 
 - `hooks`: String path to hooks.json or hooks configuration object
 - `mcpServers`: String path to MCP config or configuration object
 
+**Convention-Based Directories** (no `plugin.json` field required):
+- `output-styles/`: Markdown output style files discovered when plugin is installed (see `claude-output-styles` skill)
+
 ## Field Validation Rules
 
 ### name
@@ -192,7 +195,8 @@ plugin-name/
 │   ├── skill-one/
 │   └── skill-two/
 ├── commands/
-└── agents/
+├── agents/
+└── output-styles/
 ```
 
 **In plugin.json:**

--- a/plugins/tools/claude-code/skills/sources.md
+++ b/plugins/tools/claude-code/skills/sources.md
@@ -109,6 +109,19 @@ This file documents the sources used to create the claude-code plugin skills.
   - Variable substitution
 - **Used In**: skills/claude-hooks/SKILL.md
 
+### Claude Code Output Styles Documentation
+- **URL**: https://code.claude.com/docs/en/output-styles
+- **Purpose**: Adapting Claude Code's system prompt for non-engineering roles and response formats
+- **Date Accessed**: 2026-04-17
+- **Key Topics**:
+  - Built-in styles (Default, Explanatory, Learning)
+  - Custom style frontmatter (`name`, `description`, `keep-coding-instructions`)
+  - File locations: `~/.claude/output-styles/`, `.claude/output-styles/`, plugin `output-styles/`
+  - Session-start scoping (takes effect next session for cache stability)
+  - Comparison with CLAUDE.md, `--append-system-prompt`, agents, and skills
+  - Subagents do not inherit session output style — contracts must be explicit
+- **Used In**: skills/claude-output-styles/SKILL.md, skills/claude-plugins/SKILL.md
+
 ## Plugin Marketplace Skill
 
 ### Claude Code Plugin Marketplace Schema


### PR DESCRIPTION
- Add claude-output-styles skill covering the native Claude Code output-style feature and the reusable response-contract pattern
- Add 3 copyable contracts in assets/: worker-report-format, ci-evidence-format, review-findings-format
- Update claude-plugins skill to list output-styles/ as a convention-based plugin directory
- Bump claude-code 0.1.11 → 0.1.12 and all-skills 0.3.28 → 0.3.29
- Regenerate all-skills meta-plugin (70 skills)