### PR TITLE
feat(opus-4-7): hooks and skill rewrites for literal-adherence compliance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.3.31",
+      "version": "0.4.0",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -33,7 +33,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills: plugin marketplace management and validation",
-      "version": "0.1.14",
+      "version": "0.2.0",
       "category": "tools",
       "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark", "skill-update", "output-styles", "statusline"]
     },
@@ -42,7 +42,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.1.26",
+      "version": "0.2.0",
       "category": "development",
       "keywords": ["git", "documentation", "code-review", "tools", "beads", "bees", "container", "tdd", "agent-loop"]
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.3.31",
+  "version": "0.4.0",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.1.26",
+  "version": "0.2.0",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/hooks/hooks.json
+++ b/plugins/core/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Inject agent-loop tier model and skill-loading discipline at session start",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/core/hooks/session-start.sh
+++ b/plugins/core/hooks/session-start.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Injects agent-loop compliance anchors at session start.
+# Output goes to stdout; Claude Code injects it as turn-1 context.
+set -u
+cat >/dev/null 2>&1 || true
+
+cat <<'EOF'
+[CORE PLUGIN — SESSION-START COMMAND CONTRACT]
+
+These are commands with triggers, not informational text. Apply them
+when the trigger condition arises.
+
+1. Agent-loop tier model: Epic Author, Team Leader, Sub-team Leader,
+   Worker, Validator, Fix Agent. Default model progression
+   haiku -> sonnet -> opus, max 2 promotions per agent.
+
+2. Before any Phase 2 spawn: re-verify the core skill stack is loaded
+   by invoking each skill name explicitly with the Skill tool. Do not
+   rely on memory of Phase 1 — invoke /core:anti-fabrication, /core:tdd,
+   /core:security, /core:mise, /core:nushell, /core:agent-loop,
+   /core:bees by exact name. Glob patterns like /core:* do not expand
+   in Agent prompts.
+
+3. Every spawned agent's prompt starts with a "## Load skills" block
+   listing exact skill names. Require the agent to quote one sentence
+   from each loaded skill in its first response as proof of loading.
+   Do not proceed with the agent's work until proof is received.
+
+4. Code without tests is not complete. `mise run ci` must pass before
+   any commit, push, PR, or merge.
+
+5. NO Co-Authored-By attribution in commits or PRs. Squash merge only.
+   User approves merges; agents never merge.
+
+[END CORE SESSION-START CONTRACT]
+EOF

--- a/plugins/core/skills/agent-loop/SKILL.md
+++ b/plugins/core/skills/agent-loop/SKILL.md
@@ -15,7 +15,7 @@ Every agent, regardless of tier, follows these four phases:
 | Phase | Name | Purpose |
 |-------|------|---------|
 | 1 | Pre-flight | Load skills, check tracker, verify branch, understand assignment |
-| 2 | Working | Execute assigned work items, report progress, escalate blockers |
+| 2 | Working | Execute work items. **Before any spawn**: re-verify core skills loaded, load `/claude-code:claude-agents` always, load `/claude-code:claude-teams` for ≥2 parallel workers. |
 | 3 | Validation | Run strictest CI suite, iterate with fix agent until clean |
 | 4 | Submit | Create PR, wait for CI, report to upstream, clean up after merge |
 
@@ -55,6 +55,16 @@ Every agent at every tier loads these before any work:
 ```
 
 Domain-specific skills load based on issue/task labels.
+
+### Skills to load before spawning
+
+When a leader (Tier 1 or Tier 2) prepares to spawn an agent, load these by exact name with the Skill tool:
+
+- `/claude-code:claude-agents` — always. Carries agent file format, tool allowlists, and model selection.
+- `/claude-code:claude-teams` — if forming a team or spawning ≥2 parallel workers. Carries peer-to-peer messaging, shared task list, Agent SDK patterns.
+- `/claude-code:plugin-marketplace` — when the spawned agent needs a skill not already in the team's load list.
+
+Glob patterns like `/core:*` do not expand in Agent prompts. List skill names explicitly.
 
 ## Key Conventions
 
@@ -117,6 +127,54 @@ cd /path/to/repo
 
 Key: always reference existing code and functions to reuse. "Implement X" is vague — "add import/2 action to WorkflowController, reuse serialize_workflow/1 from line 28" is machine-executable.
 
+### Proof of loading
+
+Require each spawned agent to quote one sentence from each loaded skill in its first response. Do not proceed with the agent's work until proof is received. Listing skill names in the prompt is not the same as the agent loading them — proof prevents skipped loads.
+
+### Leader spawn — concrete example
+
+Team leader's Task-tool prompt for an Elixir worker on a Phoenix endpoint:
+
+```
+## Load skills
+/core:anti-fabrication
+/core:git
+/core:tdd
+/core:security
+/core:mise
+/core:nushell
+/elixir:phoenix-framework
+/elixir:elixir-testing
+/elixir:style
+
+## Working directory
+cd /Users/vinnie/github/runex
+
+## Bees issue
+runex-142: add /api/workflows/import endpoint
+
+## Context
+WorkflowController already exposes /export at lib/runex_web/controllers/workflow_controller.ex:14. Mirror that pattern for import. Existing serializer Runex.Workflow.serialize/1 at lib/runex/workflow.ex:28 — reuse it inverse for deserialize.
+
+## What to implement
+- POST /api/workflows/import accepting JSON body
+- New action import/2 in WorkflowController
+- Reuse Runex.Workflow.deserialize/1 (already exists at line 41)
+- Tests in test/runex_web/controllers/workflow_controller_test.exs
+
+## Rules
+- TDD: failing test first
+- async: true on all tests
+- Mock Runex.WorkflowStore.put/2
+
+## Execution order
+Follow the 9-step Agent Worker Execution Order. After step 2 (write tests),
+quote one sentence from each loaded skill and post your test code before
+proceeding to step 3.
+```
+
+Compact. Names files and functions to reuse. Anchors the proof-of-loading checkpoint inside the execution order.
+
 ## Model Selection
 
 Choose the initial model by task complexity:
@@ -173,7 +231,7 @@ Epic Author    -> Read references/epic-authoring.md
 
 Epics may include a `spec:` field pointing to a `.allium` behavioral spec file (e.g., `spec: docs/specs/<epic-slug>.allium`). When present:
 
-- The team leader checks for the spec in Phase 1 and may invoke `/allium:distill` on refactor epics lacking a spec.
+- The team leader checks for the spec in Phase 1. On a refactor epic without a `spec:` field, run `/allium:distill` to derive a baseline spec from existing code before decomposition.
 - Agent workers invoke `/allium:propagate` to seed failing test skeletons before implementation.
 - The validator invokes `/allium:weed` after CI passes to flag spec/code divergence.
 

--- a/plugins/core/skills/agent-loop/SKILL.md
+++ b/plugins/core/skills/agent-loop/SKILL.md
@@ -8,6 +8,15 @@ license: MIT
 
 Defines the standard workflow for agents working epics, issues, and tasks through a 4-phase execution model with a 6-tier prompt hierarchy.
 
+## Required plugins
+
+This skill's multi-agent workflow assumes both plugins are installed:
+
+- `core@vinnie357` (this plugin) — provides agent-loop, anti-fabrication, tdd, mise, nushell, security, bees
+- `claude-code@vinnie357` — provides claude-agents, claude-teams, plugin-marketplace, claude-hooks; carries the agent file format and team architecture knowledge that the spawning steps below reference by name
+
+When `core` is installed standalone, the spawning sections still describe the workflow but the cross-plugin skill names (e.g., `/claude-code:claude-agents`) do not resolve. Install `claude-code@vinnie357` for the full agent-loop experience, or treat those references as procedural-only.
+
 ## 4-Phase Execution
 
 Every agent, regardless of tier, follows these four phases:

--- a/plugins/core/skills/agent-loop/references/agent-worker.md
+++ b/plugins/core/skills/agent-loop/references/agent-worker.md
@@ -10,7 +10,7 @@ You are an agent working a single task within an issue. You report to your sub-t
    /core:security, /core:mise, /core:nushell
    ```
 2. Load task-specific skills from your assignment
