### PR TITLE
feat(allium-db): scaffold plugin and commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,6 +29,16 @@
       "license": "MIT"
     },
     {
+      "name": "allium-db",
+      "source": "./plugins/tools/allium-db",
+      "strict": true,
+      "description": "Allium behavioral spec store — query specs at propagate/weed time via Dolt-backed database",
+      "version": "0.1.0",
+      "category": "tools",
+      "keywords": ["allium", "spec", "dolt", "tdd", "behavioral-spec"],
+      "license": "MIT"
+    },
+    {
       "name": "claude-code",
       "source": "./plugins/tools/claude-code",
       "strict": true,

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "A curated collection of Claude skills for development workflows",
-    "version": "1.0.6"
+    "version": "1.0.7"
   },
   "plugins": [
     {

--- a/plugins/tools/allium-db/.claude-plugin/plugin.json
+++ b/plugins/tools/allium-db/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "allium-db",
+  "version": "0.1.0",
+  "description": "Allium behavioral spec store: query specs at propagate/weed time via Dolt-backed database",
+  "author": {
+    "name": "vinnie357"
+  },
+  "repository": "https://github.com/vinnie357/claude-skills",
+  "license": "MIT",
+  "keywords": ["allium", "spec", "dolt", "tdd", "behavioral-spec"],
+  "skills": [
+    "./skills/allium-db"
+  ]
+}

--- a/plugins/tools/allium-db/commands/elicit.md
+++ b/plugins/tools/allium-db/commands/elicit.md
@@ -1,0 +1,96 @@
+---
+name: elicit
+description: Interactive behavioral spec capture
+---
+
+# /allium-db:elicit
+
+Launch an interactive prompt to guide systematic behavioral spec authoring.
+
+## Command
+
+```
+/allium-db:elicit
+```
+
+## When to Use
+
+- When designing a new feature and no spec yet exists
+- To systematically capture "what should happen" before coding
+- In pair programming or design review sessions
+- When spec discovery is needed before implementation begins
+
+## Arguments
+
+None (command is fully interactive)
+
+## Returns
+
+A draft `.allium` specification file (TOML format) ready for editing and registration via `/allium-db:register`.
+
+## Interactive Flow
+
+The command prompts for:
+
+1. **Epic slug** — VantageEx epic identifier (e.g., VIN-72)
+2. **Feature name** — Brief title of the feature
+3. **Description** — Detailed description of the feature
+4. **Success criteria** — Multi-line list of measurable completion criteria
+5. **Edge cases** — Boundary conditions and error scenarios
+6. **Dependencies** — Related skills or epics (`/core:agent-loop`, etc.)
+7. **Deliverables** — Code artifacts, docs, or other outputs
+
+## Example
+
+```bash
+/allium-db:elicit
+```
+
+Interactive prompts:
+```
+[Allium Elicit - Interactive Spec Capture v0.1.0]
+
+Epic slug? VIN-72
+Feature name? Allium-db Plugin Scaffold
+Description? Create a Claude plugin for Allium-db that provides agents with
+register/resolve/weed/elicit commands for behavioral spec management.
+
+Success criteria? 
+  1. Plugin structure mirrors runex layout
+  2. Four commands are defined and working
+  3. marketplace.json includes allium-db entry
+  4. All tests pass locally and in CI
+
+Edge cases?
+  1. Missing .allium file
+  2. Invalid TOML syntax
+  3. Dolt database unavailable
+
+Dependencies?
+  /core:agent-loop
+  /allium:allium
+
+Deliverables?
+  - .claude-plugin/plugin.json
+  - skills/allium-db/SKILL.md
+  - skills/allium-db/scripts/0.1.0/allium-db.nu
+  - commands/{register,resolve,weed,elicit}.md
+
+Generating spec...
+
+[DRAFT SPEC CREATED]
+Path: /tmp/allium-spec-VIN-72.allium
+Ready for review, editing, and registration via /allium-db:register
+```
+
+## Errors
+
+- **Prompt timeout**: No input received within timeout window
+- **Database error**: Cannot connect to Allium-db
+- **Parse error**: Invalid input format
+
+## References
+
+- See `SKILL.md` for Allium workflow overview
+- See `references/commands.md` for detailed command reference
+- See `/allium:allium` for full Allium system integration

--- a/plugins/tools/allium-db/commands/register.md
+++ b/plugins/tools/allium-db/commands/register.md
@@ -1,0 +1,57 @@
+---
+name: register
+description: Register a behavioral spec file into the Allium-db database
+---
+
+# /allium-db:register
+
+Ingest a `.allium` behavioral specification file into the Allium-db database.
+
+## Command
+
+```
+/allium-db:register <spec-path>
+```
+
+## When to Use
+
+- After writing a new `.allium` spec file in ADR documentation
+- When seeding the database with baseline specs from existing epics
+- During CI/CD to version-lock specs alongside code
+- Before agents begin implementation (propagate phase of Allium workflow)
+
+## Arguments
+
+- `<spec-path>` (required): Relative or absolute path to `.allium` file
+
+## Returns
+
+A record with:
+- `epic_id`: VantageEx epic identifier (e.g., VIN-72)
+- `spec_hash`: SHA-256 hash of spec file content
+- `registered_at`: ISO 8601 timestamp
+- `git_sha`: Git commit SHA at registration time
+
+## Example
+
+```bash
+/allium-db:register ./docs/adr/ADR-035-deployment.allium
+```
+
+Output:
+```
+epic_id    spec_hash                    registered_at            git_sha
+VIN-52     a7f2d8e1c4b9f3e6a2d5c8b1f4  2026-04-18T10:30:00Z     abc1def2ghi3jkl4mno5pqr
+```
+
+## Errors
+
+- **File not found**: `<spec-path>` does not exist
+- **Parse error**: `.allium` file is malformed (invalid TOML)
+- **Database error**: Cannot connect to Allium-db Dolt repository
+- **Invalid spec**: Missing required fields in `.allium` file
+
+## References
+
+- See `SKILL.md` for Allium workflow overview
+- See `references/commands.md` for detailed command reference

--- a/plugins/tools/allium-db/commands/resolve.md
+++ b/plugins/tools/allium-db/commands/resolve.md
@@ -1,0 +1,60 @@
+---
+name: resolve
+description: Fetch a behavioral spec for an epic from the Allium-db database
+---
+
+# /allium-db:resolve
+
+Retrieve the registered behavioral specification for a given VantageEx epic.
+
+## Command
+
+```
+/allium-db:resolve <epic-slug>
+```
+
+## When to Use
+
+- Before implementing a feature (propagate phase) to load the spec
+- During code review to cross-reference implementation against original design
+- To verify what specification is currently registered for an epic
+- When verifying epic completion criteria
+
+## Arguments
+
+- `<epic-slug>` (required): VantageEx epic slug (e.g., VIN-52, VIN-72)
+
+## Returns
+
+A record with:
+- `epic_slug`: The requested epic slug
+- `spec_content`: Full `.allium` specification as TOML text
+- `registered_at`: ISO 8601 timestamp of original registration
+- `git_sha`: Git commit SHA from when spec was registered
+
+## Example
+
+```bash
+/allium-db:resolve VIN-72
+```
+
+Output:
+```
+epic_slug  spec_content                          registered_at
+VIN-72     [title]
+           name = "Allium-db Plugin Scaffold"
+           description = "..."
+           success_criteria = [...]
+           git_sha: abc1def2ghi3jkl4mno5pqr
+```
+
+## Errors
+
+- **Not found**: Epic slug not in Allium-db database
+- **Database error**: Cannot connect to Allium-db Dolt repository
+- **Invalid slug**: Malformed epic slug
+
+## References
+
+- See `SKILL.md` for Allium workflow overview
+- See `references/commands.md` for detailed command reference

--- a/plugins/tools/allium-db/commands/weed.md
+++ b/plugins/tools/allium-db/commands/weed.md
@@ -1,0 +1,58 @@
+---
+name: weed
+description: Compare code against stored behavioral spec and report divergence
+---
+
+# /allium-db:weed
+
+Compare code in a given path against the registered behavioral specification, detecting implementation misalignments.
+
+## Command
+
+```
+/allium-db:weed <code-path>
+```
+
+## When to Use
+
+- During the weed phase of TDD to detect code-spec misalignment
+- At PR time to verify implementation matches original design intent
+- When auditing implementation against behavioral spec
+- To catch scope creep or unintended feature additions
+
+## Arguments
+
+- `<code-path>` (required): Path to code file or directory (relative or absolute)
+
+## Returns
+
+A record with:
+- `status`: Overall result (pass, mismatch, missing, extra)
+- `violations`: Count of divergences found
+- `severity`: high, medium, or low
+- `details`: List of specific violations with locations
+- `remediation`: Suggested fixes or implementation steps
+
+## Example
+
+```bash
+/allium-db:weed ./lib/allium_db/register.ex
+```
+
+Output:
+```
+status       violations  severity  comment
+mismatch     3           high      Code implements features not in spec
+```
+
+## Errors
+
+- **File not found**: Invalid `<code-path>`
+- **No spec**: No registered spec found for detected epic
+- **Parse error**: Code file is unparseable
+- **Database error**: Cannot connect to Allium-db Dolt repository
+
+## References
+
+- See `SKILL.md` for Allium workflow overview
+- See `references/commands.md` for detailed command reference

--- a/plugins/tools/allium-db/skills/allium-db/SKILL.md
+++ b/plugins/tools/allium-db/skills/allium-db/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: allium-db
+description: Allium behavioral spec store for querying specs at propagate/weed time via Dolt-backed database. Use when registering behavioral specs, resolving epic specs, comparing code against stored specs, or capturing new specs interactively.
+license: MIT
+---
+
+# Allium-db Skill
+
+Allium-db is a behavioral specification store built on Dolt (version-controlled SQL database). It provides four primary commands for managing and querying behavioral specs: `/allium-db:register` (ingest `.allium` files), `/allium-db:resolve` (fetch specs for epics), `/allium-db:weed` (compare code against specs), and `/allium-db:elicit` (interactive spec capture).
+
+This skill wraps the underlying `allium-db` CLI binary (vinnie357/allium-db, private repo). The CLI implements the actual Dolt-backed storage; this skill provides Claude agents access via Nushell wrappers.
+
+## When to Use This Skill
+
+Activate when:
+- Registering or ingesting `.allium` behavioral spec files into the database
+- Resolving/fetching stored behavioral specs for a given epic
+- Comparing existing code against stored behavioral specifications (weed step)
+- Capturing new behavioral specs interactively during spec authoring (elicit step)
+- Using `/core:agent-loop` with Allium integration for TDD workflows
+
+## Commands
+
+This skill exposes four sub-commands via `/allium-db:<command>`:
+
+### `/allium-db:register <spec-path>`
+
+Ingest a `.allium` behavioral spec file into the Allium-db database.
+
+**When to use:**
+- After writing a new `.allium` file in an ADR or epic specification
+- When seeding the database with baseline specs from existing epics
+- During CI/CD to version-lock specs alongside code
+
+**Arguments:**
+- `<spec-path>`: Relative or absolute path to `.allium` file
+
+**Returns:**
+Structured output (record) confirming registration: epic ID, spec hash, timestamp, commit SHA
+
+**Example:**
+```bash
+/allium-db:register ./docs/adr/ADR-035-deployment-model.allium
+```
+
+Expected output:
+```
+epic_id    spec_hash                    registered_at            git_sha
+VIN-52     a7f2d8e1c4b9f3e6a2d5c8b1f4  2026-04-18T10:30:00Z     abc1def2ghi3jkl4mno5pqr6stu
+```
+
+### `/allium-db:resolve <epic-slug>`
+
+Fetch the behavioral specification record for a given epic from the database.
+
+**When to use:**
+- When an agent needs to load a spec before implementing a feature (propagate step)
+- To verify what spec is currently registered for an epic
+- During code review to cross-reference implementation against stored spec
+
+**Arguments:**
+- `<epic-slug>`: VantageEx epic slug (e.g., VIN-52, VIN-72)
+
+**Returns:**
+Structured output: epic slug, spec content (`.allium` TOML), registered timestamp, commit SHA
+
+**Example:**
+```bash
+/allium-db:resolve VIN-72
+```
+
+Expected output:
+```
+epic_slug  spec_content                          registered_at
+VIN-72     [title]                               2026-04-18T10:30:00Z
+           name = "Allium-db Plugin Scaffold"
+           ...
+```
+
+### `/allium-db:weed <code-path>`
+
+Compare code in a given path against the stored behavioral specification, reporting divergence.
+
+**When to use:**
+- During the weed phase of TDD to detect code-spec misalignment
+- When auditing implementation against original design intent
+- To catch scope creep or unintended feature additions
+
+**Arguments:**
+- `<code-path>`: Relative or absolute path to code file/directory
+
+**Returns:**
+Structured output: divergence report with sections (missing implementations, extra code, mismatches), severity, and remediation suggestions
+
+**Example:**
+```bash
+/allium-db:weed ./lib/allium_db/register.ex
+```
+
+Expected output:
+```
+status      violations  severity  comment
+mismatch    3           high      Code implements features not in spec
+```
+
+### `/allium-db:elicit`
+
+Interactive spec capture prompt. Guides agents through structured behavioral spec authoring.
+
+**When to use:**
+- When designing a new feature and no spec yet exists
+- To systematically capture "what should happen" before coding
+- In pair programming or design review sessions
+
+**Arguments:**
+None (interactive)
+
+**Returns:**
+Draft `.allium` specification (TOML format) ready for registration
+
+**Example:**
+```bash
+/allium-db:elicit
+```
+
+This launches an interactive flow:
+```
+[Allium Elicit - Interactive Spec Capture]
+Epic slug? VIN-72
+Feature name? Allium-db Plugin
+Description? Scaffold a Claude plugin...
+Success criteria? 
+  1. Plugin structure mirrors runex layout
+  2. Four commands (register/resolve/weed/elicit) defined
+  3. marketplace.json updated
+  4. All tests pass
+...
+```
+
+## Integration with Allium Workflow
+
+Allium-db is part of the larger Allium system (see `/allium:allium` skill for full workflow). In the agent-loop lifecycle:
+
+1. **Spec Design** — ADR author writes `.allium` file (or uses `/allium-db:elicit`)
+2. **Register** — `/allium-db:register` seeds database, locks spec with git_sha
+3. **Propagate** — Agents `/allium-db:resolve` to fetch spec before implementation
+4. **Code** — Agents implement to spec
+5. **Weed** — `/allium-db:weed` checks code against spec at PR time
+6. **Complete** — Merge PR; spec and code are versioned together
+
+## Nushell Wrapper Scripts
+
+Versioned Nushell wrappers live in `scripts/0.1.0/` and translate Claude commands to CLI invocations.
+
+The wrapper scripts are stubs initially — they print "not yet implemented — install allium-db from vinnie357/allium-db first" and delegate to the underlying CLI binary once available.
+
+### Installation
+
+The `allium-db` CLI binary is installed via `mise` from the `vinnie357/allium-db` repository (private, in development). Add to your `mise.toml` or use:
+
+```bash
+mise exec allium-db -- allium-db --version
+```
+
+(Once the private repo is configured in your mise setup.)
+
+## See Also
+
+- `/allium:allium` — Full Allium behavioral spec integration with `/core:agent-loop`
+- `references/commands.md` — Detailed command reference and examples
+- `vinnie357/allium-db` — Underlying Zig CLI (private repo, in development)

--- a/plugins/tools/allium-db/skills/allium-db/references/commands.md
+++ b/plugins/tools/allium-db/skills/allium-db/references/commands.md
@@ -1,0 +1,153 @@
+# Allium-db Command Reference
+
+Detailed reference for the four Allium-db commands: `/allium-db:register`, `/allium-db:resolve`, `/allium-db:weed`, and `/allium-db:elicit`.
+
+## register
+
+Register a behavioral spec file into the Allium-db database.
+
+**Signature:**
+```
+/allium-db:register <spec-path>
+```
+
+**Parameters:**
+- `spec-path` (required): Path to `.allium` specification file (relative or absolute)
+
+**Returns:**
+Record with fields:
+- `epic_id`: VantageEx epic identifier (e.g., VIN-72)
+- `spec_hash`: SHA-256 hash of spec content
+- `registered_at`: ISO 8601 timestamp
+- `git_sha`: Current Git commit SHA
+
+**Errors:**
+- File not found: Invalid `spec-path`
+- Parse error: Malformed `.allium` TOML
+- Database error: Dolt connectivity issue
+
+**Example:**
+```bash
+/allium-db:register ./docs/adr/ADR-035.allium
+```
+
+## resolve
+
+Fetch a behavioral spec from the database for a given epic.
+
+**Signature:**
+```
+/allium-db:resolve <epic-slug>
+```
+
+**Parameters:**
+- `epic-slug` (required): VantageEx epic slug (e.g., VIN-52, VIN-72)
+
+**Returns:**
+Record with fields:
+- `epic_slug`: The requested epic slug
+- `spec_content`: Full `.allium` specification (TOML text)
+- `registered_at`: ISO 8601 timestamp of registration
+- `git_sha`: Git commit SHA from registration
+
+**Errors:**
+- Not found: Epic slug not in database
+- Database error: Dolt connectivity issue
+
+**Example:**
+```bash
+/allium-db:resolve VIN-72
+```
+
+## weed
+
+Compare code in a given path against the stored behavioral spec.
+
+**Signature:**
+```
+/allium-db:weed <code-path>
+```
+
+**Parameters:**
+- `code-path` (required): Path to code file or directory (relative or absolute)
+
+**Returns:**
+Record with fields:
+- `status`: Overall result (pass, mismatch, missing, extra)
+- `violations`: Count of divergences
+- `severity`: high, medium, low
+- `details`: List of specific mismatches
+- `remediation`: Suggested fixes
+
+**Errors:**
+- File not found: Invalid `code-path`
+- No spec: No registered spec found for the detected epic
+- Database error: Dolt connectivity issue
+
+**Example:**
+```bash
+/allium-db:weed ./lib/allium_db/register.ex
+```
+
+## elicit
+
+Interactive prompt for capturing behavioral specs.
+
+**Signature:**
+```
+/allium-db:elicit
+```
+
+**Parameters:**
+None (interactive)
+
+**Returns:**
+Draft `.allium` specification (TOML text) ready for editing and registration
+
+**Flow:**
+1. Prompt for epic slug
+2. Prompt for feature name
+3. Prompt for description
+4. Prompt for success criteria (multi-line)
+5. Prompt for edge cases
+6. Prompt for dependencies
+7. Generate and return draft spec
+
+**Errors:**
+- Prompt timeout: No input received within timeout window
+- Database error: Dolt connectivity issue
+
+**Example:**
+```bash
+/allium-db:elicit
+```
+
+Interactive prompts:
+```
+Epic slug? VIN-72
+Feature name? Allium-db Plugin Scaffold
+Description? Create Claude plugin structure for Allium-db CLI...
+Success criteria? 
+  1. ...
+  2. ...
+Edge cases?
+  1. ...
+Dependencies? /core:agent-loop
+```
+
+## Return Data Format
+
+All commands return structured data in Nushell record format (internally converted to JSON for API transport).
+
+Example return structure:
+```
+epic_slug: "VIN-72"
+status: "success"
+registered_at: "2026-04-18T10:30:00Z"
+spec_hash: "a7f2d8e1c4b9f3e6a2d5c8b1f4e7a2d5"
+```
+
+## See Also
+
+- Main skill documentation: `SKILL.md`
+- Nushell wrapper: `scripts/0.1.0/allium-db.nu`

--- a/plugins/tools/allium-db/skills/allium-db/scripts/0.1.0/allium-db.nu
+++ b/plugins/tools/allium-db/skills/allium-db/scripts/0.1.0/allium-db.nu
@@ -1,0 +1,68 @@
+#!/usr/bin/env nu
+# Allium-db CLI wrapper for Claude agents
+# Version 0.1.0
+#
+# This script provides Nushell wrappers around the allium-db Zig CLI binary.
+# The binary is installed via mise from vinnie357/allium-db (private repo).
+#
+# Subcommands: register, resolve, weed, elicit
+#
+# Each subcommand is stubbed with "not yet implemented" until the underlying
+# CLI is available.
+
+def main [...args] {
+    if ($args | length) == 0 {
+        print "Allium-db CLI Wrapper v0.1.0"
+        print ""
+        print "Usage: allium-db <command> [args]"
+        print ""
+        print "Commands:"
+        print "  register <spec-path>     Ingest .allium file into database"
+        print "  resolve <epic-slug>      Fetch spec for epic"
+        print "  weed <code-path>         Compare code against spec"
+        print "  elicit                   Interactive spec capture"
+        print ""
+        print "Subcommands not yet implemented — install allium-db from vinnie357/allium-db first"
+        exit 1
+    }
+
+    let cmd = $args.0
+    let rest = ($args | skip 1)
+
+    match $cmd {
+        "register" => {
+            print "not yet implemented — install allium-db from vinnie357/allium-db first"
+            print ""
+            print "Usage: allium-db register <spec-path>"
+            print "Example: allium-db register ./docs/adr/ADR-035.allium"
+            exit 1
+        }
+        "resolve" => {
+            print "not yet implemented — install allium-db from vinnie357/allium-db first"
+            print ""
+            print "Usage: allium-db resolve <epic-slug>"
+            print "Example: allium-db resolve VIN-72"
+            exit 1
+        }
+        "weed" => {
+            print "not yet implemented — install allium-db from vinnie357/allium-db first"
+            print ""
+            print "Usage: allium-db weed <code-path>"
+            print "Example: allium-db weed ./lib/allium_db/register.ex"
+            exit 1
+        }
+        "elicit" => {
+            print "not yet implemented — install allium-db from vinnie357/allium-db first"
+            print ""
+            print "Usage: allium-db elicit"
+            print "Launches interactive spec capture (no args)"
+            exit 1
+        }
+        _ => {
+            print $"Unknown command: ($cmd)"
+            print ""
+            print "Available commands: register, resolve, weed, elicit"
+            exit 1
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Scaffold the Allium-db Claude plugin (deliverable C of VIN-72) with:
- Plugin structure mirroring runex layout
- Four commands: register, resolve, weed, elicit
- Marketplace.json entry

## Plugin Contents

- `.claude-plugin/plugin.json` — plugin manifest
- `skills/allium-db/SKILL.md` — main skill documentation with when-to-use and integration with Allium workflow
- `skills/allium-db/references/commands.md` — detailed command reference
- `skills/allium-db/scripts/0.1.0/allium-db.nu` — Nushell wrapper (stub, awaits vinnie357/allium-db binary)
- `commands/{register,resolve,weed,elicit}.md` — four sub-command documentation

## Commands

- `/allium-db:register <spec-path>` — Ingest .allium file into database
- `/allium-db:resolve <epic-slug>` — Fetch spec for epic
- `/allium-db:weed <code-path>` — Compare code vs stored spec
- `/allium-db:elicit` — Interactive spec capture

## Marketplace Entry

Added to `.claude-plugin/marketplace.json`:
- source: `./plugins/tools/allium-db`
- strict: `true`
- version: `0.1.0`
- category: `tools`

## Notes

- Nushell wrapper is stubbed with "not yet implemented" prompts pending vinnie357/allium-db CLI availability
- Forward reference to private allium-db repo is documented in SKILL.md
- Follows exact runex plugin structure and conventions
- Awaits sibling workers to complete ADR and Zig CLI implementation (VIN-72 deliverables A & B)