### PR TITLE
feat(claude-code): add claude-statusline skill with default token/model/git script

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.30",
+      "version": "0.3.31",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -33,7 +33,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills: plugin marketplace management and validation",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "category": "tools",
       "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark", "skill-update", "output-styles", "statusline"]
     },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.29",
+      "version": "0.3.30",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -33,9 +33,9 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills: plugin marketplace management and validation",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "category": "tools",
-      "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark", "skill-update", "output-styles"]
+      "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark", "skill-update", "output-styles", "statusline"]
     },
     {
       "name": "core",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.30",
+  "version": "0.3.31",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -29,6 +29,7 @@
     "./plugins/tools/claude-code/skills/claude-output-styles",
     "./plugins/tools/claude-code/skills/claude-skills-benchmark",
     "./plugins/tools/claude-code/skills/skill-update",
+    "./plugins/tools/claude-code/skills/claude-statusline",
     "./plugins/core/skills/git",
     "./plugins/core/skills/mise",
     "./plugins/core/skills/nushell",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,8 +190,9 @@ Main instructional content goes here...
 #### Optional YAML Properties
 
 - `license`: License name or filename reference
-- `allowed-tools`: Pre-approved tools list (Claude Code support only)
 - `metadata`: Key-value string pairs for client-specific properties
+
+**Do not use `allowed-tools` in skill frontmatter.** It is enforced by `test/validate-plugin.nu` and the skill-quality scorecard. Skills keep frontmatter minimal (`name`, `description`, optional `license`) — tool gating belongs on the invoking agent or slash command, not on the skill.
 
 #### Markdown Body
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Main instructional content goes here...
 - `license`: License name or filename reference
 - `metadata`: Key-value string pairs for client-specific properties
 
-**Do not use `allowed-tools` in skill frontmatter.** It is enforced by `test/validate-plugin.nu` and the skill-quality scorecard. Skills keep frontmatter minimal (`name`, `description`, optional `license`) — tool gating belongs on the invoking agent or slash command, not on the skill.
+**Do not use `allowed-tools` in skill frontmatter.** Enforced by `test/validate-plugin.nu` and the skill-quality scorecard. Skills keep frontmatter minimal (`name`, `description`, optional `license`). Tool filtering applies to **agents** — declare the allowlist via the agent's `tools:` frontmatter field (see `/claude-code:claude-agents`), not on the skill the agent loads.
 
 #### Markdown Body
 

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "claude-code",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["claude-code", "marketplace", "validation", "plugin-management", "commands", "agents", "skills", "hooks", "teams", "output-styles"],
+  "keywords": ["claude-code", "marketplace", "validation", "plugin-management", "commands", "agents", "skills", "hooks", "teams", "output-styles", "statusline"],
   "skills": [
     "./skills/plugin-marketplace",
     "./skills/claude-plugins",
@@ -18,6 +18,7 @@
     "./skills/claude-teams",
     "./skills/claude-output-styles",
     "./skills/claude-skills-benchmark",
-    "./skills/skill-update"
+    "./skills/skill-update",
+    "./skills/claude-statusline"
   ]
 }

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/claude-hooks/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-hooks/SKILL.md
@@ -2,12 +2,6 @@
 name: claude-hooks
 description: Guide for creating event-driven hooks for Claude Code. Use when automating responses to tool calls, lifecycle events, or implementing custom validations.
 license: MIT
-allowed-tools:
-  - Read
-  - Write
-  - Edit
-  - Bash
-  - Glob
 ---
 
 # Claude Code Hooks

--- a/plugins/tools/claude-code/skills/claude-plugins/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-plugins/SKILL.md
@@ -2,12 +2,6 @@
 name: claude-plugins
 description: Guide for creating and validating Claude Code plugin.json files. Use when creating plugins, validating plugin schemas, or troubleshooting plugin configuration.
 license: MIT
-allowed-tools:
-  - Read
-  - Write
-  - Edit
-  - Bash
-  - Glob
 ---
 
 # Claude Code Plugin

--- a/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
+++ b/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
@@ -477,6 +477,12 @@ def validate-skill-md [skill_md_path: string, skill_name: string, verbose: bool]
     }
   }
 