-   - If a skill you need is missing, report to sub-lead -- do not improvise
+   - If a skill you need is missing, check `/claude-code:plugin-marketplace` for available skills, then report to sub-lead. Never fabricate the missing knowledge.
 3. Initialize tracking with your task items
 4. Verify you are on the correct feature branch
 

--- a/plugins/core/skills/agent-loop/references/team-leader.md
+++ b/plugins/core/skills/agent-loop/references/team-leader.md
@@ -16,7 +16,7 @@ You are the Team Leader for an epic. You receive the epic assignment and are res
    /core:security, /core:mise, /core:nushell
    ```
 2. Create a bees epic that mirrors the upstream epic (same title, objective, slug)
-3. **If the epic carries a `spec:` field** (e.g., `spec: docs/specs/<slug>.allium`): confirm the spec file exists at that path. If the epic is a refactor and no `spec:` is set, offer to run `/allium:distill` to capture a behavioral baseline before decomposition (optional — only if the user or epic asks for it). Skip this step entirely if neither condition applies.
+3. **If the epic carries a `spec:` field** (e.g., `spec: docs/specs/<slug>.allium`): confirm the spec file exists at that path. If the epic is a refactor and no `spec:` is set, run `/allium:distill` to capture a behavioral baseline before decomposition. Skip this step entirely if neither condition applies.
 4. Decompose the epic into bees issues:
    - Each issue is an independently deliverable unit of work
    - Each issue must have: acceptance criteria, skill labels, clear scope
@@ -29,6 +29,19 @@ You are the Team Leader for an epic. You receive the epic assignment and are res
    - Label each agent with their assigned model and skills
    - Respect dependency ordering: do not start issue B if it depends on A
 7. Report plan before spawning any agents
+
+## Before-spawn checklist
+
+Before invoking the Task tool to spawn any agent, verify:
+
+- [ ] Core skills still loaded (quote one sentence from each as self-check)
+- [ ] `/claude-code:claude-agents` loaded (always)
+- [ ] `/claude-code:claude-teams` loaded (if spawning ≥2 parallel workers)
+- [ ] Spawn prompt names specific files and functions to reuse, not generic goals
+- [ ] Spawn prompt opens with a `## Load skills` block listing exact skill names
+- [ ] Spawn prompt requires the agent to quote one sentence from each loaded skill in its first response
+
+A failed checkbox blocks the spawn. Fix it before invoking Task.
 
 ## Phase 2: Working
 

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/hooks/hooks.json
+++ b/plugins/tools/claude-code/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Inject skill-authoring discipline and agent/team triad anchor at session start",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/tools/claude-code/hooks/session-start.sh
+++ b/plugins/tools/claude-code/hooks/session-start.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Injects skill-authoring and agent/team triad anchors at session start.
+# Output goes to stdout; Claude Code injects it as turn-1 context.
+set -u
+cat >/dev/null 2>&1 || true
+
+cat <<'EOF'
+[CLAUDE-CODE PLUGIN — SESSION-START COMMAND CONTRACT]
+
+These are commands with triggers, not informational text. Apply them
+when the trigger condition arises.
+
+1. When editing any SKILL.md in this session, these are binding:
+   - NO `allowed-tools` field in frontmatter. Tool filtering belongs
+     on agents (`tools:` field), not skills. Enforced by
+     `test/validate-plugin.nu`.
+   - Description field uses third person and contains a
+     `Use when ...` trigger pattern.
+   - Body under 300 lines. Split into `references/` once exceeded.
+   - Zero hedging verbs. Banned: should, may, might, consider, try to,
+     offer to, it would be good to. Use imperative verbs instead.
+   - References one level deep only (SKILL.md -> reference, not
+     reference -> reference).
+
+2. When spawning agents or forming teams, invoke this triad by EXACT
+   name with the Skill tool: /core:agent-loop,
+   /claude-code:claude-agents, /claude-code:claude-teams. Glob patterns
+   like /core:* do not expand in Agent prompts — list names explicitly.
+
+3. Load /core:anti-fabrication before any factual claim about a file,
+   function, test result, or system state. No claim without a tool
+   call to validate it.
+
+4. Plugin hooks live at `<plugin-root>/hooks/hooks.json` with wrapper
+   format `{ "description": "...", "hooks": { "<EventName>": [...] } }`.
+   Valid event names: PreToolUse, PostToolUse, SessionStart, SessionEnd,
+   UserPromptSubmit, Stop, SubagentStop, PreCompact, Notification.
+   Use `${CLAUDE_PLUGIN_ROOT}` for paths in commands.
+
+[END CLAUDE-CODE SESSION-START CONTRACT]
+EOF

--- a/plugins/tools/claude-code/skills/claude-agents/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-agents/SKILL.md
@@ -7,6 +7,14 @@ description: Guide for creating custom agents for Claude Code. Use when creating
 
 Guide for creating custom agents that provide specialized behaviors and tool access for specific tasks.
 
+## When spawning as part of a team
+
+Invoke `/core:agent-loop` for the 4-phase / 6-tier execution model.
+Invoke `/claude-code:claude-teams` if the agent joins a multi-agent team.
+Invoke `/core:anti-fabrication` always — every claim about a tool, file, or test result requires tool execution.
+
+Glob patterns like `/core:*` do not expand in Agent prompts. List skill names explicitly.
+
 ## When to Use This Skill
 
 Activate this skill when:
