### PR TITLE
feat(elixir): add ecto skill for schemas, changesets, migrations, and Multi

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -59,10 +59,10 @@
       "name": "elixir",
       "source": "./plugins/languages/elixir",
       "strict": true,
-      "description": "Elixir development skills: Phoenix, OTP, Ports, Tidewave MCP, testing, configuration, style",
-      "version": "0.1.7",
+      "description": "Elixir development skills: Phoenix, OTP, Ports, Ecto, Tidewave MCP, testing, configuration, style",
+      "version": "0.1.8",
       "category": "language",
-      "keywords": ["elixir", "phoenix", "otp", "ports", "style", "beam"]
+      "keywords": ["elixir", "phoenix", "otp", "ports", "ecto", "style", "beam"]
     },
     {
       "name": "github",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -54,6 +54,7 @@
     "./plugins/languages/elixir/skills/testing",
     "./plugins/languages/elixir/skills/config",
     "./plugins/languages/elixir/skills/ports",
+    "./plugins/languages/elixir/skills/ecto",
     "./plugins/languages/elixir/skills/style",
     "./plugins/languages/elixir/skills/tidewave",
     "./plugins/tools/github/skills/actions",

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@
 [tools]
 "github:nushell/nushell" = { version = "latest", exe = "nu", platforms = '{ linux-arm64 = { asset_pattern = "nu-*-aarch64-unknown-linux-gnu.tar.gz" }', " linux-x64 " = ' { asset_pattern = "nu-*-x86_64-unknown-linux-gnu.tar.gz" }', " macos-arm64 " = ' { asset_pattern = "nu-*-aarch64-apple-darwin.tar.gz" }', " macos-x64 " = ' { asset_pattern = "nu-*-x86_64-apple-darwin.tar.gz" } }' }
 act = "latest"  # Local GitHub Actions testing
+claude = "latest"  # Self-contained Bun binary; bypasses npm/node toolchain breakage
 
 # Note: Lima and Colima are macOS-only tools for local act testing
 # Install manually on Mac: mise install lima colima
@@ -41,16 +42,22 @@ run = """
 print "🔍 Running Claude native validation..."
 print ""
 
-# Check if claude CLI is available
-let claude_check = (which claude | is-not-empty)
-if not $claude_check {
-    print "⚠️  Claude CLI not found - skipping native validation"
-    print "   Install Claude Code to enable: https://claude.ai/download"
+# Resolve the mise-managed claude binary explicitly. PATH order on systems
+# that also have /opt/homebrew/bin/claude (npm-installed) finds homebrew's
+# node-based binary first, which can fail at runtime due to llhttp ABI drift.
+# The mise-managed claude is a self-contained Bun binary with no node deps.
+let claude_path = (do { mise which claude } | complete)
+
+if $claude_path.exit_code != 0 or ($claude_path.stdout | str trim | is-empty) {
+    print "⚠️  mise-managed claude not found - skipping native validation"
+    print "   Install via: mise install claude@latest"
     exit 0
 }
 
-# Run Claude's native validator
-let result = (do { claude plugin validate . } | complete)
+let claude_bin = ($claude_path.stdout | str trim)
+print $"Using ($claude_bin)"
+
+let result = (do { ^$claude_bin plugin validate . } | complete)
 
 if $result.exit_code == 0 {
     print $result.stdout

--- a/plugins/languages/elixir/.claude-plugin/plugin.json
+++ b/plugins/languages/elixir/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "elixir",
-  "version": "0.1.7",
-  "description": "Elixir development skills: Phoenix, OTP, Ports, Tidewave MCP, testing, configuration, style, and anti-patterns",
+  "version": "0.1.8",
+  "description": "Elixir development skills: Phoenix, OTP, Ports, Ecto, Tidewave MCP, testing, configuration, style, and anti-patterns",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["elixir", "phoenix", "otp", "ports", "style", "beam", "erlang"],
+  "keywords": ["elixir", "phoenix", "otp", "ports", "ecto", "style", "beam", "erlang"],
   "agents": [
     "./agents/tidewave.md"
   ],
@@ -18,6 +18,7 @@
     "./skills/testing",
     "./skills/config",
     "./skills/ports",
+    "./skills/ecto",
     "./skills/style",
     "./skills/tidewave"
   ]

--- a/plugins/languages/elixir/skills/ecto/SKILL.md
+++ b/plugins/languages/elixir/skills/ecto/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: ecto
+description: Guide for Ecto schemas, changesets, queries, migrations, and Multi. Use when writing Ecto migrations, querying or mutating Ecto schemas, designing changesets, working with Ecto.Multi, or choosing between Ecto query DSL and raw SQL.
+license: MIT
+---
+
+# Ecto
+
+Canonical reference for Ecto data work in Elixir. Verified against ecto 3.13.5 / ecto_sql 3.13.5 (signatures pulled from installed dep source). Newer minor versions add APIs but keep these signatures stable.
+
+## The default rule
+
+**Ecto schemas + changesets are the default. Raw SQL via `Ecto.Adapters.SQL.query/4` is the fallback.**
+
+Reads can use raw SQL when no Ecto query DSL covers the case. Writes go through changesets so validation and constraints run. Bypassing changesets silently ships malformed rows — bugs surface at read time, not write time.
+
+Reach for raw SQL only when one of the [escape-hatch criteria](#when-raw-sql-is-appropriate) applies. Default to `Repo.all`, `Repo.insert`, `Repo.update`, `Repo.delete` and changesets.
+
+## Reads — query DSL
+
+Use the `Ecto.Query` DSL (`from`, `where`, `join`, `select`, `fragment`) over string SQL. The DSL composes, type-checks against the schema, and prevents SQL injection.
+
+```elixir
+import Ecto.Query
+
+# Good — composable, type-safe
+def list_open_epics(repo_filter) do
+  from(e in Epic,
+    where: e.status == "open" and e.target_repos == ^repo_filter,
+    order_by: [desc: e.priority],
+    select: e
+  )
+  |> Repo.all()
+end
+
+# Use fragment/1 only for SQL the DSL cannot express
+def case_insensitive_search(term) do
+  from(e in Epic,
+    where: fragment("? ILIKE ?", e.title, ^"%#{term}%")
+  )
+  |> Repo.all()
+end
+```
+
+```elixir
+# Bad — string SQL, no schema typing, no composition
+Ecto.Adapters.SQL.query!(Repo,
+  "SELECT * FROM epics WHERE status = $1",
+  ["open"]
+)
+```
+
+`Repo.get/3` (single by primary key), `Repo.one/2` (assert single result), `Repo.all/2` (list), `Repo.exists?/2` (boolean) cover most read entry points.
+
+## Writes — changesets
+
+Every write builds a `%Ecto.Changeset{}` from a struct + attrs, then runs through `Repo.insert/2`, `Repo.update/2`, or `Repo.delete/2`.
+
+Verified signatures (ecto 3.13.5):
+
+```elixir
+Ecto.Changeset.cast(data, params, permitted, opts \\ [])
+Ecto.Changeset.validate_required(changeset, fields, opts \\ [])
+Ecto.Changeset.unique_constraint(changeset, field_or_fields, opts \\ [])
+Ecto.Changeset.validate_format(changeset, field, regex, opts \\ [])
+```
+
+Real exemplar from `Vantageex.Epics.Epic`:
+
+```elixir
+def changeset(epic, attrs) do
+  epic
+  |> cast(attrs, [:external_id, :title, :slug, :objective, :status, :priority])
+  |> validate_required([:external_id, :title, :slug, :objective])
+  |> validate_inclusion(:status, @valid_statuses)
+  |> unique_constraint(:slug)
+end
+```
+
+Return tuples are `{:ok, struct}` on success or `{:error, %Ecto.Changeset{}}` on validation/constraint failure. Pattern-match both branches:
+
+```elixir
+def create_epic(attrs) do
+  %Epic{}
+  |> Epic.changeset(attrs)
+  |> Repo.insert()
+end
+
+case create_epic(attrs) do
+  {:ok, epic} -> handle_success(epic)
+  {:error, changeset} -> render_errors(changeset)
+end
+```
+
+For bang-vs-non-bang and idiomatic error returns, see `/elixir:style`.
+
+## Batch writes
+
+`Repo.update_all/3` and `Repo.delete_all/2` skip changesets — no per-row validation, no `before_*`/`after_*` hooks. Use them for mass updates where validation is irrelevant or already enforced upstream.
+
+```elixir
+# Bulk: clear stale fields across many rows
+from(e in Epic, where: e.status == "stale")
+|> Repo.update_all(set: [last_peek_output: nil])
+```
+
+When validation matters, prefer N changeset updates inside a transaction over one `update_all`. Measure before bulk-updating "for performance" — Postgres handles thousands of indexed updates in milliseconds.
+
+## Migrations
+
+Schema changes use `add`, `alter`, `drop`, `create index`, `create table` macros. Verified signatures (ecto_sql 3.13.5):
+
+```elixir
+Ecto.Migration.add(column, type, opts \\ [])
+Ecto.Migration.execute(command)  # binary, 0-arity fn, or list
+defmacro create(object, do: block)  # for tables/indexes with column blocks
+```
+
+```elixir
+defmodule MyApp.Repo.Migrations.AddPriorityToEpics do
+  use Ecto.Migration
+
+  def change do
+    alter table(:epics) do
+      add :priority, :integer, default: 10, null: false
+    end
+    create index(:epics, [:priority])
+  end
+end
+```
+
+### Data migrations — local snapshot schema pattern
+
+Data migrations transform existing rows. Two rules:
+
+1. **Never `alias` the live application schema.** The live schema evolves; a migration written against `MyApp.Epics.Epic` today breaks when fields get renamed or removed in a future migration. Replay from scratch fails.
+2. **Define a local snapshot schema inside the migration module.** It captures the schema's shape at this point in history.
+
+```elixir
+defmodule MyApp.Repo.Migrations.BackfillEpicPriority do
+  use Ecto.Migration
+  import Ecto.Query
+
+  defmodule Epic do
+    use Ecto.Schema
+    schema "epics" do
+      field :priority, :integer
+      field :status, :string
+    end
+  end
+
+  def change do
+    repo = repo()
+
+    from(e in Epic, where: is_nil(e.priority))
+    |> repo.all()
+    |> Enum.each(fn epic ->
+      epic
+      |> Ecto.Changeset.change(priority: priority_for_status(epic.status))
+      |> repo.update!()
+    end)
+  end
+
+  defp priority_for_status("urgent"), do: 1
+  defp priority_for_status(_), do: 10
+end
+```
+
+This pattern dogfoods Ecto end-to-end: queries via DSL, writes via changesets, schemas frozen to migration time. See `references/migrations.md` for additional recipes.
+
+### When `execute/1` is appropriate
+
+`execute/1` runs raw SQL inside a migration. Use it for DB-specific DDL the macros do not cover:
+
+- Postgres extensions: `execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")`
+- Custom indexes: `execute("CREATE INDEX CONCURRENTLY ...")` (note: `CONCURRENTLY` requires `@disable_ddl_transaction true`)
+- Trigger functions, materialized views, partitioning DDL
+
+`execute/1` is **never** the right tool for data transformations. Use the local-snapshot pattern above.
+
+## Multi-step atomic ops — Ecto.Multi
+
+`Ecto.Multi` chains operations into one transaction. If any step fails, prior steps roll back. As of ecto 3.13, `Repo.transaction/2` is deprecated — use `Repo.transact/2`.
+
+Verified signatures:
+
+```elixir
+Ecto.Multi.new()                              # empty %Ecto.Multi{}
+Ecto.Multi.insert(multi, name, changeset_or_struct_or_fn, opts \\ [])
+Ecto.Multi.update(multi, name, changeset_or_fn, opts \\ [])
+Repo.transact(multi_or_fn, opts \\ [])
+```
+
+```elixir
+def transfer_funds(from_id, to_id, amount) do
+  Ecto.Multi.new()
+  |> Ecto.Multi.update(:debit, debit_changeset(from_id, amount))
+  |> Ecto.Multi.update(:credit, credit_changeset(to_id, amount))
+  |> Ecto.Multi.insert(:audit, fn %{debit: debit} ->
+    AuditLog.changeset(%AuditLog{}, %{from: debit.id, amount: amount})
+  end)
+  |> Repo.transact()
+end
+```
+
+On success: `{:ok, %{debit: ..., credit: ..., audit: ...}}`. On failure: `{:error, failed_step_name, failed_value, changes_so_far}`. Pattern-match the four-tuple for the failed-step branch.
+
+The third argument to `Multi.insert/4` and `Multi.update/4` accepts a 1-arity function `fn changes -> changeset end` — that is how downstream steps reference upstream results.
+
+## When raw SQL IS appropriate
+
+Escape hatch criteria. Each one requires evidence, not assumption.
+
+- **Complex CTEs / window functions** Ecto's DSL does not expose. Document the missing DSL feature in a comment.
+- **DB-specific features**: PostGIS spatial queries, full-text search ranking with custom dictionaries, advisory locks.
+- **Perf-critical hot paths** with measured Ecto overhead. Benchmark first; "it feels slow" is not evidence.
+- **One-off reads** in tidewave eval (single-cell exploration). Never one-off writes — those go through a changeset even at the REPL.
+
+```elixir
+# Acceptable: PostGIS — no DSL covers ST_DWithin
+{:ok, %{rows: rows}} =
+  Ecto.Adapters.SQL.query(
+    Repo,
+    "SELECT id FROM places WHERE ST_DWithin(location, ST_MakePoint($1, $2)::geography, $3)",
+    [lng, lat, radius]
+  )
+```
+
+## Anti-patterns
+
+### `repo().query!("UPDATE ...")` in migrations
+
+Bypasses Ecto, hides errors, locks the migration to the current row shape. Replace with the local-snapshot pattern.
+
+```elixir
+# Bad
+def change do
+  repo().query!("UPDATE epics SET priority = 1 WHERE status = 'urgent'")
+end
+
+# Good — snapshot schema + Repo.update_all (or Repo.update for per-row validation)
+defmodule Epic do
+  use Ecto.Schema
+  schema "epics" do
+    field :priority, :integer
+    field :status, :string
+  end
+end
+
+def change do
+  from(e in Epic, where: e.status == "urgent")
+  |> repo().update_all(set: [priority: 1])
+end
+```
+
+### Bypassing changeset validation via `insert_all`
+
+`Repo.insert_all/3` inserts raw maps without changesets. Use it only when you have already validated the data upstream OR when the rows are infrastructure (e.g. seed data). For user input, always go through a changeset.
+
+### Importing live application schema into old migrations
+
+```elixir
+# Bad — couples migration N to whatever Epic looks like at HEAD
+defmodule MyApp.Repo.Migrations.OldMigration do
+  alias MyApp.Epics.Epic   # WRONG
+  ...
+end
+```
+
+A schema change six months from now breaks migration replay. Define a local snapshot schema instead (see [Migrations](#migrations) above).
+
+### "Raw SQL because it's faster"
+
+Without measurement, this is fabrication. Ecto's overhead vs raw SQL is microseconds per row. Most perceived "slow Ecto" is N+1 queries (fix with `Repo.preload/3` or a join), missing indexes, or unbounded result sets — not the DSL itself.
+
+## References
+
+- `references/migrations.md` — local snapshot schema deep dive, common DDL recipes, reversible migrations, `@disable_ddl_transaction` rules
+- `references/changesets.md` — `cast_assoc`, `validate_*` catalog, custom validations, `prepare_changes/2`
+- HexDocs: [Ecto](https://hexdocs.pm/ecto/), [Ecto.Changeset](https://hexdocs.pm/ecto/Ecto.Changeset.html), [Ecto.Query](https://hexdocs.pm/ecto/Ecto.Query.html), [Ecto.Multi](https://hexdocs.pm/ecto/Ecto.Multi.html), [Ecto.Migration](https://hexdocs.pm/ecto_sql/Ecto.Migration.html)
+- `/elixir:tidewave` — runtime introspection of schemas via `mcp__tidewave__get_ecto_schemas` and live API doc lookup
+- `/elixir:phoenix-framework` — context-pattern integration (changeset usage in Phoenix contexts)
+- `/elixir:style` — bang-vs-non-bang return semantics, idiomatic error returns
+
+## Anti-fabrication
+
+Every API signature in this skill is verified from the installed source under `deps/ecto/` and `deps/ecto_sql/` (ecto 3.13.5). When this skill is loaded:
+
+- Cite signatures from `mcp__tidewave__get_docs` or the installed dep source — not memory.
+- Mark any unverified function as "requires investigation".
+- See `/core:anti-fabrication` for the authoritative guide.

--- a/plugins/languages/elixir/skills/ecto/references/changesets.md
+++ b/plugins/languages/elixir/skills/ecto/references/changesets.md
@@ -1,0 +1,185 @@
+# Ecto Changesets — Deep Dive
+
+Loaded on demand for non-trivial changeset work: associations, custom validations, prepare hooks. Pairs with the [Writes — changesets](../SKILL.md#writes--changesets) section in the parent skill.
+
+## Table of contents
+
+- [The cast pipeline](#the-cast-pipeline)
+- [Built-in validations](#built-in-validations)
+- [Constraint mapping](#constraint-mapping)
+- [Custom validations](#custom-validations)
+- [`cast_assoc` and `cast_embed`](#cast_assoc-and-cast_embed)
+- [`prepare_changes/2`](#prepare_changes2)
+- [Multiple changesets per schema](#multiple-changesets-per-schema)
+- [Inspecting changesets](#inspecting-changesets)
+
+## The cast pipeline
+
+`cast/4` extracts permitted fields from a params map. `validate_*` functions add errors. Constraint functions (`unique_constraint`, `foreign_key_constraint`, `check_constraint`) translate DB errors to changeset errors when the changeset hits the Repo.
+
+```elixir
+def changeset(struct, attrs) do
+  struct
+  |> cast(attrs, [:title, :slug, :status])         # extract
+  |> validate_required([:title, :slug])             # validate
+  |> validate_length(:title, max: 200)              # validate
+  |> unique_constraint(:slug)                       # constraint mapping
+end
+```
+
+Order matters for readability: cast → validate → constraint mapping. `cast/4` only adds fields listed in `permitted` — anything else is silently dropped. That is the security property: untrusted params can't set arbitrary columns.
+
+## Built-in validations
+
+Verified against ecto 3.13.5 (`deps/ecto/lib/ecto/changeset.ex`):
+
+| Function | Checks |
+|---|---|
+| `validate_required(cs, fields, opts)` | All fields are non-nil and non-blank |
+| `validate_length(cs, field, opts)` | `:min`, `:max`, `:is`, `:count` (`:graphemes`/`:codepoints`/`:bytes`) |
+| `validate_format(cs, field, regex, opts)` | Regex match |
+| `validate_inclusion(cs, field, list, opts)` | Value in list |
+| `validate_exclusion(cs, field, list, opts)` | Value not in list |
+| `validate_subset(cs, field, list, opts)` | Field (a list) is subset of list |
+| `validate_number(cs, field, opts)` | `:less_than`, `:greater_than`, `:less_than_or_equal_to`, `:greater_than_or_equal_to`, `:equal_to`, `:not_equal_to` |
+| `validate_acceptance(cs, field, opts)` | Field is `true` (terms-of-service style) |
+| `validate_confirmation(cs, field, opts)` | `field_confirmation` matches `field` |
+| `validate_change(cs, field, validator)` | Custom validator function |
+
+Every validation accepts `:message` to override the default error string. Errors accumulate on the changeset — multiple validation failures all surface to the caller.
+
+## Constraint mapping
+
+Constraints translate Postgres errors into changeset errors at insert/update time. Without these, a constraint violation raises an exception instead of returning `{:error, changeset}`.
+
+```elixir
+|> unique_constraint(:email)
+|> foreign_key_constraint(:owner_id)
+|> check_constraint(:age, name: :age_must_be_positive)
+|> exclusion_constraint(:reserved, name: :no_overlapping_reservations)
+|> assoc_constraint(:owner)              # FK on a belongs_to assoc
+|> no_assoc_constraint(:posts)           # blocks delete if children exist
+```
+
+The `:name` option matches the actual Postgres constraint name. Default conventions:
+- `unique_index(:users, [:email])` → constraint name `users_email_index` → `unique_constraint(:email)` works without `:name`.
+- Custom-named constraints require `:name`.
+
+## Custom validations
+
+```elixir
+def changeset(struct, attrs) do
+  struct
+  |> cast(attrs, [:start_date, :end_date])
+  |> validate_required([:start_date, :end_date])
+  |> validate_date_range()
+end
+
+defp validate_date_range(changeset) do
+  start_date = get_field(changeset, :start_date)
+  end_date = get_field(changeset, :end_date)
+
+  if start_date && end_date && Date.compare(start_date, end_date) == :gt do
+    add_error(changeset, :end_date, "must be after start_date")
+  else
+    changeset
+  end
+end
+```
+
+`get_field/2` reads from changes-or-data; `get_change/2` reads only from changes (returns `nil` if unchanged). Use `get_field` for cross-field validations.
+
+## `cast_assoc` and `cast_embed`
+
+For nested data (associations or embedded schemas), use `cast_assoc/3` / `cast_embed/3` instead of cascading `cast/4` calls.
+
+```elixir
+schema "orders" do
+  field :total, :decimal
+  has_many :line_items, MyApp.LineItem
+end
+
+def changeset(order, attrs) do
+  order
+  |> cast(attrs, [:total])
+  |> cast_assoc(:line_items, with: &MyApp.LineItem.changeset/2, required: true)
+end
+```
+
+`cast_assoc` handles inserts (new children), updates (existing children matched by primary key), and deletes (set `:replace_assoc_with` or pass an `__delete__` flag depending on version). It runs the child's changeset for each item.
+
+`cast_embed/3` is the same pattern for embedded schemas (`embeds_one` / `embeds_many`). Embeds live inside the parent's row; associations are separate tables.
+
+## `prepare_changes/2`
+
+Runs a function during `Repo.insert/update/delete`, after validations but before hitting the database, inside the same transaction. Useful for derived fields that need a DB query:
+
+```elixir
+def changeset(post, attrs) do
+  post
+  |> cast(attrs, [:title, :content])
+  |> validate_required([:title, :content])
+  |> prepare_changes(fn changeset ->
+    case get_change(changeset, :title) do
+      nil -> changeset
+      title -> put_change(changeset, :slug, slugify(title))
+    end
+  end)
+end
+```
+
+Code inside `prepare_changes` runs against the transaction's repo — `repo.insert(...)` inside it would commit to the same transaction.
+
+## Multiple changesets per schema
+
+Different write paths often need different validation rules. Define multiple changeset functions:
+
+```elixir
+def changeset(epic, attrs) do
+  epic
+  |> cast(attrs, [:title, :slug, :status])
+  |> validate_required([:title, :slug])
+end
+
+def admin_changeset(epic, attrs) do
+  epic
+  |> changeset(attrs)
+  |> cast(attrs, [:priority, :auto_merge])  # admin-only fields
+end
+
+def status_transition(epic, new_status) do
+  epic
+  |> change(status: new_status)
+  |> validate_inclusion(:status, @valid_statuses)
+end
+```
+
+`change/2` builds a changeset directly without going through `cast/4` — use it when the input is already trusted (internal code, not user params).
+
+## Inspecting changesets
+
+```elixir
+%Ecto.Changeset{
+  valid?: false,
+  changes: %{title: "New"},
+  errors: [slug: {"can't be blank", [validation: :required]}],
+  data: %Epic{...},
+  changeset_fields: [...]
+}
+```
+
+- `valid?` — false if any errors accumulated
+- `changes` — only the fields cast that differ from `data`
+- `errors` — keyword list of `{field, {message, metadata}}`
+- `data` — the original struct
+
+`Ecto.Changeset.traverse_errors/2` flattens errors for rendering:
+
+```elixir
+Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+  Enum.reduce(opts, msg, fn {key, value}, acc ->
+    String.replace(acc, "%{#{key}}", to_string(value))
+  end)
+end)
+# => %{slug: ["can't be blank"]}
+```

--- a/plugins/languages/elixir/skills/ecto/references/migrations.md
+++ b/plugins/languages/elixir/skills/ecto/references/migrations.md
@@ -1,0 +1,202 @@
+# Ecto Migrations — Deep Dive
+
+Loaded on demand when authoring or reviewing an Ecto migration. Pairs with the [Migrations](../SKILL.md#migrations) section in the parent skill.
+
+## Table of contents
+
+- [Local snapshot schema pattern (the rule)](#local-snapshot-schema-pattern-the-rule)
+- [Reversible vs irreversible migrations](#reversible-vs-irreversible-migrations)
+- [Common DDL recipes](#common-ddl-recipes)
+- [`@disable_ddl_transaction` and concurrent indexes](#disable_ddl_transaction-and-concurrent-indexes)
+- [Backfilling large tables in batches](#backfilling-large-tables-in-batches)
+- [`execute/2` for reversible raw SQL](#execute2-for-reversible-raw-sql)
+- [Ordering rules](#ordering-rules)
+
+## Local snapshot schema pattern (the rule)
+
+Data migrations transform existing rows. The rule is: **never `alias` the live application schema inside a migration**. The live schema evolves; the migration is a historical artifact. Coupling them breaks replay.
+
+```elixir
+defmodule MyApp.Repo.Migrations.BackfillUserDisplayName do
+  use Ecto.Migration
+  import Ecto.Query
+
+  # Local snapshot — frozen to this migration's point in history.
+  # Never `alias MyApp.Accounts.User`.
+  defmodule User do
+    use Ecto.Schema
+
+    schema "users" do
+      field :first_name, :string
+      field :last_name, :string
+      field :display_name, :string
+    end
+  end
+
+  def change do
+    repo = repo()
+
+    from(u in User, where: is_nil(u.display_name))
+    |> repo.all()
+    |> Enum.each(fn user ->
+      user
+      |> Ecto.Changeset.change(display_name: "#{user.first_name} #{user.last_name}")
+      |> repo.update!()
+    end)
+  end
+end
+```
+
+Why this works when the live `User` schema later drops `first_name`:
+- The migration's local `User` still references `first_name` (frozen in time).
+- Replay reads the column that existed at this migration's point, not what HEAD looks like now.
+- New developers running migrations from scratch get a working backfill.
+
+## Reversible vs irreversible migrations
+
+`change/0` covers the common case — Ecto infers the rollback. Use `up/0` + `down/0` when the rollback isn't auto-derivable, or when the migration is data-only.
+
+```elixir
+def up do
+  alter table(:users) do
+    add :role, :string, default: "member", null: false
+  end
+end
+
+def down do
+  alter table(:users) do
+    remove :role
+  end
+end
+```
+
+Mark genuinely-irreversible data migrations:
+
+```elixir
+def up do
+  # ... data transformation ...
+end
+
+def down do
+  raise Ecto.MigrationError, "irreversible: backfill cannot be undone safely"
+end
+```
+
+## Common DDL recipes
+
+### Add a NOT NULL column with a default
+
+```elixir
+def change do
+  alter table(:epics) do
+    add :priority, :integer, default: 10, null: false
+  end
+end
+```
+
+Postgres rewrites the table on default-with-NOT-NULL on older versions. Postgres 11+ handles this without rewrite when the default is a constant.
+
+### Add a NOT NULL column to a populated table without a default
+
+Three steps across migrations:
+
+```elixir
+# Migration 1: add nullable
+alter table(:epics) do: add :owner_id, :binary_id
+
+# Migration 2: backfill (local snapshot pattern)
+# ... see above ...
+
+# Migration 3: enforce
+alter table(:epics) do: modify :owner_id, :binary_id, null: false
+```
+
+### Rename a column
+
+```elixir
+def change do
+  rename table(:epics), :slug, to: :handle
+end
+```
+
+Postgres handles this without table rewrite. Application code referencing the old name breaks at runtime — coordinate with a deploy.
+
+### Composite unique index
+
+```elixir
+def change do
+  create unique_index(:epics, [:tenant_id, :slug], name: :epics_tenant_slug_index)
+end
+```
+
+Pair with `unique_constraint(:slug, name: :epics_tenant_slug_index)` in the changeset.
+
+### Foreign key with cascade
+
+```elixir
+def change do
+  alter table(:tasks) do
+    add :epic_id, references(:epics, type: :binary_id, on_delete: :delete_all), null: false
+  end
+  create index(:tasks, [:epic_id])
+end
+```
+
+Always create an index on FK columns — Postgres does not auto-index them.
+
+## `@disable_ddl_transaction` and concurrent indexes
+
+Postgres `CREATE INDEX CONCURRENTLY` cannot run inside a transaction. Disable the migration-wrapping transaction:
+
+```elixir
+defmodule MyApp.Repo.Migrations.AddIndexConcurrently do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    create index(:epics, [:status], concurrently: true)
+  end
+end
+```
+
+`@disable_migration_lock true` is required when the migration runs against a hot table — the default lock blocks writes.
+
+## Backfilling large tables in batches
+
+A single `Repo.update_all` over millions of rows holds locks too long. Batch by primary key:
+
+```elixir
+def change do
+  batch_size = 1_000
+  stream_batches(batch_size, fn ids ->
+    from(u in User, where: u.id in ^ids and is_nil(u.display_name))
+    |> repo().update_all(set: [display_name: ""])
+  end)
+end
+
+defp stream_batches(size, fun) do
+  # Iterate by max(id) cursor — see HexDocs Ecto.Repo.stream/2
+end
+```
+
+For very large tables, use `Repo.stream/2` inside a transaction with `:max_rows` set, or process in an external worker. Migrations are the wrong place for multi-hour backfills — separate the schema change from the data change.
+
+## `execute/2` for reversible raw SQL
+
+`execute/1` runs one direction. `execute/2` provides up + down strings for reversibility:
+
+```elixir
+def change do
+  execute(
+    "CREATE EXTENSION IF NOT EXISTS pgcrypto",
+    "DROP EXTENSION IF EXISTS pgcrypto"
+  )
+end
+```
+
+## Ordering rules
+
+- One migration per schema change. Mixing column adds, data backfill, and NOT NULL enforcement in one migration creates a non-recoverable state on partial failure.
+- File names are timestamps — `20260507120000_add_priority_to_epics.exs`. The timestamp is the order; never edit it after merge.
+- `mix ecto.migrate` is idempotent when migrations are pure. Side effects (file writes, HTTP calls, queue publishes) inside `change/0` break that — keep migrations DB-only.

--- a/plugins/languages/elixir/skills/sources.md
+++ b/plugins/languages/elixir/skills/sources.md
@@ -224,11 +224,59 @@ This file documents the sources used to create the elixir plugin skills.
 - **Date Accessed**: 2026-03-29
 - **Key Topics**: schema/2, embedded_schema/1, field types, associations
 
+## Ecto Skill
+
+### Ecto Documentation
+- **URL**: https://hexdocs.pm/ecto/
+- **Purpose**: Foundation for the Ecto skill — schemas, changesets, queries, Multi
+- **Date Accessed**: 2026-05-06
+- **Key Topics**: Repo callbacks, changeset pipeline, query DSL, transactions
+
+### Ecto.Changeset
+- **URL**: https://hexdocs.pm/ecto/Ecto.Changeset.html
+- **Purpose**: Authoritative reference for `cast/4`, `validate_*`, constraint mapping
+- **Date Accessed**: 2026-05-06
+- **Key Topics**: cast pipeline, validation catalog, `prepare_changes/2`, `cast_assoc`, `cast_embed`
+
+### Ecto.Query
+- **URL**: https://hexdocs.pm/ecto/Ecto.Query.html
+- **Purpose**: Reference for the query DSL, `from`, `where`, `join`, `select`, `fragment`
+- **Date Accessed**: 2026-05-06
+- **Key Topics**: query composition, `fragment/1`, `subquery/1`, named bindings
+
+### Ecto.Multi
+- **URL**: https://hexdocs.pm/ecto/Ecto.Multi.html
+- **Purpose**: Reference for atomic multi-step operations
+- **Date Accessed**: 2026-05-06
+- **Key Topics**: `Multi.new/0`, `Multi.insert/4`, `Multi.update/4`, `Multi.run/3`, transaction failure tuple
+
+### Ecto.Migration (ecto_sql)
+- **URL**: https://hexdocs.pm/ecto_sql/Ecto.Migration.html
+- **Purpose**: Reference for migration DDL — `add`, `alter`, `create`, `execute`, indexes, references
+- **Date Accessed**: 2026-05-06
+- **Key Topics**: `change/0` vs `up/down`, `@disable_ddl_transaction`, concurrent indexes, reversible `execute/2`
+
+### Ecto.Adapters.SQL
+- **URL**: https://hexdocs.pm/ecto_sql/Ecto.Adapters.SQL.html
+- **Purpose**: Raw SQL escape-hatch reference — `query/4`, `query!/4`, return shape
+- **Date Accessed**: 2026-05-06
+- **Key Topics**: `{:ok, %{columns, rows}}` return shape, parameter binding, telemetry
+
+### Verified runtime sources
+- **Path**: `~/github/vantageex/deps/ecto/lib/ecto/` and `~/github/vantageex/deps/ecto_sql/lib/`
+- **Purpose**: Anti-fabrication — every API signature in the skill body is read from the installed dep source for ecto 3.13.5 / ecto_sql 3.13.5, not memory.
+- **Date Accessed**: 2026-05-06
+
+### Vantageex.Epics.Epic exemplar
+- **Path**: `~/github/vantageex/lib/vantageex/epics/epic.ex`
+- **Purpose**: Real-world changeset example referenced in the Writes — changesets section of SKILL.md
+- **Date Accessed**: 2026-05-06
+
 ## Plugin Information
 
 - **Name**: elixir
-- **Version**: 0.1.7
-- **Description**: Elixir development skills: Phoenix, OTP, Ports, Style, testing, configuration, anti-patterns, and Tidewave MCP dev tools
-- **Skills**: 8 skills covering Elixir language, framework, and best practices
+- **Version**: 0.1.8
+- **Description**: Elixir development skills: Phoenix, OTP, Ports, Ecto, Style, testing, configuration, anti-patterns, and Tidewave MCP dev tools
+- **Skills**: 9 skills covering Elixir language, framework, and best practices
 - **Created**: 2025-11-15
-- **Updated**: 2026-03-29
+- **Updated**: 2026-05-06


### PR DESCRIPTION
- Add /elixir:ecto skill at plugins/languages/elixir/skills/ecto/SKILL.md (291 lines, 12/12 quality score)
- Default rule: Ecto schemas + changesets are the default; raw SQL is the fallback
- Cover query DSL, changesets, batch writes, migrations, Ecto.Multi, escape-hatch criteria, anti-patterns
- references/migrations.md: local snapshot schema pattern, concurrent indexes, batched backfills, reversible execute
- references/changesets.md: validation catalog, constraint mapping, cast_assoc/cast_embed, prepare_changes, traverse_errors
- API signatures verified against installed source (ecto 3.13.5, ecto_sql 3.13.5) — anti-fabrication
- Real exemplar from Vantageex.Epics.Epic in changeset section
- Note Repo.transaction/2 deprecation in 3.13 → use Repo.transact/2
- Bump elixir plugin 0.1.7 → 0.1.8 in plugin.json and marketplace.json
- Add ecto keyword to plugin and marketplace entries
- Update sources.md with HexDocs URLs and verified-runtime-source attribution
- mise update-all-skills synced (72 skills total in all-skills meta-plugin)
- Closes claude-skills-31