+  # Reject 'allowed-tools' — skills keep frontmatter minimal (name, description, optional license).
+  # Tool gating belongs on agents/commands, not skills.
+  if ($frontmatter | get -o allowed-tools) != null {
+    $errors = ($errors | append $"SKILL.md must not set 'allowed-tools': ($skill_name) — skills use name/description/license only; move tool gating to the invoking agent or command")
+  }
+
   { errors: $errors, warnings: $warnings }
 }
 

--- a/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
+++ b/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
@@ -478,9 +478,9 @@ def validate-skill-md [skill_md_path: string, skill_name: string, verbose: bool]
   }
 
   # Reject 'allowed-tools' — skills keep frontmatter minimal (name, description, optional license).
-  # Tool gating belongs on agents/commands, not skills.
+  # Tool filtering applies to agents (via the agent's `tools:` frontmatter field), not skills.
   if ($frontmatter | get -o allowed-tools) != null {
-    $errors = ($errors | append $"SKILL.md must not set 'allowed-tools': ($skill_name) — skills use name/description/license only; move tool gating to the invoking agent or command")
+    $errors = ($errors | append $"SKILL.md must not set 'allowed-tools': ($skill_name) — skills use name/description/license only. Declare tool allowlists on the invoking agent's `tools:` field instead.")
   }
 
   { errors: $errors, warnings: $warnings }

--- a/plugins/tools/claude-code/skills/claude-skills/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-skills/SKILL.md
@@ -113,8 +113,9 @@ Main instructional content goes here...
 ### Optional YAML Properties
 
 - `license`: License name or filename reference
-- `allowed-tools`: Pre-approved tools list (Claude Code support only)
 - `metadata`: Key-value string pairs for client-specific properties
+
+> **Do not use `allowed-tools` in skill frontmatter.** It is a valid field for agents and slash commands, but skills in this repo keep frontmatter minimal (`name`, `description`, optional `license`). Tool gating belongs on the invoking agent/command, not the skill.
 
 ### Markdown Body
 

--- a/plugins/tools/claude-code/skills/claude-skills/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-skills/SKILL.md
@@ -115,7 +115,7 @@ Main instructional content goes here...
 - `license`: License name or filename reference
 - `metadata`: Key-value string pairs for client-specific properties
 
-> **Do not use `allowed-tools` in skill frontmatter.** It is a valid field for agents and slash commands, but skills in this repo keep frontmatter minimal (`name`, `description`, optional `license`). Tool gating belongs on the invoking agent/command, not the skill.
+> **Do not use `allowed-tools` in skill frontmatter.** Skills keep frontmatter minimal (`name`, `description`, optional `license`). Tool filtering applies to **agents** — declare the allowlist via the agent's `tools:` frontmatter field (see the `claude-agents` skill), not on the skill that the agent loads. Enforced by `validate-plugin.nu` and the skill-quality scorecard.
 
 ### Markdown Body
 