@@ -240,7 +248,7 @@ Task(
 
 ### Clear Purpose
 
-Each agent should have a specific, well-defined purpose:
+Each agent has a specific, well-defined purpose:
 
 ```markdown
 ---

--- a/plugins/tools/claude-code/skills/claude-hooks/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-hooks/SKILL.md
@@ -1,607 +1,251 @@
 ---
 name: claude-hooks
-description: Guide for creating event-driven hooks for Claude Code. Use when automating responses to tool calls, lifecycle events, or implementing custom validations.
+description: Guide for creating event-driven hooks for Claude Code. Use when configuring SessionStart/PreToolUse/PostToolUse/Stop hooks, blocking dangerous tool calls, injecting context at turn 1, or troubleshooting plugin hook configuration.
 license: MIT
 ---
 
 # Claude Code Hooks
 
-Guide for creating hooks that execute shell commands or scripts in response to Claude Code events and tool calls.
+Hooks are shell commands or prompts that Claude Code executes in response to events. They are the only mechanism that can compel behavior — Claude reads memory and skills as guidance, but the harness runs hooks, not Claude.
 
-## When to Use This Skill
+## When to Use
 
-Activate this skill when:
-- Creating event-driven automations
-- Implementing custom validation or formatting
-- Integrating with external tools and services
-- Setting up project-specific workflows
-- Responding to tool execution events
+- Inject binding context at session start (SessionStart)
+- Validate or block tool calls before execution (PreToolUse)
+- Format, lint, or log after tool calls (PostToolUse)
+- Enforce completion standards before the agent stops (Stop / SubagentStop)
+- Augment user prompts with project context (UserPromptSubmit)
 
-## What Are Hooks?
+## Hook Configuration Locations
 
-Hooks are shell commands that execute automatically in response to specific events:
+| Scope | Path | Use case |
+|---|---|---|
+| User | `~/.claude/settings.json` under `hooks` | Personal automation across all projects |
+| Project | `<project>/.claude/settings.json` under `hooks` | Repo-shared automation |
+| Plugin | `<plugin-root>/hooks/hooks.json` | Distribute hooks via plugin install |
+| Skill/Subagent | Skill or subagent frontmatter `hooks:` field | Lifecycle-scoped hooks |
 
-- **Tool Call Hooks**: Trigger before/after specific tool calls
-- **Lifecycle Hooks**: Trigger on plugin install/uninstall
-- **User Prompt Hooks**: Trigger when users submit prompts
-- **Custom Events**: Application-specific trigger points
+Plugin hooks at `<plugin-root>/hooks/hooks.json` are auto-discovered. No registration in `plugin.json` required.
 
-## Hook Configuration
+## Plugin Hook File Structure
 
-### Location
+Plugin `hooks/hooks.json` uses the wrapper format:
 
-Hooks are configured in:
-- Plugin: `<plugin-root>/.claude-plugin/hooks.json`
-- User-level: `.claude/hooks.json`
-- Plugin manifest: Inline in `plugin.json`
-
-### File Structure
-
-**Standalone hooks.json:**
 ```json
 {
-  "onToolCall": {
-    "Write": {
-      "before": ["./hooks/format-check.sh"],
-      "after": ["./hooks/lint.sh"]
-    },
-    "Bash": {
-      "before": ["./hooks/validate-command.sh"]
-    }
-  },
-  "onInstall": ["./hooks/setup.sh"],
-  "onUninstall": ["./hooks/cleanup.sh"],
-  "onUserPromptSubmit": ["./hooks/log-prompt.sh"]
-}
-```
-
-**Inline in plugin.json:**
-```json
-{
+  "description": "Brief explanation of what these hooks do",
   "hooks": {
-    "onToolCall": {
-      "Write": {
-        "after": ["prettier --write {{file_path}}"]
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/check.sh",
+            "timeout": 5
+          }
+        ]
       }
-    }
+    ]
   }
 }
 ```
+
+- `description` — optional, surfaced in plugin metadata
+- `hooks` — required wrapper containing event arrays
+- `matcher` — regex of tool names (PreToolUse/PostToolUse) or session lifecycle phases (SessionStart)
+- `${CLAUDE_PLUGIN_ROOT}` — absolute path to the plugin root, expanded at runtime
+
+## Hook Events
+
+| Event | When it fires | Common use |
+|---|---|---|
+| `SessionStart` | Session start, resume, clear | Inject binding context to turn 1 |
+| `SessionEnd` | Session ends | Cleanup, telemetry |
+| `UserPromptSubmit` | User submits a prompt | Augment prompt, log interaction |
+| `PreToolUse` | Before a tool executes | Block dangerous calls, validate input |
+| `PostToolUse` | After a tool completes | Format, lint, sync, log |
+| `Stop` | Agent finishes responding | Enforce completion standards |
+| `SubagentStop` | Spawned subagent finishes | Subagent-specific cleanup |
+| `PreCompact` | Before context compaction | Inject context to preserve |
+| `Notification` | A notification fires | Custom notification routing |
 
 ## Hook Types
 
-### Tool Call Hooks
+### Command Hooks
 
-Execute before or after specific tool calls.
+Execute a shell command. Deterministic, fast.
 
-**Available Tools:**
-- `Read`, `Write`, `Edit`, `MultiEdit`
-- `Bash`, `BashOutput`
-- `Glob`, `Grep`
-- `Task`, `Skill`, `SlashCommand`
-- `TodoWrite`
-- `WebFetch`, `WebSearch`
-- `AskUserQuestion`
-
-**Example:**
 ```json
 {
-  "onToolCall": {
-    "Write": {
-      "before": [
-        "echo 'Writing file: {{file_path}}'",
-        "./hooks/backup.sh {{file_path}}"
-      ],
-      "after": [
-        "prettier --write {{file_path}}",
-        "git add {{file_path}}"
-      ]
-    },
-    "Edit": {
-      "after": ["eslint --fix {{file_path}}"]
-    }
+  "type": "command",
+  "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/validate.sh",
+  "timeout": 60
+}
+```
+
+### Prompt Hooks
+
+Send a prompt to a model for context-aware decisions. Slower but flexible.
+
+```json
+{
+  "type": "prompt",
+  "prompt": "Evaluate if this tool use is appropriate: $TOOL_INPUT",
+  "timeout": 30
+}
+```
+
+Supported events for prompt hooks: `Stop`, `SubagentStop`, `UserPromptSubmit`, `PreToolUse`.
+
+## SessionStart — Injecting Turn-1 Context
+
+`SessionStart` is the strongest compliance mechanism: stdout from the hook script becomes part of the model's first input. Memory and skills inform; SessionStart compels.
+
+Plugin example (`plugins/example/hooks/hooks.json`):
+
+```json
+{
+  "description": "Inject project conventions at session start",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
   }
 }
 ```
 
-### Lifecycle Hooks
-
-Execute during plugin installation/uninstallation.
-
-```json
-{
-  "onInstall": [
-    "./hooks/setup-dependencies.sh",
-    "npm install",
-    "echo 'Plugin installed successfully'"
-  ],
-  "onUninstall": [
-    "./hooks/cleanup.sh",
-    "echo 'Plugin uninstalled'"
-  ]
-}
-```
-
-### User Prompt Submit Hook
-
-Execute when user submits a prompt:
-
-```json
-{
-  "onUserPromptSubmit": [
-    "./hooks/log-interaction.sh '{{prompt}}'",
-    "./hooks/check-context.sh"
-  ]
-}
-```
-
-## Hook Variables
-
-Hooks have access to context-specific variables using `{{variable}}` syntax.
-
-### Tool Call Variables
-
-Different tools provide different variables:
-
-**Write Tool:**
-- `{{file_path}}`: Path to file being written
-- `{{content}}`: Content being written (before hooks only)
-
-**Edit Tool:**
-- `{{file_path}}`: Path to file being edited
-- `{{old_string}}`: String being replaced
-- `{{new_string}}`: Replacement string
-
-**Bash Tool:**
-- `{{command}}`: Command being executed
-
-**Read Tool:**
-- `{{file_path}}`: Path to file being read
-
-### Global Variables
-
-Available in all hooks:
-- `{{cwd}}`: Current working directory
-- `{{timestamp}}`: Current Unix timestamp
-- `{{user}}`: Current user
-- `{{plugin_root}}`: Plugin installation directory
-
-### User Prompt Variables
-
-- `{{prompt}}`: User's submitted prompt text
-
-## Hook Examples
-
-### Auto-Format on Write
-
-```json
-{
-  "onToolCall": {
-    "Write": {
-      "after": [
-        "prettier --write {{file_path}}",
-        "eslint --fix {{file_path}}"
-      ]
-    }
-  }
-}
-```
-
-### Pre-Commit Validation
-
-```json
-{
-  "onToolCall": {
-    "Bash": {
-      "before": ["./hooks/validate-git-command.sh '{{command}}'"]
-    }
-  }
-}
-```
-
-**validate-git-command.sh:**
-```bash
-#!/bin/bash
-
-COMMAND="$1"
-
-# Block force push to main/master
-if [[ "$COMMAND" =~ "git push --force" ]] && [[ "$COMMAND" =~ "main|master" ]]; then
-  echo "ERROR: Force push to main/master is not allowed"
-  exit 1
-fi
-
-exit 0
-```
-
-### Automatic Backups
-
-```json
-{
-  "onToolCall": {
-    "Write": {
-      "before": ["cp {{file_path}} {{file_path}}.backup"]
-    },
-    "Edit": {
-      "before": ["cp {{file_path}} {{file_path}}.backup"]
-    }
-  }
-}
-```
-
-### Logging and Analytics
-
-```json
-{
-  "onToolCall": {
-    "Write": {
-      "after": ["./hooks/log-file-change.sh {{file_path}}"]
-    }
-  },
-  "onUserPromptSubmit": ["./hooks/log-prompt.sh '{{prompt}}'"]
-}
-```
-
-**log-file-change.sh:**
-```bash
-#!/bin/bash
-
-FILE="$1"
-TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
-echo "$TIMESTAMP - Modified: $FILE" >> .claude/file-changes.log
-```
-
-### Integration with External Tools
-
-```json
-{
-  "onToolCall": {
-    "Write": {
-      "after": [
-        "notify-send 'File Updated' 'Modified {{file_path}}'",
-        "curl -X POST https://api.example.com/notify -d 'file={{file_path}}'"
-      ]
-    }
-  }
-}
-```
-
-## Hook Execution
-
-### Execution Order
-
-Multiple hooks execute in array order:
-
-```json
-{
-  "onToolCall": {
-    "Write": {
-      "after": [
-        "echo 'Step 1'",  // Runs first
-        "echo 'Step 2'",  // Runs second
-        "echo 'Step 3'"   // Runs third
-      ]
-    }
-  }
-}
-```
-
-### Exit Codes
-
-**Before Hooks:**
-- Exit code `0`: Continue with tool execution
-- Exit code non-zero: **Block tool execution**, show error to user
-
-**After Hooks:**
-- Exit codes are logged but don't affect tool execution
-- Tool has already completed
-
-### Error Handling
+Companion script (`plugins/example/hooks/session-start.sh`):
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
+set -u
+cat >/dev/null 2>&1 || true   # consume stdin
 
-# Before hook - blocks tool on error
-if [[ ! -f "$1" ]]; then
-  echo "ERROR: File does not exist"
-  exit 1  # Blocks tool execution
-fi
+cat <<'EOF'
+[PLUGIN-NAME — SESSION-START COMMAND CONTRACT]
 
-# Validation passed
-exit 0
+These are commands with triggers, not informational text.
+
+1. Run mise run ci before any commit.
+2. Conventional commits, no Co-Authored-By attribution.
+3. ...
+EOF
 ```