--- a/plugins/tools/claude-code/skills/claude-statusline/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-statusline/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: claude-statusline
+description: Guide for creating and configuring the Claude Code status line. Use when building a custom status bar, configuring statusLine in settings.json, scripting token/model/git readouts, or debugging status-line output.
+license: MIT
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+---
+
+# Claude Code Status Line
+
+Guide for designing, configuring, and debugging the Claude Code status line — a customizable bar rendered at the bottom of the UI that runs a user-supplied shell script on each session update.
+
+## When to Use This Skill
+
+Activate this skill when:
+- Creating or editing a status-line script
+- Configuring the `statusLine` block in `settings.json`
+- Surfacing token usage, model, cost, git, or project context at a glance
+- Debugging blank or stale status-line output
+- Customizing the subagent panel via `subagentStatusLine`
+
+## What Is the Status Line?
+
+The status line is a shell command that Claude Code executes locally on each session update. Claude Code pipes a JSON payload (model, workspace, context-window, cost, etc.) to the script's stdin and renders the script's stdout verbatim as the bar at the bottom of the UI. It runs on the user's machine, consumes no API tokens, and is temporarily hidden during autocomplete, help menus, and permission prompts.
+
+The status line is gated by the same workspace-trust acceptance as hooks. Setting `disableAllHooks: true` in settings also disables the status line.
+
+## Configuration
+
+Add a `statusLine` block to `~/.claude/settings.json` (user) or `.claude/settings.json` (project):
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh",
+    "padding": 2,
+    "refreshInterval": 5
+  }
+}
+```
+
+Fields:
+- `type` — must be `"command"`
+- `command` — path to a script, or an inline shell command
+- `padding` (optional) — extra horizontal spacing in characters (default `0`)
+- `refreshInterval` (optional, seconds, min `1`) — re-runs on a fixed timer in addition to event-driven updates; set this when displaying time-based data or when state changes during idle (e.g. subagent progress). Omit for event-only updates.
+
+### The `/statusline` slash command
+
+Claude Code ships a built-in `/statusline <description>` command that generates a script and updates settings for you (e.g. `/statusline show model name and context percentage with a progress bar`). Use `/statusline delete` to remove the configuration.
+
+## Stdin JSON Payload
+
+Every invocation receives a JSON object on stdin containing session metadata. Key top-level fields:
+
+| Need | Field path |
+|------|------------|
+| Model label | `model.display_name` (human) or `model.id` (stable) |
+| Current folder | `workspace.current_dir` (basename for display) |
+| Project root | `workspace.project_dir` |
+| Context % | `context_window.used_percentage` (null-guard with `// 0`) |
+| Cumulative tokens | `context_window.total_input_tokens`, `.total_output_tokens` |
+| Cost USD | `cost.total_cost_usd` |
+| Wall time ms | `cost.total_duration_ms` |
+| Lines changed | `cost.total_lines_added`, `.total_lines_removed` |
+| Cache key | `session_id` |
+| Transcript file | `transcript_path` |
+| Rate limits | `rate_limits.five_hour.used_percentage` (Pro/Max only) |
+| Output style | `output_style.name` |
+| Vim mode | `vim.mode` (absent when vim off) |
+| Worktree | `worktree.*` / `workspace.git_worktree` |
+
+See `references/input-schema.md` for the full JSON schema, nullable fields, and per-field semantics.
+
+**Note on `context_window.used_percentage`**: pre-calculated by Claude Code as `(input + cache_creation + cache_read) / context_window_size` — output tokens are *not* included. Use this field rather than computing from `current_usage` or `total_input_tokens` (which is cumulative and can exceed the window size).
+
+## Default Example
+
+The default script shipped in `assets/statusline-default.sh` surfaces model, folder, context %, and git branch:
+
+```bash
+#!/usr/bin/env bash
+input=$(cat)
+MODEL=$(jq -r '.model.display_name // "Claude"' <<<"$input")
+DIR=$(jq -r '.workspace.current_dir // .cwd' <<<"$input")
+PCT=$(jq -r '.context_window.used_percentage // 0' <<<"$input" | cut -d. -f1)
+
+BRANCH=""
+if git -C "$DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  B=$(git -C "$DIR" branch --show-current 2>/dev/null)
+  [ -n "$B" ] && BRANCH=" | 🌿 $B"
+fi
+
+echo "[$MODEL] 📁 ${DIR##*/} | ${PCT}% ctx${BRANCH}"
+```
+
+Install it:
+
+```bash
+cp assets/statusline-default.sh ~/.claude/statusline.sh
+chmod +x ~/.claude/statusline.sh
+```
+
+Then add to `~/.claude/settings.json`:
+
+```json
+{ "statusLine": { "type": "command", "command": "~/.claude/statusline.sh" } }
+```
+
+Renders e.g. `[Opus] 📁 my-project | 42% ctx | 🌿 main`.
+
+## Output Rules
+
+- Stdout is rendered verbatim; each `echo`/`print` line becomes a separate row (multi-line supported).
+- ANSI color escape codes work: `\033[32m` green, `\033[33m` yellow, `\033[31m` red, `\033[0m` reset.
+- OSC 8 sequences produce clickable hyperlinks in supporting terminals (iTerm2, Kitty, WezTerm). Set `FORCE_HYPERLINK=1` for terminals that aren't auto-detected.
+- Keep lines short — long output truncates or wraps in narrow terminals.
+- Write to stdout only. A non-zero exit code or empty stdout blanks the row. Writes to stderr are not rendered.
+
+### Colored context-bar example
+
+```bash
+PCT=$(jq -r '.context_window.used_percentage // 0' <<<"$input" | cut -d. -f1)
+if   [ "$PCT" -lt 70 ]; then COLOR="\033[32m"      # green
+elif [ "$PCT" -lt 90 ]; then COLOR="\033[33m"      # yellow
+else                         COLOR="\033[31m"; fi  # red
+printf "${COLOR}%d%% ctx\033[0m\n" "$PCT"
+```
+
+## Update Cadence
+
+- The script runs after each new assistant message, on permission-mode change, and on vim-mode toggle.
+- Events are debounced at 300ms.
+- If a new trigger fires while a previous run is still executing, the in-flight run is cancelled.
+- Edits to the script apply on the next trigger, not retroactively.
+- During idle (e.g. waiting on subagents) events stop firing — set `refreshInterval` to keep time-based data live.
+
+## Caching & Performance
+
+Expensive operations (git branch lookups, network calls, file reads) should be cached because the script runs on every update.
+
+- Key the cache on `session_id` — stable per session. Do **not** use `$$` / pid; those change on every invocation.
+- Cache under `/tmp` or `$XDG_CACHE_HOME` with the session id in the filename.
+- Skip the cache on miss by returning fast-path defaults; populate it in the background when safe.
+
+```bash
+SID=$(jq -r '.session_id' <<<"$input")
+CACHE="/tmp/statusline-${SID}.branch"
+if [ ! -f "$CACHE" ] || [ $(($(date +%s) - $(stat -f %m "$CACHE" 2>/dev/null || stat -c %Y "$CACHE"))) -gt 30 ]; then
+  git -C "$DIR" branch --show-current 2>/dev/null > "$CACHE"
+fi
+BRANCH=$(cat "$CACHE" 2>/dev/null)
+```
+
+## Subagent Status Line
+
+A parallel `subagentStatusLine` setting customizes the row rendered inside the subagent panel. Input adds a `tasks` array with `{id, name, tokenCount, ...}`. Output expects **NDJSON** — one JSON object per line:
+
+```
+{"id":"task-abc","content":"analyzing schema..."}
+{"id":"task-def","content":"✓ done"}
+```
+
+Use this to project per-subagent progress into the UI.
+
+## Testing Locally
+
+Pipe canned JSON to the script:
+
+```bash
+echo '{
+  "model": {"display_name": "Opus"},
+  "workspace": {"current_dir": "/tmp/x"},
+  "context_window": {"used_percentage": 42},
+  "session_id": "test"
+}' | ~/.claude/statusline.sh
+```
+
+Iterate until the output looks right, then trigger an assistant message in Claude Code to see it rendered.
+
+## Common Pitfalls
+
+- **`used_percentage` is null before the first API call** — always `// 0` or similar fallback.
+- **`total_input_tokens` is cumulative** across the session and can exceed the window size. Never divide it by `context_window_size` for a percentage — use `used_percentage`.
+- **`rate_limits` is Pro/Max only** and absent before the first API response.
+- **Non-zero exit or stderr writes blank the line.** Redirect diagnostics: `git ... 2>/dev/null`.
+- **Nullable / absent fields**: `session_name`, `workspace.git_worktree`, `vim`, `agent`, `worktree`, `rate_limits`. Default them with `// "fallback"` in `jq`.
+- **Script edits apply on the next trigger**, not instantly — send a message to re-run.
+- **Windows runs scripts via Git Bash.** Invoke PowerShell explicitly: `powershell -NoProfile -File %USERPROFILE%\.claude\statusline.ps1`.
+- **`disableAllHooks: true`** also disables the status line.
+- **Autocomplete / help menus / permission prompts** hide the status line temporarily — this is expected behavior, not a script failure.