+
+The header in the heredoc lands as turn-1 context. Keep it tight — every session pays this token cost.
+
+## PreToolUse — Validation and Blocking
+
+Exit code from a `PreToolUse` command hook controls whether the tool runs:
+
+- Exit 0: continue
+- Exit non-zero: block the tool, show stderr to the user
+
+Example — block force-push to main:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/guard-push.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`guard-push.sh` reads the tool input from stdin (JSON), parses with `jq`, and exits non-zero on a forbidden pattern.
+
+## PostToolUse — Auto-Format, Lint, Sync
+
+`PostToolUse` runs after the tool completes. Exit codes are logged but do not affect the tool result.
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/format.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The hook reads the tool input from stdin and runs the formatter on the modified file.
+
+## Hook Inputs and Outputs
+
+Hook scripts receive event JSON on stdin:
+
+```json
+{
+  "session_id": "abc123",
+  "transcript_path": "/path/to/transcript.jsonl",
+  "cwd": "/path/to/project",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Write",
+  "tool_input": { "file_path": "...", "content": "..." }
+}
+```
+
+Parse with `jq` in the hook script:
+
+```bash
+file_path=$(jq -r '.tool_input.file_path' < /dev/stdin)
+```
+
+Stdout from `SessionStart` and `UserPromptSubmit` hooks is injected into the model's context. Stdout from other events is logged but not surfaced.
 
 ## Best Practices
 
-### Keep Hooks Fast
-
-Hooks block execution - keep them lightweight:
-
-```json
-{
-  "onToolCall": {
-    "Write": {
-      // ✅ Fast linter
-      "after": ["eslint --fix {{file_path}}"]
-
-      // ❌ Slow test suite
-      // "after": ["npm test"]
-    }
-  }
-}
-```
-
-### Use Absolute Paths
-
-Reference scripts with paths relative to plugin:
-
-```json
-{
-  "onInstall": ["${CLAUDE_PLUGIN_ROOT}/hooks/setup.sh"]
-}
-```
-
-### Validate Input
-
-Always validate hook variables:
-
-```bash
-#!/bin/bash
-
-FILE="$1"
-
-if [[ -z "$FILE" ]]; then
-  echo "ERROR: No file path provided"
-  exit 1
-fi
-
-if [[ ! -f "$FILE" ]]; then
-  echo "ERROR: File does not exist: $FILE"
-  exit 1
-fi
-```
-
-### Provide Clear Feedback
-
-```bash
-#!/bin/bash
-
-echo "Running pre-commit checks..."
-
-if ! npm run lint; then
-  echo "❌ Linting failed. Please fix errors before committing."
-  exit 1
-fi
-
-echo "✅ All checks passed"
-exit 0
-```
-
-### Handle Edge Cases
-
-```bash
-#!/bin/bash
-
-# Handle files with spaces in names
-FILE="$1"
-
-# Validate file type
-if [[ ! "$FILE" =~ \.(js|ts|jsx|tsx)$ ]]; then
-  # Skip non-JavaScript files silently
-  exit 0
-fi
-
-# Run formatter
-prettier --write "$FILE"
-```
-
-## Security Considerations
-
-### Validate Commands
-
-Before hooks can block dangerous operations:
-
-```json
-{
-  "onToolCall": {
-    "Bash": {
-      "before": ["./hooks/validate-command.sh '{{command}}'"]
-    }
-  }
-}
-```
-
-**validate-command.sh:**
-```bash
-#!/bin/bash
-
-COMMAND="$1"
-
-# Block dangerous patterns
-DANGEROUS_PATTERNS=(
-  "rm -rf /"
-  "dd if="
-  "mkfs"
-  "> /dev/sda"
-)
-
-for pattern in "${DANGEROUS_PATTERNS[@]}"; do
-  if [[ "$COMMAND" =~ $pattern ]]; then
-    echo "ERROR: Dangerous command blocked: $pattern"
-    exit 1
-  fi
-done
-
-exit 0
-```
-
-### Limit Hook Scope
-
-Only hook necessary tools:
-
-```json
-{
-  // ✅ Specific tools only
-  "onToolCall": {
-    "Write": { "after": ["./format.sh {{file_path}}"] }
-  }
-
-  // ❌ Don't hook everything unnecessarily
-}
-```
-
-### Sanitize Variables
-
-```bash
-#!/bin/bash
-
-# Sanitize file path
-FILE=$(realpath "$1")
-
-# Ensure file is within project
-if [[ ! "$FILE" =~ ^$(pwd) ]]; then
-  echo "ERROR: File outside project directory"
-  exit 1
-fi
-```
-
-## Debugging Hooks
-
-### Enable Verbose Output
-
-```json
-{
-  "onToolCall": {
-    "Write": {
-      "before": ["set -x; ./hooks/debug.sh {{file_path}}; set +x"]
-    }
-  }
-}
-```
-
-### Log Hook Execution
-
-```bash
-#!/bin/bash
-
-LOG_FILE=".claude/hooks.log"
-TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
-echo "$TIMESTAMP - Hook: $0, Args: $@" >> "$LOG_FILE"
-
-# Rest of hook logic...
-```
-
-### Test Hooks Manually
-
-```bash
-# Test hook with sample data
-./hooks/format.sh "src/main.js"
-
-# Check exit code
-echo $?
-```
-
-## Common Hook Patterns
-
-### Auto-Format Pipeline
-
-```json
-{
-  "onToolCall": {
-    "Write": {
-      "after": [
-        "prettier --write {{file_path}}",
-        "eslint --fix {{file_path}}"
-      ]
-    },
-    "Edit": {
-      "after": [
-        "prettier --write {{file_path}}",
-        "eslint --fix {{file_path}}"
-      ]
-    }
-  }
-}
-```
-
-### Test on Write
-
-```json
-{
-  "onToolCall": {
-    "Write": {
-      "after": ["./hooks/run-relevant-tests.sh {{file_path}}"]
-    }
-  }
-}
-```
-
-### Git Integration
-
-```json
-{
-  "onToolCall": {
-    "Write": {
-      "after": ["git add {{file_path}}"]
-    },
-    "Edit": {
-      "after": ["git add {{file_path}}"]
-    }
-  }
-}
-```
-
-## Troubleshooting
-
-### Hook Not Executing
-
-- Check hook file has execute permissions: `chmod +x hooks/script.sh`
-- Verify path is correct relative to plugin root
-- Check JSON syntax in hooks.json
-- Look for errors in Claude Code logs
-
-### Hook Blocking Tool
-
-- Check exit code of before hooks
-- Add debug logging
-- Test hook script manually
-- Verify validation logic
-
-### Variables Not Substituting
-
-- Check variable name spelling: `{{file_path}}` not `{{filepath}}`
-- Verify variable is available for that tool
-- Quote variables in bash: `"{{file_path}}"`
+- **Keep hooks fast.** Hooks block the harness. Aim for under 1 second for `PreToolUse`/`PostToolUse`. Set explicit `timeout` values.
+- **Use `${CLAUDE_PLUGIN_ROOT}`.** Never hardcode plugin paths.
+- **Validate stdin.** Hook input is JSON; use `jq` and exit cleanly on parse failure.
+- **Scope matchers narrowly.** Match `Write|Edit` over matching all tools.
+- **Mark scripts executable.** `chmod +x` after creating shell scripts; the hook will fail silently otherwise.
+- **Test scripts standalone.** Run `echo '{...}' | bash hooks/script.sh` before relying on the hook to fire.
+
+## Security
+
+- Treat all stdin fields as untrusted input. Use `jq` to parse, never eval.
+- Block destructive patterns in `PreToolUse` Bash hooks (`rm -rf /`, `dd if=`, force-push to protected branches).
+- Sanitize file paths with `realpath` and verify they remain inside the project root.
+- Hooks run with the user's full privileges. A malicious plugin hook can do anything the user can do — review before installing.
+
+## Anti-Fabrication
+
+Validate hook behavior with actual execution before claiming it works. Run the hook script standalone, observe stdin parsing, exit codes, and stdout. Do not assume an event fires without verifying the hook entry in the harness logs.
 
 ## Templates
 
-Reference templates for common hook configurations:
-
-```
-claude-hooks/
-└── templates/
-    ├── plugin-hook.md    # Plugin hook configuration example
-    └── skill-hook.md     # Skill/subagent frontmatter hooks example
-```
-
-### Plugin Hook Template
-
-Example configuration for defining hooks in a plugin's `hooks/hooks.json`:
-- PostToolUse hook with `Write|Edit` matcher
-- Uses `${CLAUDE_PLUGIN_ROOT}` for script references
-- Includes timeout configuration
-
-### Skill Hook Template
-
-Example frontmatter for embedding hooks directly in skills:
-- Supported events: PreToolUse, PostToolUse, Stop
-- Hooks scoped to component lifecycle
-- Runs only when skill/subagent is active
+- `templates/plugin-hook.md` — plugin `hooks/hooks.json` configuration with `PostToolUse`, `Write|Edit` matcher, and `${CLAUDE_PLUGIN_ROOT}`
+- `templates/skill-hook.md` — skill/subagent frontmatter hook example for `PreToolUse`, `PostToolUse`, `Stop`
 
 ## References
 
-For more information:
-- Claude Code Hooks Documentation: https://code.claude.com/docs/en/hooks
+- Claude Code Hooks: https://code.claude.com/docs/en/hooks
 - Plugin Configuration: https://code.claude.com/docs/en/plugins#hooks

--- a/plugins/tools/claude-code/skills/claude-skills/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-skills/SKILL.md
@@ -24,7 +24,7 @@ Skills fall into two categories (source: Anthropic PDF Guide):
 
 **Capability Uplift**: Enhances Claude's core abilities (coding, analysis, reasoning). These are stable across model versions because they build on general capabilities. Example: a code review skill that adds structured review steps.
 