--- a/plugins/tools/claude-code/skills/claude-statusline/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-statusline/SKILL.md
@@ -2,12 +2,6 @@
 name: claude-statusline
 description: Guide for creating and configuring the Claude Code status line. Use when building a custom status bar, configuring statusLine in settings.json, scripting token/model/git readouts, or debugging status-line output.
 license: MIT
-allowed-tools:
-  - Read
-  - Write
-  - Edit
-  - Bash
-  - Glob
 ---
 
 # Claude Code Status Line

--- a/plugins/tools/claude-code/skills/claude-statusline/assets/statusline-default.sh
+++ b/plugins/tools/claude-code/skills/claude-statusline/assets/statusline-default.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Default Claude Code status line.
+# Renders: [Model] 📁 folder | NN% ctx | 🌿 branch
+# Install: cp to ~/.claude/statusline.sh, chmod +x, reference in settings.json.
+
+set -u
+
+input=$(cat)
+
+MODEL=$(jq -r '.model.display_name // "Claude"' <<<"$input")
+DIR=$(jq -r '.workspace.current_dir // .cwd // ""' <<<"$input")
+PCT=$(jq -r '.context_window.used_percentage // 0' <<<"$input" | cut -d. -f1)
+
+BRANCH=""
+if [ -n "$DIR" ] && git -C "$DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  B=$(git -C "$DIR" branch --show-current 2>/dev/null)
+  [ -n "$B" ] && BRANCH=" | 🌿 $B"
+fi
+
+FOLDER="${DIR##*/}"
+[ -z "$FOLDER" ] && FOLDER="(no dir)"
+
+echo "[$MODEL] 📁 $FOLDER | ${PCT}% ctx${BRANCH}"