-**Encoded Preference**: Encodes user-specific workflows, formatting, and conventions. These may need updates when models change because they depend on model behavior for fidelity. Example: a commit message skill that enforces team-specific format.
+**Encoded Preference**: Encodes user-specific workflows, formatting, and conventions. These need updates when models change because they depend on model behavior for fidelity. Example: a commit message skill that enforces team-specific format.
 
 When creating a skill, identify its category — this determines testing strategy and maintenance expectations.
 
@@ -82,44 +82,39 @@ license: MIT
 Main instructional content goes here...
 ```
 
-### Required YAML Properties
+### YAML Properties
 
-- `name`:
-   Hyphen-case identifier matching directory name (lowercase alphanumeric and hyphens only, max 64 characters)
-   Maximum 64 characters
-   Must contain only lowercase letters, numbers, and hyphens
-   Cannot contain XML tags
-   Cannot contain reserved words: "anthropic", "claude"
-- `description`:
-   Explains the skill's purpose and when Claude should utilize it
-   Must be non-empty
-   Maximum 1024 characters
-   Cannot contain XML tags
-   The description should include both what the Skill does and when Claude should use it. For complete authoring guidance, see the best practices guide.
+Source: [Claude Code Skills documentation](https://code.claude.com/docs/en/skills#frontmatter-reference). All fields are optional; only `description` is recommended.
 
+- `name`: Display name. If omitted, defaults to the directory name. Lowercase letters, numbers, and hyphens only (max 64 characters).
+- `description` (recommended): What the skill does and when to use it. Claude uses this to decide when to apply the skill. Combined `description` + `when_to_use` is truncated at 1,536 characters in the skill listing — put the key use case first.
+- `when_to_use`: Additional trigger phrases or example requests, appended to `description` in the listing.
+- `license`: License name or filename reference.
 
+The full upstream frontmatter reference (with `disable-model-invocation`, `user-invocable`, `allowed-tools`, `model`, `effort`, `context: fork`, `agent`, `hooks`, `paths`, `shell`, `arguments`, `argument-hint`, `metadata`) lives in `references/frontmatter-fields.md`. Load that reference when authoring a skill that needs anything beyond name/description/license.
 
-**Description Constraints** (from Anthropic best-practices):
-- Maximum 1024 characters
-- Must use third person (not "I can help you" or "You can use this")
-- Must include both **what it does** AND **when to use it**
-- Use pattern: `[What it does]. Use when [trigger conditions].`
+**Description constraints**:
+- Use third person (not "I can help you" or "You can use this")
+- Include both **what it does** AND **when to use it**
+- Pattern: `[What it does]. Use when [trigger conditions].`
 
-> **Critical**: The `description` is the ONLY text Claude sees during skill discovery (Level 1).
-> The body's "When to Use" section only loads AFTER activation (Level 2) and cannot trigger it.
-> All activation triggers must be in the description.
+> **Critical**: The `description` is the ONLY text Claude sees during skill discovery (Level 1). The body's "When to Use" section only loads AFTER activation (Level 2) and cannot trigger it. All activation triggers belong in the description.
 
+### Frontmatter policy for THIS marketplace
 
-### Optional YAML Properties
+The upstream Claude Code spec allows `allowed-tools` on a skill — it pre-approves listed tools while the skill is active. **This marketplace's `test/validate-plugin.nu` rejects `allowed-tools` on skills as a hard validation failure.** Reasoning:
 
-- `license`: License name or filename reference
-- `metadata`: Key-value string pairs for client-specific properties
+- Tool filtering belongs on **agents** (the `tools:` frontmatter on an agent file), not on skills the agent loads. See the `claude-agents` skill.
+- Skills in this marketplace stay capability-driven (knowledge, procedure) and inherit tools from the calling context.
+- An agent that needs constrained tool access defines its own allowlist; skills it consumes do not override that.
 
-> **Do not use `allowed-tools` in skill frontmatter.** Skills keep frontmatter minimal (`name`, `description`, optional `license`). Tool filtering applies to **agents** — declare the allowlist via the agent's `tools:` frontmatter field (see the `claude-agents` skill), not on the skill that the agent loads. Enforced by `validate-plugin.nu` and the skill-quality scorecard.
+When working in this marketplace: keep skill frontmatter to `name`, `description`, optional `license`, optional `metadata`. Use `allowed-tools` on agents instead.
+
+When working in another project that does not enforce this policy, the upstream `allowed-tools` field is valid and documented.
 
 ### Markdown Body
 
-The content section has no restrictions and should contain:
+The content section has no structural restrictions. Include:
 
 - When to activate the skill
 - Core procedural knowledge
@@ -127,11 +122,54 @@ The content section has no restrictions and should contain:
 - Examples and patterns
 - References to additional resources (if any)
 
+## Pre-edit checklist
+
+Before writing or editing any SKILL.md, verify:
+
+- [ ] Description uses third person and includes a `Use when ...` trigger pattern
+- [ ] Combined `description` + `when_to_use` under 1,536 characters
+- [ ] No `allowed-tools` field in frontmatter (this marketplace's validator rejects it; use agents for tool allowlists)
+- [ ] Body under 500 lines per upstream guideline; split into `references/` once exceeded
+- [ ] References stay one level deep (SKILL.md → reference, not reference → reference)
+- [ ] Zero hedging verbs: should, may, might, consider, try to, offer to, it would be good to
+- [ ] Anti-fabrication rules apply to this SKILL.md itself — every claim about a tool, file, or behavior is verifiable
+
+A failed checkbox is a blocker, not a preference.
+
+## Skill content types
+
+Three patterns from the upstream docs guide what to put in the body:
+
+- **Reference content** — knowledge, conventions, style guides. Loads inline alongside conversation context. Example: API design patterns for a codebase.
+- **Task content** — step-by-step instructions for a specific action (deploy, commit, generate). Often pair with `disable-model-invocation: true` to prevent automatic invocation.
+- **Subagent-fork content** — runs in an isolated context (`context: fork` + `agent: Explore|Plan|...`). Skill body becomes the task prompt; skill produces a self-contained result.
+
+## Dynamic context and substitutions
+
+Skills support runtime substitution before content reaches the model. Source: [Claude Code Skills docs](https://code.claude.com/docs/en/skills#inject-dynamic-context).
+
+**Shell injection** — `` !`<command>` `` inline or fenced ` ```! ` blocks run shell commands; output replaces the placeholder before Claude sees the skill:
+
+````markdown
+## Current diff
+!`git diff HEAD`
+````
+
+**String substitutions** in skill content:
+- `$ARGUMENTS` — full arguments string
+- `$ARGUMENTS[N]` or `$N` — argument by 0-based index
+- `$name` — named argument when `arguments:` declared in frontmatter
+- `${CLAUDE_SESSION_ID}` — current session ID
+- `${CLAUDE_EFFORT}` — current effort level
+- `${CLAUDE_SKILL_DIR}` — absolute path to this skill's directory (use for bundled scripts: `bash ${CLAUDE_SKILL_DIR}/scripts/foo.sh`)
+
+Disable shell injection across user/project/plugin skills via `"disableSkillShellExecution": true` in settings — useful for managed environments.
+
 ## Creating Skills: Seven-Step Workflow
 
 ### 1. Understanding Through Examples
 