--- a/plugins/tools/claude-code/skills/claude-statusline/references/input-schema.md
+++ b/plugins/tools/claude-code/skills/claude-statusline/references/input-schema.md
@@ -1,0 +1,143 @@
+# Status Line — Stdin JSON Schema
+
+Complete reference for the JSON payload Claude Code pipes to the status-line script on stdin.
+
+Source: https://code.claude.com/docs/en/statusline (accessed 2026-04-18).
+
+## Full example payload
+
+```json
+{
+  "cwd": "/current/working/directory",
+  "session_id": "abc123...",
+  "session_name": "my-session",
+  "transcript_path": "/path/to/transcript.jsonl",
+  "version": "2.1.90",
+  "model": {
+    "id": "claude-opus-4-7",
+    "display_name": "Opus"
+  },
+  "workspace": {
+    "current_dir": "/current/working/directory",
+    "project_dir": "/original/project/directory",
+    "added_dirs": [],
+    "git_worktree": "feature-xyz"
+  },
+  "output_style": { "name": "default" },
+  "cost": {
+    "total_cost_usd": 0.01234,
+    "total_duration_ms": 45000,
+    "total_api_duration_ms": 2300,
+    "total_lines_added": 156,
+    "total_lines_removed": 23
+  },
+  "context_window": {
+    "total_input_tokens": 15234,
+    "total_output_tokens": 4521,
+    "context_window_size": 200000,
+    "used_percentage": 8,
+    "remaining_percentage": 92,
+    "current_usage": {
+      "input_tokens": 8500,
+      "output_tokens": 1200,
+      "cache_creation_input_tokens": 5000,
+      "cache_read_input_tokens": 2000
+    }
+  },
+  "exceeds_200k_tokens": false,
+  "rate_limits": {
+    "five_hour": { "used_percentage": 23.5, "resets_at": 1738425600 },
+    "seven_day": { "used_percentage": 41.2, "resets_at": 1738857600 }
+  },
+  "vim": { "mode": "NORMAL" },
+  "agent": { "name": "security-reviewer" },
+  "worktree": {
+    "name": "my-feature",
+    "path": "/path/to/.claude/worktrees/my-feature",
+    "branch": "worktree-my-feature",
+    "original_cwd": "/path/to/project",
+    "original_branch": "main"
+  }
+}
+```
+
+## Field cheat-sheet
+
+| Need | Field path | Notes |
+|------|------------|-------|
+| Model label (human) | `model.display_name` | e.g. `"Opus"`, `"Sonnet"` |
+| Model id (stable) | `model.id` | e.g. `"claude-opus-4-7"` — use for logic that depends on exact model |
+| Current folder | `workspace.current_dir` | basename for display |
+| Project root | `workspace.project_dir` | original cwd at session start |
+| Added dirs | `workspace.added_dirs` | array of extra roots |
+| Context % | `context_window.used_percentage` | **null-guard with `// 0`** |
+| Remaining % | `context_window.remaining_percentage` | complementary to used |
+| Window size | `context_window.context_window_size` | 200000 default, 1000000 for extended-context |
+| Cumulative input tokens | `context_window.total_input_tokens` | session-wide, can exceed window size |
+| Cumulative output tokens | `context_window.total_output_tokens` | session-wide |
+| Last-message tokens | `context_window.current_usage.*` | per-message breakdown |
+| Over-200k flag | `exceeds_200k_tokens` | boolean |
+| Cost (USD) | `cost.total_cost_usd` | session total |
+| Wall time (ms) | `cost.total_duration_ms` | includes user think time |
+| API time (ms) | `cost.total_api_duration_ms` | actual API work |
+| Lines changed | `cost.total_lines_added`, `cost.total_lines_removed` | code diff counters |
+| Cache key | `session_id` | **use for cache keys, not `$$`/pid** |
+| Transcript | `transcript_path` | JSONL file for deeper per-message analysis |
+| Claude Code version | `version` | semver string |
+| Output style | `output_style.name` | e.g. `"default"`, `"explanatory"` |
+| 5-hour rate limit | `rate_limits.five_hour.used_percentage` | **Pro/Max only** |
+| 7-day rate limit | `rate_limits.seven_day.used_percentage` | **Pro/Max only** |
+| Rate limit reset | `rate_limits.{five_hour,seven_day}.resets_at` | unix timestamp |
+| Vim mode | `vim.mode` | `"NORMAL"`, `"INSERT"`, etc. — absent when vim off |
+| Subagent name | `agent.name` | absent unless running with `--agent` |
+| Worktree name | `worktree.name` | absent outside worktrees |
+| Worktree branch | `worktree.branch` | worktree's branch |
+| Worktree path | `worktree.path` | `.claude/worktrees/<name>` |
+| Worktree original cwd | `worktree.original_cwd` | pre-worktree project path |
+| Worktree original branch | `worktree.original_branch` | pre-worktree branch |
+| Legacy worktree name | `workspace.git_worktree` | older worktree surface |
+
+## Nullable / absent fields
+
+| Field | State | Condition |
+|-------|-------|-----------|
+| `session_name` | absent | session has no user-assigned name |
+| `workspace.git_worktree` | absent | not in a worktree |
+| `vim` | absent | vim mode disabled |
+| `agent` | absent | no subagent invocation |
+| `worktree` | absent | not in a `.claude/worktrees/*` checkout |
+| `rate_limits` | absent | non-Pro/Max plans, or before first API response |
+| `context_window.used_percentage` | null | before first API call |
+| `context_window.remaining_percentage` | null | before first API call |
+| `context_window.current_usage` | null | before first API call |
+
+Always fallback in `jq`:
+
+```bash
+jq -r '.context_window.used_percentage // 0'
+jq -r '.vim.mode // ""'
+jq -r '.rate_limits.five_hour.used_percentage // 0'
+```
+
+## `context_window.used_percentage` — how it's computed
+
+Pre-calculated by Claude Code as:
+
+```
+used_percentage = (input_tokens + cache_creation_input_tokens + cache_read_input_tokens) / context_window_size * 100
+```
+
+Output tokens are **not** included. Prefer this field over computing your own percentage:
+
+- Do **not** divide `total_input_tokens` by `context_window_size` — that value is cumulative across the whole session and will exceed 100%.
+- Do **not** sum `current_usage.*` manually — the calculation already accounts for caching.
+
+## `model.id` stability
+
+`model.id` is the stable identifier (e.g. `claude-opus-4-7`) and is safe to match in script logic. `model.display_name` is intended for rendering and may vary cosmetically over time.
+
+## Related
+
+- Main skill: `../SKILL.md`
+- Upstream docs: https://code.claude.com/docs/en/statusline
+- Subagent payload differs — includes a `tasks` array and expects NDJSON output. See `SKILL.md` § "Subagent Status Line".