-Gather concrete use cases to clarify what the skill should support. Real-world examples reveal actual needs better than theoretical requirements.
+Gather concrete use cases to clarify what the skill needs to support. Real-world examples reveal actual needs better than theoretical requirements.
 
 **Example:**
 ```
@@ -209,7 +247,7 @@ Refine based on real-world usage and evaluation data:
 - **Optimize descriptions**: Reduce false positives (too broad) and false negatives (too narrow)
 - **Test across models**: Verify behavior on Haiku, Sonnet, and Opus
 - **Monitor activation**: Track when the skill triggers correctly vs incorrectly
-- **Deprecation signal**: If the base model passes evals without the skill loaded, the skill may no longer be needed
+- **Deprecation signal**: If the base model passes evals without the skill loaded, the skill is unnecessary — deprecate it
 
 For description optimization techniques, see `references/evaluation-guide.md`.
 
@@ -223,7 +261,7 @@ Build skills using an evaluation-first approach (source: Anthropic Blog Post):
 2. **Test with and without**: Compare Claude's output with the skill loaded vs without it
 3. **Measure, don't guess**: Track pass rates, token usage, and timing — not subjective quality
 4. **Run A/B comparisons**: Use independent agents to compare skill versions blindly
-5. **Detect obsolescence**: When the base model passes evals without the skill, consider deprecation
+5. **Detect obsolescence**: When the base model passes evals without the skill, deprecate it
 
 For the complete methodology, see `references/evaluation-guide.md`. For a copyable checklist, see `templates/evaluation-checklist.md`.
 
@@ -232,7 +270,7 @@ For the complete methodology, see `references/evaluation-guide.md`. For a copyab
 Balance specificity against fragility in skill instructions (source: Anthropic PDF Guide):
 
 - **Specify constraints, not implementations**: "Ensure commit messages follow conventional format" not "Run git commit -m with prefix type(scope):"
-- **Allow model adaptation**: Instructions should work across Haiku, Sonnet, and Opus without modification
+- **Allow model adaptation**: Instructions must work across Haiku, Sonnet, and Opus without modification
 - **Test fragility**: If a minor model update breaks your skill, instructions are too rigid
 - **Test looseness**: If Claude produces inconsistent results, instructions are too loose
 
@@ -240,12 +278,14 @@ For the full framework with examples, see `references/design-patterns.md`.
 
 ### Context Window Discipline
 
-The context window is a shared resource (source: Anthropic PDF Guide):
+The context window is a shared resource (source: [Claude Code Skills docs](https://code.claude.com/docs/en/skills#add-supporting-files)):
 
-- Keep SKILL.md under **500 lines** — larger files degrade performance in smaller context windows
-- Move detailed content to `references/` and load only when needed
-- Monitor cumulative load: skill + prompt + conversation history must all fit
-- Every line in SKILL.md is loaded on every activation — justify each line's presence
+- Keep SKILL.md under **500 lines** per upstream guideline. Split detailed content into `references/` once the body exceeds 500 lines.
+- Move detailed reference material (API specs, deep-dive docs, examples) to separate files. Load only when needed.
+- Monitor cumulative load: skill + prompt + conversation history must all fit.
+- Every line in SKILL.md is loaded on every activation — justify each line's presence.
+
+**Skill content lifecycle:** A skill loads as a single message and stays for the session. Auto-compaction keeps the first 5,000 tokens of each invoked skill, with a 25,000-token combined budget filled from most-recently-invoked first. Older skills can be dropped after compaction. Re-invoke a skill if it stops influencing behavior post-compaction.
 
 ### Structure for Scale
 
@@ -271,12 +311,12 @@ Compare skill effectiveness using blind evaluation (source: Anthropic Blog Post)
 
 For detailed setup instructions, see `references/evaluation-guide.md`.
 
-### Consider Claude's Perspective
+### Claude's Perspective
 
 The skill name and description heavily influence when Claude activates it. Pay particular attention to:
 
-- **Name**: Should be clear and reflect the domain (e.g., `git-operations`, `elixir-phoenix`)
-- **Description**: Should specify both what the skill does and when to use it
+- **Name**: Reflects the domain in clear hyphen-case (e.g., `git-operations`, `elixir-phoenix`)
+- **Description**: States both what the skill does and when to use it, in third person
 
 > **Critical**: The `description` is the ONLY text Claude sees during skill discovery (Level 1).
 > The body's "When to Use" section only loads AFTER activation (Level 2) and cannot trigger it.
@@ -292,7 +332,7 @@ Monitor real usage patterns and iterate based on actual behavior.
 
 ### Platform Constraints
 
-Skills may run in different environments with different capabilities (source: Anthropic PDF Guide):
+Skills run in different environments with different capabilities (source: Anthropic PDF Guide):
 
 | Platform | Script Execution | Network | Filesystem |
 |----------|-----------------|---------|------------|

--- a/plugins/tools/claude-code/skills/claude-skills/references/frontmatter-fields.md
+++ b/plugins/tools/claude-code/skills/claude-skills/references/frontmatter-fields.md
@@ -1,0 +1,119 @@
+# Skill Frontmatter Reference
+
+Complete reference for SKILL.md YAML frontmatter fields. Source: [Claude Code Skills documentation](https://code.claude.com/docs/en/skills#frontmatter-reference). Load this when authoring a skill that needs anything beyond `name` / `description` / `license`.
+
+## All fields are optional
+
+Only `description` is recommended (so Claude knows when to invoke the skill).
+
+## Field reference
+
+### Identity
+
+| Field | Description |
+|---|---|
+| `name` | Display name. Defaults to directory name if omitted. Lowercase letters, numbers, hyphens only. Max 64 chars. |
+| `description` | What the skill does and when to use it. Use third person. Combined with `when_to_use` and capped at 1,536 chars in the listing — put key use case first. |
+| `when_to_use` | Additional triggers / example phrases. Appended to `description` in the listing; counts toward the 1,536-char cap. |
+| `license` | License name (e.g., `MIT`) or filename reference. |
+| `metadata` | Key-value string pairs for client-specific properties. |
+
+### Invocation control
+
+| Field | Description |
+|---|---|
+| `disable-model-invocation` | `true` prevents Claude from auto-loading the skill. User can still invoke with `/name`. Also blocks preload into subagents. Default: `false`. |
+| `user-invocable` | `false` hides the skill from the `/` menu. Claude can still invoke it. Use for background knowledge. Default: `true`. |
+| `argument-hint` | Autocomplete hint shown for arguments. Example: `[issue-number]` or `[filename] [format]`. |
+| `arguments` | Named positional arguments for `$name` substitution. Space-separated string or YAML list. Names map to argument positions in order. |
+
+### Tools and permissions
+
+| Field | Description |
+|---|---|
+| `allowed-tools` | Tools pre-approved while this skill is active. Space-separated string or YAML list. **Rejected by this marketplace's `test/validate-plugin.nu`** — declare allowlists on agents instead. Permission rules in `.claude/settings.json` still apply. |
+
+### Execution control
+
+| Field | Description |
+|---|---|
+| `model` | Override the session model while this skill is active. Same values as `/model`, or `inherit`. Reverts at end of turn. |
+| `effort` | Override effort level: `low`, `medium`, `high`, `xhigh`, `max`. Available levels depend on model. Default: inherit. |
+| `context` | `fork` runs the skill in a forked subagent context. Skill body becomes the subagent prompt. |
+| `agent` | Subagent type when `context: fork`. Built-in: `Explore`, `Plan`, `general-purpose`. Or any custom subagent in `.claude/agents/`. |
+| `hooks` | Hooks scoped to this skill's lifecycle. See `claude-hooks` skill. |
+| `paths` | Glob patterns that limit auto-activation. Comma-separated string or YAML list. Skill loads only when working with matching files. |
+| `shell` | `bash` (default) or `powershell` for `` !`...` `` inline shell. PowerShell requires `CLAUDE_CODE_USE_POWERSHELL_TOOL=1`. |
+
+## String substitutions in skill content
+
+| Variable | Expansion |
+|---|---|
+| `$ARGUMENTS` | All arguments passed when invoking the skill. |
+| `$ARGUMENTS[N]` / `$N` | Single argument by 0-based index. |
+| `$name` | Named argument from the `arguments:` frontmatter list. |
+| `${CLAUDE_SESSION_ID}` | Current session ID. |
+| `${CLAUDE_EFFORT}` | Current effort level. |
+| `${CLAUDE_SKILL_DIR}` | Absolute path to the skill's directory. Use for referencing bundled scripts: `bash ${CLAUDE_SKILL_DIR}/scripts/foo.sh`. |
+
+Indexed arguments use shell-style quoting. Wrap multi-word values in quotes: `/skill "hello world" second` makes `$0 = "hello world"`, `$1 = "second"`. `$ARGUMENTS` always expands to the full string as typed.
+
+## Dynamic context injection
+
+Inline shell commands run before the skill content reaches Claude. Output replaces the placeholder:
+
+```markdown
+## Current changes
+!`git diff HEAD`
+```
+
+Multi-line form uses a fenced code block opened with ` ```! `:
+
+````markdown
+## Environment
+```!
+node --version
+npm --version
+```
+````
+
+Disable across user/project/plugin/additional-directory skills via `"disableSkillShellExecution": true` in settings. Bundled and managed skills are unaffected.
+
+## Invocation matrix
+
+| Frontmatter | User invokes? | Claude invokes? | Description in context? |
+|---|---|---|---|
+| (default) | yes | yes | always |
+| `disable-model-invocation: true` | yes | no | not in context — full skill loads only when user invokes |
+| `user-invocable: false` | no | yes | always — but hidden from `/` menu |
+
+## Where skills live
+
+Precedence: enterprise > personal > project. Plugin skills use `plugin-name:skill-name` namespace and cannot conflict with other levels.
+
+| Location | Path | Scope |
+|---|---|---|
+| Enterprise | managed settings | All users in org |
+| Personal | `~/.claude/skills/<name>/SKILL.md` | All your projects |
+| Project | `.claude/skills/<name>/SKILL.md` | This project only |
+| Plugin | `<plugin>/skills/<name>/SKILL.md` | Where plugin is enabled |
+
+Live change detection: edits to existing skill directories take effect mid-session. Creating a top-level skills directory mid-session requires restart so the watcher picks it up.
+
+## Description budget
+
+Skill descriptions are loaded into context so Claude can decide when to invoke. Combined description + when_to_use is capped at 1,536 characters per skill in the listing.
+
+Total slash-command-tool char budget defaults to 1% of context window (or 8,000 char fallback). Override via `SLASH_COMMAND_TOOL_CHAR_BUDGET` env var. When too many skills exceed budget, descriptions get shortened — front-load the key use case.
+
+## Pre-approve patterns
+
+`allowed-tools` accepts patterns:
+
+```yaml
+allowed-tools: Bash(git add *) Bash(git commit *) Bash(git status *)
+```
+
+For project-level skills, `allowed-tools` activates after the workspace trust dialog is accepted, like `.claude/settings.json` permission rules. Review skills before trusting a repo — a malicious skill can grant itself broad tool access.
+
+This marketplace prohibits `allowed-tools` on skills (validator-enforced). The pattern lives on agents.