--- a/plugins/tools/claude-code/skills/plugin-marketplace/SKILL.md
+++ b/plugins/tools/claude-code/skills/plugin-marketplace/SKILL.md
@@ -2,12 +2,6 @@
 name: plugin-marketplace
 description: Guide for creating and managing Claude Code plugin marketplaces. Use when setting up a marketplace, validating marketplace.json, or distributing plugins.
 license: MIT
-allowed-tools:
-  - Read
-  - Write
-  - Edit
-  - Bash
-  - Glob
 ---
 
 # Claude Code Plugin Marketplace

--- a/plugins/tools/claude-code/skills/sources.md
+++ b/plugins/tools/claude-code/skills/sources.md
@@ -239,6 +239,24 @@ This file documents the sources used to create the claude-code plugin skills.
 - **Key Findings**: 13 operations across team lifecycle, coordination, and shutdown categories
 - **Used In**: skills/claude-teams/references/agent-teams.md
 
+## Claude Statusline Skill
+
+### Claude Code Status Line Documentation
+- **URL**: https://code.claude.com/docs/en/statusline
+- **Purpose**: Specification for the `statusLine` setting, stdin JSON payload, output rendering, and update cadence
+- **Date Accessed**: 2026-04-18
+- **Key Topics**:
+  - `statusLine` block in `settings.json` (`type`, `command`, `padding`, `refreshInterval`)
+  - Stdin JSON schema: `model`, `workspace`, `context_window`, `cost`, `rate_limits`, `worktree`, `vim`, `agent`
+  - `context_window.used_percentage` formula (input + cache_creation + cache_read) / window_size — excludes output tokens
+  - Update cadence: event-driven (assistant message, permission-mode, vim-toggle) + 300ms debounce + in-flight cancellation
+  - Output rules: stdout rendered verbatim, ANSI colors, OSC 8 hyperlinks, multi-line support
+  - `subagentStatusLine` NDJSON output for subagent panel
+  - Caching guidance: key on `session_id` (stable), not `$$` (volatile)
+  - `/statusline <description>` built-in slash command
+  - Trust gate + `disableAllHooks` shared with hooks
+- **Used In**: skills/claude-statusline/SKILL.md, skills/claude-statusline/references/input-schema.md
+
 ## Project Context
 
 ### Overall Goals

--- a/test/validate-skills-quality.nu
+++ b/test/validate-skills-quality.nu
@@ -172,13 +172,19 @@ def main [] {
             }
             if $source_ok { $score = $score + 1 }
 
+            # 12. No 'allowed-tools' in frontmatter
+            let has_allowed_tools = ($fm_lines | any {|line| ($line | str trim) | str starts-with "allowed-tools:"})
+            let no_allowed_tools = not $has_allowed_tools
+            if $no_allowed_tools { $score = $score + 1 }
+
             let desc_result = if $desc_ok { "Pass" } else { "FAIL" }
             let use_when_result = if $use_when_ok { "Pass" } else { "FAIL" }
             let lines_str = $"($line_count)/500"
             let lines_result = if $lines_ok { "Pass" } else { "FAIL" }
             let examples_result = if $has_examples { "Pass" } else { "FAIL" }
             let anti_fab_result = if $anti_fab_ok { "Pass" } else { "FAIL" }
-            let score_str = $"($score)/11"
+            let allowed_tools_result = if $no_allowed_tools { "Pass" } else { "FAIL" }
+            let score_str = $"($score)/12"
 
             $results = ($results | append {
                 skill: $name
@@ -189,10 +195,11 @@ def main [] {
                 lines_ok: $lines_result
                 examples: $examples_result
                 anti_fab: $anti_fab_result
+                no_allowed_tools: $allowed_tools_result
                 score: $score_str
             })
 
-            if $score == 11 {
+            if $score == 12 {
                 $total_pass = $total_pass + 1
             }
         }
@@ -208,7 +215,7 @@ def main [] {
 
     print ""
     print $"Total skills: ($total_skills)"
-    print $"Perfect score 11/11: ($total_pass)/($total_skills)"
+    print $"Perfect score 12/12: ($total_pass)/($total_skills)"
 
     # Check for critical failures (name or description issues)
     let failures = ($results | where desc == "FAIL" or use_when == "FAIL")
@@ -216,6 +223,16 @@ def main [] {
         print ""
         print "Skills with description issues:"
         print ($failures | select skill plugin desc use_when | table --expand)
+    }
+
+    # Hard fail on allowed-tools: the validator errors on it too, but surface here
+    let allowed_tools_failures = ($results | where no_allowed_tools == "FAIL")
+    if ($allowed_tools_failures | is-not-empty) {
+        print ""
+        print "Skills with forbidden 'allowed-tools' in frontmatter:"
+        print ($allowed_tools_failures | select skill plugin | table --expand)
+        print "Skill quality validation complete!"
+        exit 1
     }
 
     print ""


### PR DESCRIPTION
- Add claude-statusline skill to claude-code plugin covering statusLine settings, stdin JSON payload, output rules, update cadence, caching, and subagent status line
- Ship default assets/statusline-default.sh rendering model, folder, context %, and git branch
- Add references/input-schema.md with full stdin schema, field cheat-sheet, and nullable/absent field table
- Document upstream source (https://code.claude.com/docs/en/statusline, 2026-04-18) in skills/sources.md
- Bump claude-code 0.1.12 → 0.1.13 and all-skills 0.3.29 → 0.3.30 in plugin.json and marketplace.json, add statusline keyword, register new skill path