--- a/plugins/tools/claude-code/skills/claude-teams/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-teams/SKILL.md
@@ -8,6 +8,16 @@ license: MIT
 
 Coordinate multiple Claude Code agents working together on shared tasks.
 
+## When forming a team
+
+Invoke `/core:agent-loop` for the 4-phase / 6-tier execution model.
+Invoke `/claude-code:claude-agents` for agent file format, tool allowlists, and model selection.
+Invoke `/core:anti-fabrication` always — every claim about a tool, file, or test result requires tool execution.
+
+Require each teammate to quote one sentence from each loaded skill in its first message as proof of loading. Do not proceed with the teammate's work until proof is received.
+
+Glob patterns like `/core:*` do not expand in Agent prompts. List skill names explicitly.
+
 ## When to Use
 
 Activate when:


### PR DESCRIPTION
- Add SessionStart hook to core plugin (agent-loop tier model, skill-loading discipline)
- Add SessionStart hook to claude-code plugin (skill-authoring rules, agent/team triad anchor)
- Rewrite claude-hooks SKILL.md with correct event names (PreToolUse/PostToolUse/SessionStart/UserPromptSubmit/Stop/SubagentStop/PreCompact/Notification — was wrongly documenting onToolCall/onInstall/onUserPromptSubmit)
- Update claude-skills SKILL.md per new https://code.claude.com/docs/en/skills guidance: reframe allowed-tools as upstream-valid but marketplace-rejected, add full frontmatter table reference, document dynamic context injection and string substitutions
- Add references/frontmatter-fields.md with complete upstream field reference (when_to_use, disable-model-invocation, user-invocable, model, effort, context: fork, agent, hooks, paths, shell, arguments)
- Add agent/team triad anchors to claude-agents and claude-teams (cross-reference agent-loop)
- Update agent-loop SKILL.md: Phase 2 spawn gate, Skills-to-load-before-spawning block, proof-of-loading directive, concrete leader spawn example
- Add Before-spawn checklist to team-leader.md, fix optional-language hedge on /allium:distill
- Add marketplace fallback line to agent-worker.md
- Strip hedging verbs (should/may/might/consider/try-to/offer-to) across all 7 edited skill files
- Bump core 0.1.26 → 0.2.0, claude-code 0.1.14 → 0.2.0, all-skills 0.3.31 → 0.4.0 (clean break for Opus 4.7 literal-adherence behavior)

Closes claude-skills-30