### PR TITLE
feat(ansible): Add ansible plugin with 5 skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "A curated collection of Claude skills for development workflows",
-    "version": "1.0.6"
+    "version": "1.0.7"
   },
   "plugins": [
     {
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -26,6 +26,16 @@
       "version": "0.1.0",
       "category": "tools",
       "keywords": ["allium", "agent-loop", "tdd", "behavioral-spec"],
+      "license": "MIT"
+    },
+    {
+      "name": "ansible",
+      "source": "./plugins/tools/ansible",
+      "strict": true,
+      "description": "Ansible automation skills: playbooks, inventory, roles, vault secrets, and Molecule testing",
+      "version": "0.1.0",
+      "category": "tools",
+      "keywords": ["ansible", "automation", "configuration-management", "devops", "playbooks", "molecule"],
       "license": "MIT"
     },
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -19,6 +19,11 @@
   ],
   "skills": [
     "./plugins/tools/allium/skills/allium",
+    "./plugins/tools/ansible/skills/ansible",
+    "./plugins/tools/ansible/skills/ansible-inventory",
+    "./plugins/tools/ansible/skills/ansible-roles",
+    "./plugins/tools/ansible/skills/ansible-vault",
+    "./plugins/tools/ansible/skills/ansible-testing",
     "./plugins/tools/claude-code/skills/plugin-marketplace",
     "./plugins/tools/claude-code/skills/claude-plugins",
     "./plugins/tools/claude-code/skills/claude-commands",

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Add the marketplace and install plugins:
 /plugin install tweag@vinnie357       # Topiary formatter and Nickel config
 /plugin install ui@vinnie357          # daisyUI, Tailwind CSS theming
 /plugin install claude-code@vinnie357 # Plugin marketplace management tools
+/plugin install ansible@vinnie357      # Ansible automation, roles, vault, testing
 ```
 
 Verify installation:
@@ -195,6 +196,19 @@ Claude Code plugin marketplace management and validation.
 
 **Keywords**: claude-code, marketplace, validation
 
+### `ansible` - Ansible Automation
+
+Ansible configuration management and automation skills.
+
+**Skills:**
+- **ansible** - Playbooks, tasks, handlers, variables, conditionals, loops, and project layout
+- **ansible-inventory** - Static and dynamic inventory, host patterns, group_vars, host_vars
+- **ansible-roles** - Role structure, Galaxy collections, Jinja2 templates, role dependencies
+- **ansible-vault** - Encrypting secrets, vault IDs, password sources, security practices
+- **ansible-testing** - Molecule test scenarios, Docker/Podman drivers, Testinfra, CI integration
+
+**Keywords**: ansible, automation, configuration-management, devops, playbooks, molecule
+
 ## Usage
 
 Skills are automatically activated by Claude based on task context once plugins are installed.
@@ -258,6 +272,7 @@ claude-skills/
     │   ├── rust/                 # Rust programming
     │   └── zig/                  # Zig programming
     ├── tools/
+    │   ├── ansible/              # Ansible automation
     │   ├── claude-code/          # Plugin development tools
     │   ├── dagu/                 # Workflow orchestration
     │   ├── github/               # GitHub Actions and workflows
@@ -306,6 +321,7 @@ Install only the plugins you need:
 # DevOps/Platform engineer
 /plugin install core@vinnie357
 /plugin install dagu@vinnie357
+/plugin install ansible@vinnie357
 
 # Plugin developer
 /plugin install claude-code@vinnie357

--- a/plugins/tools/ansible/.claude-plugin/plugin.json
+++ b/plugins/tools/ansible/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "ansible",
+  "version": "0.1.0",
+  "description": "Ansible automation skills: playbooks, inventory, roles, vault secrets, and Molecule testing",
+  "author": {
+    "name": "rginnow"
+  },
+  "repository": "https://github.com/rginnow/claude-skills",
+  "license": "MIT",
+  "keywords": ["ansible", "automation", "configuration-management", "devops", "playbooks", "molecule", "roles", "vault"],
+  "skills": [
+    "./skills/ansible",
+    "./skills/ansible-inventory",
+    "./skills/ansible-roles",
+    "./skills/ansible-vault",
+    "./skills/ansible-testing"
+  ]
+}

--- a/plugins/tools/ansible/.claude-plugin/plugin.json
+++ b/plugins/tools/ansible/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "rginnow"
   },
-  "repository": "https://github.com/rginnow/claude-skills",
+  "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
   "keywords": ["ansible", "automation", "configuration-management", "devops", "playbooks", "molecule", "roles", "vault"],
   "skills": [

--- a/plugins/tools/ansible/skills/ansible-inventory/SKILL.md
+++ b/plugins/tools/ansible/skills/ansible-inventory/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: ansible-inventory
+description: Guide for Ansible inventory management. Use when configuring static or dynamic inventory files, defining host patterns, setting host and group variables, using group_vars and host_vars directories, or working with inventory plugins.
+license: MIT
+---
+
+# Ansible Inventory
+
+Activate when defining which hosts Ansible should manage, grouping hosts, setting connection parameters, or configuring dynamic inventory sources like AWS or Azure.
+
+## What Is Inventory
+
+An inventory maps the control node's knowledge of managed nodes. At minimum it lists hostnames or IP addresses. Inventory also defines groups, per-host and per-group variables, and connection parameters.
+
+Ansible looks for inventory in this order:
+1. `-i` flag on the command line
+2. `inventory` key in `ansible.cfg`
+3. `/etc/ansible/hosts` (fallback default)
+
+```ini
+# ansible.cfg
+[defaults]
+inventory = inventory/
+```
+
+## Static Inventory — INI Format
+
+```ini
+# inventory/hosts.ini
+
+# Ungrouped hosts
+192.168.1.10
+backup.example.com
+
+[webservers]
+web1.example.com
+web2.example.com ansible_port=2222    # host-level variable inline
+
+[dbservers]
+db1.example.com
+db2.example.com
+
+[webservers:vars]
+http_port=80
+max_connections=200
+
+[production:children]   # group of groups
+webservers
+dbservers
+```
+
+## Static Inventory — YAML Format
+
+```yaml
+# inventory/hosts.yml
+all:
+  children:
+    webservers:
+      hosts:
+        web1.example.com:
+          ansible_port: 22
+        web2.example.com:
+      vars:
+        http_port: 80
+    dbservers:
+      hosts:
+        db1.example.com:
+        db2.example.com:
+    production:
+      children:
+        webservers:
+        dbservers:
+  vars:
+    ansible_user: deploy          # applies to all hosts
+```
+
+## Host Patterns
+
+Use patterns with `-i` or in the `hosts:` field to target a subset:
+
+```bash
+# In ansible-playbook command
+ansible-playbook site.yml --limit webservers
+ansible-playbook site.yml --limit "web1.example.com,web2.example.com"
+
+# Wildcard
+ansible-playbook site.yml --limit "web*.example.com"
+
+# Union (comma separated)
+ansible-playbook site.yml --limit "webservers,dbservers"
+
+# Intersection (AND): hosts in both groups
+ansible-playbook site.yml --limit "production:&webservers"
+
+# Exclusion (NOT): production but not dbservers
+ansible-playbook site.yml --limit "production:!dbservers"
+
+# Numeric ranges
+ansible-playbook site.yml --limit "web[1:5].example.com"
+```
+
+In a playbook `hosts:` field:
+
+```yaml
+- hosts: webservers:&production   # webservers that are also in production
+- hosts: all:!dbservers           # every host except dbservers
+```
+
+## group_vars and host_vars
+
+Variables in these directories are automatically loaded by Ansible — no explicit include needed.
+
+```
+inventory/
+├── hosts.ini
+├── group_vars/
+│   ├── all.yml           # applies to every host in every group
+│   ├── webservers.yml    # applies to webservers group
+│   └── webservers/       # directory form: all files here merge together
+│       ├── main.yml
+│       └── vault.yml     # encrypted vars (ansible-vault)
+└── host_vars/
+    ├── web1.example.com.yml    # applies to this specific host
+    └── db1.example.com/
+        ├── main.yml
+        └── vault.yml
+```
+
+```yaml
+# group_vars/webservers.yml
+nginx_version: "1.24"
+app_root: /var/www/html
+```
+
+## Connection Variables
+
+Set these per host or group to control how Ansible connects:
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `ansible_host` | IP or hostname to connect to | inventory hostname |
+| `ansible_port` | SSH port | 22 |
+| `ansible_user` | SSH user | current user |
+| `ansible_ssh_private_key_file` | Path to SSH key | SSH agent / default key |
+| `ansible_become` | Enable privilege escalation | false |
+| `ansible_become_user` | User to become | root |
+| `ansible_python_interpreter` | Python path on managed node | auto-detected |
+| `ansible_connection` | Connection plugin (`ssh`, `local`, `docker`) | ssh |
+
+```yaml
+# host_vars/web1.example.com.yml
+ansible_host: 10.0.1.15
+ansible_user: ubuntu
+ansible_ssh_private_key_file: ~/.ssh/deploy_key
+ansible_become: true
+```
+
+## Dynamic Inventory
+
+When infrastructure changes frequently (cloud, containers), use a dynamic inventory plugin instead of a static file. Plugins query your cloud provider's API and return hosts at runtime.
+
+### Using a Plugin
+
+Create a YAML file that ends in `.yml` or `.yaml` and configure the plugin:
+
+```yaml
+# inventory/aws_ec2.yml
+plugin: amazon.aws.aws_ec2
+regions:
+  - us-east-1
+  - us-west-2
+filters:
+  instance-state-name: running
+  tag:Environment: production
+keyed_groups:
+  - key: tags.Role
+    prefix: role
+  - key: placement.region
+    prefix: region
+hostnames:
+  - private-ip-address
+```
+
+```yaml
+# inventory/azure_rm.yml
+plugin: azure.azcollection.azure_rm
+auth_source: auto
+include_vm_resource_groups:
+  - my-resource-group
+keyed_groups:
+  - key: tags.Environment
+    prefix: env
+```
+
+Install the collection before use:
+
+```bash
+ansible-galaxy collection install amazon.aws
+ansible-galaxy collection install azure.azcollection
+```
+
+## Inspecting Inventory
+
+Always verify your inventory before running a playbook:
+
+```bash
+ansible-inventory -i inventory/ --list          # JSON dump of all hosts and vars
+ansible-inventory -i inventory/ --graph         # tree view of groups
+ansible-inventory -i inventory/ --host web1     # vars for a specific host
+ansible all -m ping                             # test connectivity to all hosts
+ansible webservers -m ping -i inventory/        # test a group
+```
+
+## References
+
+- **[dynamic-inventory.md](references/dynamic-inventory.md)** — AWS EC2, Azure, GCP inventory plugin config examples; constructing groups from instance tags

--- a/plugins/tools/ansible/skills/ansible-inventory/references/dynamic-inventory.md
+++ b/plugins/tools/ansible/skills/ansible-inventory/references/dynamic-inventory.md
@@ -1,0 +1,224 @@
+# Dynamic Inventory Reference
+
+## AWS EC2 Inventory Plugin
+
+Requires the `amazon.aws` collection:
+
+```bash
+ansible-galaxy collection install amazon.aws
+pip install boto3 botocore
+```
+
+```yaml
+# inventory/aws_ec2.yml
+# File must end in aws_ec2.yml or aws_ec2.yaml
+plugin: amazon.aws.aws_ec2
+
+regions:
+  - us-east-1
+  - us-west-2
+
+# Credentials — prefer environment variables or IAM roles over hardcoded values
+# AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN
+# Or configure a profile in ~/.aws/credentials:
+# boto_profile: myprofile
+
+filters:
+  instance-state-name: running          # only running instances
+  tag:Environment: production           # filter by tag
+  tag:Role:                             # any value for this tag
+    - webserver
+    - appserver
+
+# What to use as the inventory hostname
+hostnames:
+  - private-ip-address                  # use private IP (common for internal VPC access)
+  # - tag:Name                          # use Name tag
+  # - dns-name                          # use public DNS
+
+# Build groups from instance properties
+keyed_groups:
+  - key: tags.Role                      # group by Role tag value
+    prefix: role
+    separator: "_"
+  - key: tags.Environment
+    prefix: env
+  - key: placement.region
+    prefix: region
+  - key: instance_type
+    prefix: type
+
+# Add all instances to a top-level group
+groups:
+  aws_ec2: true                         # group all EC2 instances together
+
+# Set host variables from instance attributes
+compose:
+  ansible_host: private_ip_address      # connect via private IP
+  ansible_user: "'ubuntu'"             # hardcode SSH user for all
+```
+
+Verify the output:
+
+```bash
+ansible-inventory -i inventory/aws_ec2.yml --list
+ansible-inventory -i inventory/aws_ec2.yml --graph
+```
+
+## Azure Resource Manager Inventory Plugin
+
+Requires the `azure.azcollection` collection:
+
+```bash
+ansible-galaxy collection install azure.azcollection
+pip install -r ~/.ansible/collections/ansible_collections/azure/azcollection/requirements.txt
+```
+
+```yaml
+# inventory/azure_rm.yml
+plugin: azure.azcollection.azure_rm
+
+# Authentication — prefer environment variables:
+# AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_SECRET, AZURE_TENANT
+auth_source: auto                       # tries env vars, then CLI credentials
+
+include_vm_resource_groups:
+  - my-app-rg
+  - my-db-rg
+# exclude_vm_resource_groups:
+#   - staging-rg
+
+# Build groups from Azure tags
+keyed_groups:
+  - key: tags.Environment | default('untagged')
+    prefix: env
+  - key: tags.Role | default('untagged')
+    prefix: role
+
+# Use private IP for connection
+hostnames:
+  - default                             # uses the VM name
+
+compose:
+  ansible_host: private_ipv4_addresses[0]
+```
+
+## GCP Compute Engine Inventory Plugin
+
+Requires the `google.cloud` collection:
+
+```bash
+ansible-galaxy collection install google.cloud
+pip install requests google-auth
+```
+
+```yaml
+# inventory/gcp_compute.yml
+plugin: google.cloud.gcp_compute
+
+projects:
+  - my-gcp-project-id
+
+zones:
+  - us-central1-a
+  - us-central1-b
+
+# Authenticate via service account key or application default credentials
+# auth_kind: serviceaccount
+# service_account_file: /path/to/key.json
+# Or set GOOGLE_APPLICATION_CREDENTIALS env var
+
+filters:
+  - status = RUNNING
+  - labels.environment = production
+
+keyed_groups:
+  - key: labels.role
+    prefix: role
+  - key: zone
+    prefix: zone
+
+compose:
+  ansible_host: networkInterfaces[0].networkIP    # private IP
+```
+
+## Constructing Groups from Tags
+
+The `constructed` inventory plugin can post-process any other inventory source to add groups based on variable values:
+
+```yaml
+# inventory/constructed.yml
+plugin: ansible.builtin.constructed
+
+# Point to another inventory source
+strict: false
+
+# Create groups from expressions
+groups:
+  # Group hosts that have the "webserver" role tag
+  webservers: "'webserver' in (tags | default({}) | dict2items | map(attribute='value'))"
+
+  # Group hosts in us-east-1
+  us_east: "placement.region == 'us-east-1'"
+
+# Compose new host variables from existing ones
+compose:
+  # Set ansible_host based on environment
+  ansible_host: >-
+    private_ip_address if tags.Environment == 'production'
+    else public_ip_address
+```
+
+## Testing Dynamic Inventory
+
+Before running a playbook, always verify dynamic inventory output:
+
+```bash
+# List all hosts and their variables as JSON
+ansible-inventory -i inventory/ --list | jq .
+
+# Show host tree grouped by inventory groups
+ansible-inventory -i inventory/ --graph
+
+# Show all variables for a specific host
+ansible-inventory -i inventory/ --host 10.0.1.15
+
+# Test connectivity to all dynamic hosts
+ansible all -i inventory/ -m ping
+
+# Limit to one group
+ansible role_webserver -i inventory/ -m ping
+
+# Combine static and dynamic inventory
+ansible all -i inventory/hosts.ini -i inventory/aws_ec2.yml -m ping
+```
+
+## Caching Dynamic Inventory
+
+Dynamic inventory can be slow when querying large cloud environments. Enable caching:
+
+```ini
+# ansible.cfg
+[inventory]
+cache = true
+cache_plugin = jsonfile
+cache_connection = /tmp/ansible_inventory_cache
+cache_timeout = 3600    # seconds (1 hour)
+```
+
+Or per-plugin:
+
+```yaml
+# inventory/aws_ec2.yml
+plugin: amazon.aws.aws_ec2
+cache: true
+cache_plugin: jsonfile
+cache_connection: /tmp/aws_inventory_cache
+cache_timeout: 3600
+```
+
+Clear the cache:
+
+```bash
+ansible-inventory -i inventory/ --list --refresh-cache
+```

--- a/plugins/tools/ansible/skills/ansible-roles/SKILL.md
+++ b/plugins/tools/ansible/skills/ansible-roles/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: ansible-roles
+description: Guide for Ansible roles and Galaxy. Use when creating or consuming roles, structuring role directories, defining role dependencies, using meta/main.yml, working with Jinja2 templates, or installing collections and roles from Ansible Galaxy.
+license: MIT
+---
+
+# Ansible Roles and Galaxy
+
+Activate when creating reusable role structures, using `import_role:` or `include_role:`, writing Jinja2 templates, or working with Ansible Galaxy collections and roles.
+
+## What Are Roles
+
+A role is a self-contained directory of tasks, handlers, variables, templates, and files organized for reuse. Instead of copying tasks between playbooks, extract them into a role and apply the role wherever needed.
+
+Roles enforce a consistent directory layout that Ansible recognizes automatically.
+
+## Role Directory Structure
+
+```
+roles/
+└── my_role/
+    ├── tasks/
+    │   └── main.yml        # entry point — required
+    ├── handlers/
+    │   └── main.yml        # handlers (notified by tasks)
+    ├── defaults/
+    │   └── main.yml        # default variables (lowest precedence)
+    ├── vars/
+    │   └── main.yml        # role variables (higher precedence than defaults)
+    ├── files/
+    │   └── app.conf        # static files (copy: module)
+    ├── templates/
+    │   └── nginx.conf.j2   # Jinja2 templates (template: module)
+    ├── meta/
+    │   └── main.yml        # role metadata and dependencies
+    └── tests/
+        ├── inventory
+        └── test.yml        # simple smoke test playbook
+```
+
+Scaffold a new role:
+
+```bash
+ansible-galaxy role init my_role
+```
+
+## Defaults vs Vars
+
+| Location | Precedence | Purpose |
+|----------|-----------|---------|
+| `defaults/main.yml` | Lowest — easily overridden | User-facing knobs with sensible fallbacks |
+| `vars/main.yml` | Higher — harder to override | Internal role constants |
+
+```yaml
+# defaults/main.yml
+nginx_port: 80
+nginx_worker_processes: auto
+nginx_log_level: warn
+
+# vars/main.yml
+nginx_config_dir: /etc/nginx
+nginx_pid_file: /var/run/nginx.pid
+```
+
+Set defaults for everything a consumer might want to change. Put implementation details in vars.
+
+## Using Roles in Playbooks
+
+```yaml
+# Classic roles: block (static, resolved at parse time)
+- hosts: webservers
+  roles:
+    - common
+    - role: nginx
+      vars:
+        nginx_port: 8080
+
+# import_role (static — analyzed before execution)
+- hosts: webservers
+  tasks:
+    - name: Apply base role
+      ansible.builtin.import_role:
+        name: common
+
+# include_role (dynamic — resolved at runtime, supports when:/loop:)
+- hosts: webservers
+  tasks:
+    - name: Apply role conditionally
+      ansible.builtin.include_role:
+        name: nginx
+      when: install_nginx | bool
+      loop: "{{ nginx_sites }}"
+      loop_control:
+        loop_var: nginx_site
+```
+
+Use `import_role` when you need tags to propagate; use `include_role` when you need conditionals or loops on the role itself.
+
+## Role Dependencies
+
+Declare roles that must run before this role in `meta/main.yml`:
+
+```yaml
+# roles/app/meta/main.yml
+galaxy_info:
+  author: rginnow
+  description: Deploy the application
+  license: MIT
+  min_ansible_version: "2.14"
+
+dependencies:
+  - role: common
+  - role: nginx
+    vars:
+      nginx_port: 8080
+```
+
+Dependencies run first, in order. Ansible deduplicates them — a dependency listed by multiple roles only runs once per play.
+
+## Jinja2 Templates
+
+Use the `template:` module to render Jinja2 templates from `templates/` onto managed nodes.
+
+```yaml
+- name: Write nginx config
+  ansible.builtin.template:
+    src: nginx.conf.j2         # relative to templates/ — Ansible finds it
+    dest: /etc/nginx/nginx.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload nginx
+```
+
+Template syntax:
+
+```jinja
+{# nginx.conf.j2 #}
+worker_processes {{ nginx_worker_processes }};
+pid {{ nginx_pid_file }};
+
+events {
+    worker_connections {{ nginx_worker_connections | default(1024) }};
+}
+
+http {
+    server {
+        listen {{ nginx_port }};
+        server_name {{ ansible_fqdn }};
+
+        {% for location in nginx_locations %}
+        location {{ location.path }} {
+            proxy_pass {{ location.upstream }};
+        }
+        {% endfor %}
+    }
+}
+```
+
+Key Jinja2 syntax:
+- `{{ variable }}` — output a value
+- `{% if condition %}...{% endif %}` — conditional block
+- `{% for item in list %}...{% endfor %}` — loop
+- `{# comment #}` — template comment (not in output)
+- `{{ value | filter }}` — apply a filter
+
+Common filters:
+```jinja
+{{ my_list | join(', ') }}           {# join list items #}
+{{ name | upper }}                   {# uppercase #}
+{{ path | basename }}                {# filename from path #}
+{{ value | default('fallback') }}    {# fallback if undefined #}
+{{ items | selectattr('active') }}   {# filter objects by attribute #}
+{{ count | int }}                    {# type conversion #}
+```
+
+## Ansible Galaxy
+
+Galaxy is the public hub for community roles and collections.
+
+### Install from Galaxy
+
+```bash
+# Install a role
+ansible-galaxy role install geerlingguy.nginx
+
+# Install a collection (namespaced: namespace.collection)
+ansible-galaxy collection install community.general
+ansible-galaxy collection install amazon.aws
+
+# Specify version
+ansible-galaxy collection install community.general:==6.0.0
+```
+
+### requirements.yml
+
+Pin dependencies in a `requirements.yml` file and install all at once:
+
+```yaml
+# requirements.yml
+roles:
+  - name: geerlingguy.nginx
+    version: "3.2.0"
+  - src: https://github.com/example/my-role
+    name: my_custom_role
+
+collections:
+  - name: community.general
+    version: ">=6.0.0"
+  - name: amazon.aws
+    version: "6.5.0"
+```
+
+```bash
+ansible-galaxy role install -r requirements.yml
+ansible-galaxy collection install -r requirements.yml
+```
+
+### Local Roles Path
+
+```ini
+# ansible.cfg
+[defaults]
+roles_path = roles:~/.ansible/roles:/usr/share/ansible/roles
+```
+
+Ansible searches each path in order when resolving role names.
+
+## References
+
+- **[jinja2-filters.md](references/jinja2-filters.md)** — Complete Jinja2 filter and test reference with examples; template patterns for common config file structures

--- a/plugins/tools/ansible/skills/ansible-roles/references/jinja2-filters.md
+++ b/plugins/tools/ansible/skills/ansible-roles/references/jinja2-filters.md
@@ -1,0 +1,204 @@
+# Jinja2 Filter and Test Reference
+
+## String Filters
+
+```jinja
+{{ name | upper }}                    {# "hello" → "HELLO" #}
+{{ name | lower }}                    {# "HELLO" → "hello" #}
+{{ name | capitalize }}               {# "hello world" → "Hello world" #}
+{{ name | title }}                    {# "hello world" → "Hello World" #}
+{{ name | replace("old", "new") }}    {# string substitution #}
+{{ name | trim }}                     {# strip leading/trailing whitespace #}
+{{ name | truncate(20) }}             {# truncate to 20 chars with "..." #}
+{{ text | wordwrap(80) }}             {# wrap text at 80 characters #}
+{{ value | string }}                  {# convert to string #}
+{{ name | regex_replace('^www\.', '') }}  {# regex substitution #}
+{{ name | regex_search('(\d+)') }}    {# extract first match #}
+```
+
+## List Filters
+
+```jinja
+{{ list | join(', ') }}               {# ["a", "b", "c"] → "a, b, c" #}
+{{ list | first }}                    {# first element #}
+{{ list | last }}                     {# last element #}
+{{ list | length }}                   {# count elements #}
+{{ list | sort }}                     {# sort ascending #}
+{{ list | reverse | list }}           {# reverse order #}
+{{ list | unique }}                   {# remove duplicates #}
+{{ list | flatten }}                  {# flatten nested lists one level #}
+{{ list | flatten(levels=2) }}        {# flatten 2 levels deep #}
+{{ list | min }}                      {# smallest value #}
+{{ list | max }}                      {# largest value #}
+{{ list | sum }}                      {# sum numeric values #}
+{{ list | random }}                   {# random element #}
+{{ list | shuffle }}                  {# randomly reorder #}
+{{ list | select('match', '^web') | list }}  {# filter by regex match #}
+{{ list | reject('equalto', 'skip_me') | list }}  {# exclude values #}
+{{ list | map('upper') | list }}      {# apply filter to each element #}
+{{ list | zip(other_list) | list }}   {# pair two lists element-wise #}
+```
+
+## List of Dicts Filters
+
+```jinja
+{# Filter objects where attribute matches a value #}
+{{ users | selectattr('active', 'equalto', true) | list }}
+
+{# Filter objects where attribute is defined #}
+{{ users | selectattr('email', 'defined') | list }}
+
+{# Extract one attribute from each object #}
+{{ users | map(attribute='name') | list }}
+
+{# Sort by attribute #}
+{{ users | sort(attribute='name') }}
+
+{# Group by attribute → dict of lists #}
+{{ users | groupby('department') }}
+
+{# Find first match #}
+{{ users | selectattr('name', 'equalto', 'alice') | first }}
+```
+
+## Dict Filters
+
+```jinja
+{{ my_dict | dict2items }}            {# [{"key": k, "value": v}, ...] #}
+{{ items_list | items2dict }}         {# reverse of dict2items #}
+{{ my_dict | combine(other_dict) }}   {# merge dicts (other_dict wins on conflict) #}
+{{ my_dict.keys() | list }}           {# list of keys #}
+{{ my_dict.values() | list }}         {# list of values #}
+{{ my_dict | length }}                {# number of keys #}
+```
+
+## Path and File Filters
+
+```jinja
+{{ "/etc/nginx/nginx.conf" | basename }}      {# "nginx.conf" #}
+{{ "/etc/nginx/nginx.conf" | dirname }}       {# "/etc/nginx" #}
+{{ "nginx.conf" | splitext }}                 {# ["nginx", ".conf"] #}
+{{ path | expanduser }}                       {# expand ~ #}
+{{ path | realpath }}                         {# resolve symlinks #}
+{{ "/etc" | path_join("nginx", "conf.d") }}   {# "/etc/nginx/conf.d" #}
+```
+
+## Type Conversion Filters
+
+```jinja
+{{ "42" | int }}                      {# string → integer #}
+{{ "3.14" | float }}                  {# string → float #}
+{{ value | bool }}                    {# truthy → True/False #}
+{{ value | string }}                  {# any → string #}
+{{ value | list }}                    {# iterable → list #}
+{{ dict | to_json }}                  {# serialize to JSON #}
+{{ dict | to_nice_json }}             {# pretty-printed JSON #}
+{{ json_str | from_json }}            {# parse JSON string #}
+{{ dict | to_yaml }}                  {# serialize to YAML #}
+{{ yaml_str | from_yaml }}            {# parse YAML string #}
+```
+
+## Default and Fallback Filters
+
+```jinja
+{# Return default if variable is undefined or empty #}
+{{ my_var | default('fallback') }}
+
+{# Return default only if variable is undefined (not if empty string) #}
+{{ my_var | default('fallback', boolean=true) }}
+
+{# Omit the key entirely from a module call if variable is undefined #}
+{{ my_var | default(omit) }}
+
+{# Example: only set owner if defined #}
+ansible.builtin.file:
+  path: /var/app
+  owner: "{{ file_owner | default(omit) }}"
+```
+
+## Hash and Encoding Filters
+
+```jinja
+{{ "password" | password_hash('sha512') }}    {# hash for /etc/shadow #}
+{{ data | b64encode }}                        {# base64 encode #}
+{{ encoded | b64decode }}                     {# base64 decode #}
+{{ text | hash('sha256') }}                   {# SHA-256 hex digest #}
+{{ text | checksum }}                         {# SHA-1 checksum #}
+```
+
+## Jinja2 Tests
+
+Tests return `true`/`false` and are used with `is`:
+
+```jinja
+{% if my_var is defined %}            {# variable exists #}
+{% if my_var is undefined %}          {# variable does not exist #}
+{% if my_var is none %}               {# variable is null #}
+{% if my_var is string %}             {# is a string type #}
+{% if my_var is number %}             {# is a number type #}
+{% if my_var is iterable %}           {# can be iterated #}
+{% if my_var is mapping %}            {# is a dict #}
+{% if my_var is sequence %}           {# is a list or string #}
+{% if my_var is sameas other %}       {# identical object #}
+{% if my_var is equalto 42 %}         {# equals value #}
+{% if path is file %}                 {# path is a file (Ansible-specific) #}
+{% if path is directory %}            {# path is a directory #}
+{% if path is link %}                 {# path is a symlink #}
+{% if version is version('2.0', '>=') %}  {# version comparison #}
+```
+
+## Common Template Patterns
+
+### Config file with conditional sections
+
+```jinja
+{# nginx.conf.j2 #}
+user {{ nginx_user | default('www-data') }};
+worker_processes {{ nginx_worker_processes | default('auto') }};
+
+{% if nginx_error_log is defined %}
+error_log {{ nginx_error_log }};
+{% else %}
+error_log /var/log/nginx/error.log warn;
+{% endif %}
+
+events {
+    worker_connections {{ nginx_worker_connections | default(1024) }};
+    {% if nginx_multi_accept | default(false) %}
+    multi_accept on;
+    {% endif %}
+}
+```
+
+### Iterating a list of dicts to produce config blocks
+
+```jinja
+{# haproxy.cfg.j2 #}
+{% for backend in haproxy_backends %}
+backend {{ backend.name }}
+    balance {{ backend.balance | default('roundrobin') }}
+    {% for server in backend.servers %}
+    server {{ server.name }} {{ server.host }}:{{ server.port }} check
+    {% endfor %}
+
+{% endfor %}
+```
+
+### Building a list of values from group members
+
+```jinja
+{# List all webserver IPs for an upstream block #}
+{% for host in groups['webservers'] %}
+    server {{ hostvars[host].ansible_host }}:8080 weight=1;
+{% endfor %}
+```
+
+### Conditional include of a config section
+
+```jinja
+{% if ssl_enabled | default(false) | bool %}
+    ssl_certificate {{ ssl_cert_path }};
+    ssl_certificate_key {{ ssl_key_path }};
+    ssl_protocols {{ ssl_protocols | default('TLSv1.2 TLSv1.3') }};
+{% endif %}
+```

--- a/plugins/tools/ansible/skills/ansible-testing/SKILL.md
+++ b/plugins/tools/ansible/skills/ansible-testing/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: ansible-testing
+description: Guide for testing Ansible roles and playbooks with Molecule. Use when writing Molecule test scenarios, configuring drivers (Docker, Podman, delegated), writing Testinfra or Ansible Verify tests, or integrating Molecule into CI pipelines.
+license: MIT
+---
+
+# Ansible Testing with Molecule
+
+Activate when setting up Molecule for a role, writing test scenarios, configuring drivers, writing Testinfra assertions, or integrating Ansible tests into CI.
+
+## Why Test Ansible Code
+
+Without automated tests:
+- Refactoring breaks things silently
+- Idempotency regressions go undetected (tasks that should be no-ops make changes on repeated runs)
+- Roles stop working on newer OS versions without anyone noticing
+
+Molecule provides a framework to spin up a test environment, run your role against it, verify the end state, and tear it down — all automatically.
+
+## Molecule Test Phases
+
+Molecule runs these phases in order when you execute `molecule test`:
+
+| Phase | What it does |
+|-------|-------------|
+| `lint` | Run `ansible-lint` and `yamllint` on your role |
+| `destroy` | Remove any leftover test instances |
+| `create` | Spin up fresh test instances (containers or VMs) |
+| `prepare` | Optional: run a prepare playbook before converge |
+| `converge` | Apply your role to the test instances |
+| `idempotency` | Run converge again — assert zero changes |
+| `verify` | Run your test assertions against live instances |
+| `cleanup` | Optional: cleanup tasks before destroy |
+| `destroy` | Tear down all test instances |
+
+Run individual phases during development:
+
+```bash
+molecule converge     # apply role (keep instance running)
+molecule verify       # run assertions only
+molecule login        # SSH into the test instance
+molecule destroy      # tear down
+molecule test         # full cycle: destroy → create → converge → verify → destroy
+```
+
+## Install Molecule
+
+```bash
+pip install molecule molecule-plugins[docker]   # Docker driver
+pip install molecule molecule-plugins[podman]   # Podman driver
+pip install pytest testinfra                    # for Testinfra verifier
+```
+
+## Initialize a Molecule Scenario
+
+From inside an existing role directory:
+
+```bash
+cd roles/my_role
+molecule init scenario --driver-name docker         # default scenario
+molecule init scenario staging --driver-name podman  # named scenario
+```
+
+This creates:
+
+```
+roles/my_role/
+└── molecule/
+    └── default/             # scenario name
+        ├── molecule.yml     # driver, platforms, verifier config
+        ├── converge.yml     # playbook Molecule runs against instances
+        ├── verify.yml       # assertions (if using ansible verifier)
+        └── prepare.yml      # optional: pre-role setup
+```
+
+## molecule.yml Structure
+
+```yaml
+# molecule/default/molecule.yml
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: requirements.yml   # install Galaxy deps before testing
+
+driver:
+  name: docker                            # docker, podman, delegated
+
+platforms:
+  - name: instance                        # container name
+    image: geerlingguy/docker-ubuntu2204-ansible  # pre-built image with systemd+Python
+    pre_build_image: true
+    command: /lib/systemd/systemd         # init system (for service tests)
+    privileged: true                      # needed for systemd inside Docker
+
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+    prepare: prepare.yml                  # optional
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+  inventory:
+    group_vars:
+      all:
+        ansible_user: root
+
+verifier:
+  name: ansible                           # or: testinfra
+
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+```
+
+## converge.yml
+
+The playbook Molecule runs to apply your role to test instances:
+
+```yaml
+# molecule/default/converge.yml
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    nginx_port: 80
+  roles:
+    - role: my_role
+```
+
+## Idempotency
+
+Molecule runs converge twice and checks that the second run produces zero changed tasks. Tasks that always report `changed` will fail the idempotency check.
+
+Common idempotency failures:
+- `command:` / `shell:` tasks without `changed_when: false` or `creates:`
+- Tasks that generate random values on each run
+- File timestamps checked as changed
+
+Fix:
+
+```yaml
+- name: Compile app (only when source changes)
+  ansible.builtin.command: make build
+  args:
+    chdir: /var/app
+    creates: /var/app/dist/app.bin    # skip if output already exists
+  changed_when: false                 # or mark as never changed
+```
+
+## Verify Phase — Ansible Verifier
+
+Write a playbook of assertion tasks:
+
+```yaml
+# molecule/default/verify.yml
+---
+- name: Verify
+  hosts: all
+  become: true
+  tasks:
+    - name: Check nginx is installed
+      ansible.builtin.package:
+        name: nginx
+        state: present
+      check_mode: true
+      register: pkg
+      failed_when: pkg.changed
+
+    - name: Check nginx service is running
+      ansible.builtin.service:
+        name: nginx
+        state: started
+        enabled: true
+      check_mode: true
+      register: svc
+      failed_when: svc.changed
+
+    - name: Check nginx responds on port 80
+      ansible.builtin.uri:
+        url: http://localhost:80
+        status_code: 200
+
+    - name: Check config file exists with correct permissions
+      ansible.builtin.stat:
+        path: /etc/nginx/nginx.conf
+      register: conf
+      failed_when: not conf.stat.exists or conf.stat.mode != "0644"
+```
+
+## Verify Phase — Testinfra Verifier
+
+Testinfra is a Python testing library with a pytest interface. More expressive for complex assertions.
+
+```yaml
+# molecule.yml — switch verifier
+verifier:
+  name: testinfra
+```
+
+```python
+# molecule/default/tests/test_nginx.py
+import pytest
+
+def test_nginx_installed(host):
+    pkg = host.package("nginx")
+    assert pkg.is_installed
+
+def test_nginx_running(host):
+    svc = host.service("nginx")
+    assert svc.is_running
+    assert svc.is_enabled
+
+def test_nginx_config_exists(host):
+    conf = host.file("/etc/nginx/nginx.conf")
+    assert conf.exists
+    assert conf.mode == 0o644
+    assert conf.user == "root"
+
+def test_nginx_listening(host):
+    socket = host.socket("tcp://0.0.0.0:80")
+    assert socket.is_listening
+
+def test_nginx_responds(host):
+    cmd = host.run("curl -s -o /dev/null -w '%{http_code}' http://localhost")
+    assert cmd.stdout == "200"
+```
+
+## Linting
+
+```bash
+# Run all linting (yamllint + ansible-lint)
+molecule lint
+
+# Run ansible-lint directly
+ansible-lint roles/my_role/
+
+# yamllint config
+# .yamllint
+extends: default
+rules:
+  line-length:
+    max: 120
+  truthy:
+    allowed-values: ['true', 'false']
+```
+
+```yaml
+# .ansible-lint
+skip_list:
+  - yaml[line-length]    # skip specific rules
+profile: production      # safety, shared, production (strictest)
+```
+
+## Multiple Platforms
+
+Test across OS versions with multiple platform entries:
+
+```yaml
+platforms:
+  - name: ubuntu22
+    image: geerlingguy/docker-ubuntu2204-ansible
+    pre_build_image: true
+  - name: ubuntu20
+    image: geerlingguy/docker-ubuntu2004-ansible
+    pre_build_image: true
+  - name: rocky9
+    image: geerlingguy/docker-rockylinux9-ansible
+    pre_build_image: true
+```
+
+## CI Integration
+
+```bash
+# GitHub Actions: run molecule test for a role
+molecule test -s default
+```
+
+## check_mode and --diff
+
+Before running against production, validate with a dry run:
+
+```bash
+ansible-playbook site.yml --check           # no changes made
+ansible-playbook site.yml --check --diff    # show what would change
+```
+
+Some tasks behave differently in check mode. Mark tasks that must always run regardless:
+
+```yaml
+- name: Always run this
+  ansible.builtin.command: echo "status check"
+  check_mode: false
+```
+
+## References
+
+- **[molecule-scenarios.md](references/molecule-scenarios.md)** — Complete annotated `molecule.yml` for Docker, Podman, and delegated drivers; multi-platform test matrix; Testinfra assertion patterns; GitHub Actions CI workflow

--- a/plugins/tools/ansible/skills/ansible-testing/references/molecule-scenarios.md
+++ b/plugins/tools/ansible/skills/ansible-testing/references/molecule-scenarios.md
@@ -1,0 +1,348 @@
+# Molecule Scenario Reference
+
+## Docker Driver — Full Annotated molecule.yml
+
+```yaml
+# molecule/default/molecule.yml
+---
+dependency:
+  name: galaxy
+  options:
+    # Install Galaxy requirements before running tests
+    requirements-file: requirements.yml
+    ignore-errors: false
+
+driver:
+  name: docker
+
+platforms:
+  - name: ubuntu22-instance        # unique name for this container
+    image: geerlingguy/docker-ubuntu2204-ansible
+    pre_build_image: true           # use image as-is, don't build from Dockerfile
+    command: /lib/systemd/systemd  # init system (needed for service tests)
+    privileged: true               # required for systemd inside Docker
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    capabilities:
+      - SYS_ADMIN
+    tmpfs:
+      - /run
+      - /tmp
+
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: prepare.yml           # optional: runs before converge
+    converge: converge.yml
+    verify: verify.yml
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      callback_whitelist: profile_tasks   # show task timing
+  inventory:
+    group_vars:
+      all:
+        ansible_user: root
+  env:
+    ANSIBLE_ROLES_PATH: ../../     # look for roles relative to molecule dir
+
+verifier:
+  name: ansible                    # or: testinfra
+
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+```
+
+## Podman Driver — molecule.yml
+
+```yaml
+# molecule/default/molecule.yml
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: podman
+
+platforms:
+  - name: instance
+    image: ghcr.io/hifis-net/ubuntu-systemd:22.04
+    pre_build_image: true
+    systemd: always                # enable systemd in container
+    privileged: false              # Podman works rootless
+    capabilities:
+      - SYS_ADMIN
+    tmpfs:
+      - /tmp
+      - /run
+
+provisioner:
+  name: ansible
+  inventory:
+    group_vars:
+      all:
+        ansible_user: root
+        ansible_connection: podman
+
+verifier:
+  name: ansible
+
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+```
+
+## Delegated Driver — molecule.yml
+
+Use the delegated driver when you want to manage your own test infrastructure (existing VMs, cloud instances, etc.):
+
+```yaml
+# molecule/default/molecule.yml
+---
+driver:
+  name: delegated
+  options:
+    managed: false                 # Molecule won't create/destroy — you manage instances
+    login_cmd_template: "ssh {instance}"
+    ansible_connection_options:
+      ansible_connection: ssh
+
+platforms:
+  - name: my-test-vm
+    address: 10.0.1.100           # IP of your existing test VM
+
+provisioner:
+  name: ansible
+  inventory:
+    hosts:
+      all:
+        hosts:
+          my-test-vm:
+            ansible_host: 10.0.1.100
+            ansible_user: ubuntu
+            ansible_ssh_private_key_file: ~/.ssh/test_key
+
+verifier:
+  name: ansible
+```
+
+With `managed: false`, you are responsible for running `create` and `destroy` yourself — Molecule skips those phases.
+
+## Multi-Platform Test Matrix
+
+```yaml
+platforms:
+  - name: ubuntu22
+    image: geerlingguy/docker-ubuntu2204-ansible
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    groups:
+      - debian_family
+
+  - name: ubuntu20
+    image: geerlingguy/docker-ubuntu2004-ansible
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    groups:
+      - debian_family
+
+  - name: rocky9
+    image: geerlingguy/docker-rockylinux9-ansible
+    pre_build_image: true
+    command: /usr/lib/systemd/systemd
+    privileged: true
+    groups:
+      - redhat_family
+
+  - name: debian12
+    image: geerlingguy/docker-debian12-ansible
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    groups:
+      - debian_family
+```
+
+Target only specific platforms:
+
+```bash
+molecule converge --platform ubuntu22
+molecule test -- --platform rocky9
+```
+
+## Testinfra Assertion Patterns
+
+```python
+# molecule/default/tests/test_default.py
+import pytest
+
+
+# ─── Package assertions ───────────────────────────────────────────────────────
+
+def test_nginx_installed(host):
+    pkg = host.package("nginx")
+    assert pkg.is_installed
+
+def test_nginx_version(host):
+    pkg = host.package("nginx")
+    assert pkg.is_installed
+    # Version string varies by distro — check it's not empty
+    assert pkg.version
+
+
+# ─── Service assertions ───────────────────────────────────────────────────────
+
+def test_nginx_running_and_enabled(host):
+    svc = host.service("nginx")
+    assert svc.is_running
+    assert svc.is_enabled
+
+
+# ─── File and directory assertions ───────────────────────────────────────────
+
+def test_config_file_exists(host):
+    conf = host.file("/etc/nginx/nginx.conf")
+    assert conf.exists
+    assert conf.is_file
+
+def test_config_permissions(host):
+    conf = host.file("/etc/nginx/nginx.conf")
+    assert conf.user == "root"
+    assert conf.group == "root"
+    assert oct(conf.mode) == "0o644"
+
+def test_config_contains_port(host):
+    conf = host.file("/etc/nginx/nginx.conf")
+    assert conf.contains("listen 80")
+
+def test_web_root_is_directory(host):
+    d = host.file("/var/www/html")
+    assert d.is_directory
+    assert d.user == "www-data"
+
+
+# ─── Socket and port assertions ───────────────────────────────────────────────
+
+def test_nginx_listening_on_80(host):
+    socket = host.socket("tcp://0.0.0.0:80")
+    assert socket.is_listening
+
+def test_nginx_listening_on_ipv6(host):
+    socket = host.socket("tcp://:::80")
+    assert socket.is_listening
+
+
+# ─── HTTP endpoint assertions ─────────────────────────────────────────────────
+
+def test_nginx_returns_200(host):
+    cmd = host.run("curl -s -o /dev/null -w '%{http_code}' http://localhost")
+    assert cmd.rc == 0
+    assert cmd.stdout == "200"
+
+
+# ─── User and group assertions ────────────────────────────────────────────────
+
+def test_deploy_user_exists(host):
+    user = host.user("deploy")
+    assert user.exists
+    assert user.shell == "/bin/bash"
+    assert "www-data" in user.groups
+
+
+# ─── Process assertions ───────────────────────────────────────────────────────
+
+def test_nginx_process_running(host):
+    process = host.process.filter(user="root", comm="nginx")
+    assert len(process) >= 1
+
+
+# ─── Command output assertions ────────────────────────────────────────────────
+
+def test_nginx_config_valid(host):
+    cmd = host.run("nginx -t")
+    assert cmd.rc == 0
+```
+
+## GitHub Actions CI Workflow
+
+```yaml
+# .github/workflows/molecule.yml
+name: Molecule Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Molecule (${{ matrix.role }} / ${{ matrix.scenario }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        role:
+          - nginx
+          - postgresql
+        scenario:
+          - default
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install Molecule and dependencies
+        run: |
+          pip install molecule molecule-plugins[docker] ansible-lint testinfra pytest
+
+      - name: Install Ansible Galaxy requirements
+        run: ansible-galaxy install -r requirements.yml
+        if: hashFiles('requirements.yml') != ''
+
+      - name: Run Molecule
+        run: molecule test -s ${{ matrix.scenario }}
+        working-directory: roles/${{ matrix.role }}
+        env:
+          MOLECULE_NO_LOG: "false"
+          PY_COLORS: "1"
+          ANSIBLE_FORCE_COLOR: "1"
+```
+
+## Named Scenarios
+
+Create additional scenarios for different test conditions:
+
+```bash
+# Initialize a named scenario
+molecule init scenario production --driver-name docker
+molecule init scenario check-mode --driver-name delegated
+
+# Run a specific scenario
+molecule test -s production
+molecule converge -s check-mode
+
+# List all scenarios in a role
+molecule list
+```
+
+Each scenario lives in its own directory under `molecule/`:
+
+```
+roles/nginx/
+└── molecule/
+    ├── default/       # normal install + verify
+    ├── production/    # test with production-like settings
+    └── upgrade/       # test upgrading from a previous version
+```

--- a/plugins/tools/ansible/skills/ansible-vault/SKILL.md
+++ b/plugins/tools/ansible/skills/ansible-vault/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: ansible-vault
+description: Guide for Ansible Vault secrets management and security practices. Use when encrypting variables or files with ansible-vault, configuring vault passwords, using vault IDs, or applying security hardening to playbooks.
+license: MIT
+---
+
+# Ansible Vault
+
+Activate when encrypting secrets, managing vault passwords, configuring vault IDs, or applying security hardening to Ansible playbooks and variable files.
+
+## Why Vault Exists
+
+Secrets (passwords, API keys, certificates) must never be committed to version control in plaintext. Ansible Vault encrypts secrets at rest using AES-256 so they can be safely committed to git while remaining usable by Ansible at runtime.
+
+## ansible-vault CLI Commands
+
+```bash
+# Create a new encrypted file
+ansible-vault create secrets.yml
+
+# Encrypt an existing file
+ansible-vault encrypt vars/db_password.yml
+
+# Decrypt a file to plaintext (use with caution)
+ansible-vault decrypt vars/db_password.yml
+
+# View encrypted content without decrypting the file
+ansible-vault view vars/secrets.yml
+
+# Edit an encrypted file (opens $EDITOR)
+ansible-vault edit vars/secrets.yml
+
+# Change the vault password on an encrypted file
+ansible-vault rekey vars/secrets.yml
+
+# Encrypt a single string value (paste the output inline in YAML)
+ansible-vault encrypt_string 'my-secret-value' --name 'db_password'
+```
+
+## Encrypting Individual Variables
+
+Use `encrypt_string` to encrypt a single value and embed it inline in an otherwise plain YAML file:
+
+```bash
+ansible-vault encrypt_string 'super_secret_pw' --name 'db_password'
+```
+
+Output to paste into your vars file:
+
+```yaml
+db_password: !vault |
+  $ANSIBLE_VAULT;1.1;AES256
+  61383334343430363636393231363962626536346232613...
+  ...
+```
+
+This lets you keep most vars readable while encrypting only the sensitive ones.
+
+## Encrypting Entire Files
+
+For files that are entirely sensitive (private keys, certificates), encrypt the whole file:
+
+```bash
+ansible-vault encrypt roles/app/files/server.key
+```
+
+The `copy:` module works transparently with vault-encrypted files — Ansible decrypts at runtime before copying.
+
+## Vault Password Sources
+
+Ansible needs the vault password at runtime to decrypt. Provide it in one of these ways:
+
+```bash
+# Interactive prompt (good for one-off runs)
+ansible-playbook site.yml --ask-vault-pass
+
+# Password file (good for automation)
+ansible-playbook site.yml --vault-password-file ~/.vault_pass
+
+# Environment variable (set ANSIBLE_VAULT_PASSWORD_FILE in ansible.cfg or shell)
+export ANSIBLE_VAULT_PASSWORD_FILE=~/.vault_pass
+ansible-playbook site.yml
+```
+
+```ini
+# ansible.cfg
+[defaults]
+vault_password_file = ~/.vault_pass
+```
+
+The password file should contain only the password string with no trailing newline. Protect it with `chmod 600`.
+
+## Vault IDs
+
+Vault IDs let you manage multiple passwords — useful when different environments (dev, prod) or different secret types use different passwords.
+
+```bash
+# Encrypt with a vault ID label
+ansible-vault encrypt_string 'dev_secret' --name 'api_key' --vault-id dev@prompt
+ansible-vault encrypt_string 'prod_secret' --name 'api_key' --vault-id prod@~/.prod_vault_pass
+
+# Run with multiple vault IDs
+ansible-playbook site.yml \
+  --vault-id dev@~/.dev_vault_pass \
+  --vault-id prod@~/.prod_vault_pass
+```
+
+Encrypted values tagged with a vault ID look like:
+
+```yaml
+api_key: !vault |
+  $ANSIBLE_VAULT;1.2;AES256;prod
+  ...
+```
+
+## Organizing Vault Files with group_vars
+
+A common pattern: keep plaintext vars and vault vars side by side in a directory:
+
+```
+inventory/
+└── group_vars/
+    └── production/
+        ├── vars.yml       # plaintext — committed as-is
+        └── vault.yml      # encrypted — committed safely
+```
+
+```yaml
+# vars.yml — plaintext reference file
+db_host: db.example.com
+db_user: app
+db_password: "{{ vault_db_password }}"   # references the vaulted var
+```
+
+```yaml
+# vault.yml — encrypted file, edit with: ansible-vault edit
+vault_db_password: actual_secret_here
+```
+
+Prefix vault variables with `vault_` to make it obvious where they come from.
+
+## Security Practices
+
+**Prevent plaintext leakage in task output:**
+
+```yaml
+- name: Set database password
+  ansible.builtin.command: "db-cli set-password {{ db_password }}"
+  no_log: true          # suppress this task's output entirely
+```
+
+**Suppress skipped host output:**
+
+```bash
+ANSIBLE_DISPLAY_SKIPPED_HOSTS=false ansible-playbook site.yml
+```
+
+**Protect local files:**
+
+```bash
+chmod 600 ~/.vault_pass
+echo ".vault_pass" >> .gitignore
+echo "*.key" >> .gitignore
+```
+
+**Audit what's encrypted before committing:**
+
+```bash
+git diff --cached | grep -E "^\+.*\$ANSIBLE_VAULT"
+```
+
+Never use `ansible-vault decrypt` on a file you intend to commit — keep encrypted versions in the repo.
+
+## External Secret Backends
+
+For production environments, consider lookup plugins that retrieve secrets from a dedicated secrets manager at runtime instead of storing vault-encrypted values in the repo.
+
+```yaml
+# HashiCorp Vault lookup (requires community.hashi_vault collection)
+db_password: "{{ lookup('community.hashi_vault.hashi_vault',
+    'secret/data/myapp/db password',
+    url='https://vault.example.com',
+    token=lookup('env', 'VAULT_TOKEN')) }}"
+
+# AWS SSM Parameter Store (requires amazon.aws collection)
+db_password: "{{ lookup('amazon.aws.aws_ssm',
+    '/myapp/production/db_password',
+    region='us-east-1') }}"
+
+# Simple environment variable lookup (no collection needed)
+api_key: "{{ lookup('env', 'MY_API_KEY') }}"
+```
+
+## References
+
+- **[secret-backends.md](references/secret-backends.md)** — HashiCorp Vault, AWS Secrets Manager, AWS SSM, Azure Key Vault lookup plugin examples with authentication config and failure handling

--- a/plugins/tools/ansible/skills/ansible-vault/references/secret-backends.md
+++ b/plugins/tools/ansible/skills/ansible-vault/references/secret-backends.md
@@ -1,0 +1,168 @@
+# External Secret Backend Reference
+
+## HashiCorp Vault
+
+Requires the `community.hashi_vault` collection:
+
+```bash
+ansible-galaxy collection install community.hashi_vault
+pip install hvac
+```
+
+### Token Authentication
+
+```yaml
+# vars/secrets.yml — retrieved at runtime, never stored in repo
+db_password: "{{ lookup('community.hashi_vault.hashi_vault',
+    'secret/data/myapp/db',
+    return_format='dict',
+    url='https://vault.example.com',
+    token=lookup('env', 'VAULT_TOKEN')) | json_query('data.password') }}"
+```
+
+### AppRole Authentication (for CI/automation)
+
+```yaml
+db_password: "{{ lookup('community.hashi_vault.hashi_vault',
+    'secret/data/myapp/db password',
+    auth_method='approle',
+    role_id=lookup('env', 'VAULT_ROLE_ID'),
+    secret_id=lookup('env', 'VAULT_SECRET_ID'),
+    url='https://vault.example.com') }}"
+```
+
+### AWS IAM Authentication
+
+```yaml
+db_password: "{{ lookup('community.hashi_vault.hashi_vault',
+    'secret/data/myapp/db password',
+    auth_method='aws_iam',
+    url='https://vault.example.com') }}"
+```
+
+### Configuring via Environment Variables
+
+Set these in your shell or CI pipeline to avoid repeating connection details in every lookup:
+
+```bash
+export VAULT_ADDR=https://vault.example.com
+export VAULT_TOKEN=hvs.xxxxx
+# Then lookups can omit url and token:
+```
+
+```yaml
+db_password: "{{ lookup('community.hashi_vault.hashi_vault',
+    'secret/data/myapp/db password') }}"
+```
+
+## AWS Secrets Manager
+
+Requires the `amazon.aws` collection:
+
+```bash
+ansible-galaxy collection install amazon.aws
+pip install boto3
+```
+
+```yaml
+# Retrieve a secret value
+db_password: "{{ lookup('amazon.aws.aws_secret',
+    'myapp/production/db_password',
+    region='us-east-1') }}"
+
+# Retrieve a JSON secret and extract a field
+db_config: "{{ lookup('amazon.aws.aws_secret',
+    'myapp/production/db_config',
+    region='us-east-1') | from_json }}"
+db_password: "{{ db_config.password }}"
+```
+
+## AWS SSM Parameter Store
+
+```yaml
+# Retrieve a plain SecureString parameter
+db_password: "{{ lookup('amazon.aws.aws_ssm',
+    '/myapp/production/db_password',
+    region='us-east-1') }}"
+
+# Retrieve all parameters under a path prefix
+app_params: "{{ lookup('amazon.aws.aws_ssm',
+    '/myapp/production/',
+    shortnames=true,
+    recursive=true,
+    region='us-east-1') }}"
+# app_params is now a dict: {"db_password": "...", "api_key": "..."}
+```
+
+## Azure Key Vault
+
+Requires the `azure.azcollection` collection:
+
+```bash
+ansible-galaxy collection install azure.azcollection
+```
+
+```yaml
+db_password: "{{ lookup('azure.azcollection.azure_keyvault_secret',
+    'db-password',
+    vault_url='https://mykeyvault.vault.azure.net') }}"
+```
+
+Authentication uses the same credential chain as the Azure inventory plugin (`AZURE_CLIENT_ID`, `AZURE_SECRET`, `AZURE_TENANT`, etc.).
+
+## Handling Lookup Failures
+
+By default a failed lookup raises an error and stops the play. Handle failures gracefully:
+
+```yaml
+# Provide a fallback default (empty string if secret not found)
+db_password: "{{ lookup('amazon.aws.aws_ssm', '/myapp/db_pass',
+    region='us-east-1',
+    errors='warn') | default('') }}"
+
+# Use default() filter to provide a fallback
+api_key: "{{ lookup('env', 'API_KEY') | default(lookup('community.hashi_vault.hashi_vault',
+    'secret/data/api api_key'), true) }}"
+```
+
+Use `errors='warn'` (warn and continue) instead of the default `errors='fatal'` (stop play) when a missing secret is acceptable.
+
+## Caching Lookup Results
+
+Lookups run on every task evaluation by default. Cache the result in a variable to avoid repeated API calls:
+
+```yaml
+- name: Fetch all secrets once
+  ansible.builtin.set_fact:
+    db_password: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/data/db password') }}"
+    api_key: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/data/api key') }}"
+  run_once: true
+  delegate_to: localhost
+  no_log: true
+
+- name: Use the cached secrets
+  ansible.builtin.template:
+    src: app.conf.j2
+    dest: /etc/myapp/app.conf
+  no_log: true
+```
+
+## Environment Variable Lookups (No Plugin Required)
+
+For simple cases where secrets are injected via CI environment variables:
+
+```yaml
+db_password: "{{ lookup('env', 'DB_PASSWORD') }}"
+api_key: "{{ lookup('env', 'API_KEY') }}"
+```
+
+Fail explicitly if a required variable is missing:
+
+```yaml
+- name: Assert required secrets are set
+  ansible.builtin.assert:
+    that:
+      - lookup('env', 'DB_PASSWORD') | length > 0
+      - lookup('env', 'API_KEY') | length > 0
+    fail_msg: "Required environment variables DB_PASSWORD and API_KEY must be set"
+```

--- a/plugins/tools/ansible/skills/ansible/SKILL.md
+++ b/plugins/tools/ansible/skills/ansible/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: ansible
+description: Guide for Ansible automation and configuration management. Use when writing playbooks, tasks, handlers, variables, conditionals, loops, or needing an overview of Ansible project structure and development workflows.
+license: MIT
+---
+
+# Ansible
+
+Activate when working with Ansible playbooks, tasks, variables, handlers, conditionals, loops, or setting up an Ansible project from scratch.
+
+## What Is Ansible
+
+Ansible is an agentless, push-based automation tool. The control node (your machine) connects to managed nodes (servers) over SSH and runs tasks declared in YAML files called playbooks. There is no agent to install on managed nodes — only Python and SSH access are required.
+
+Key properties:
+- **Idempotent**: Running a playbook multiple times produces the same result. Tasks check current state before making changes.
+- **Declarative**: You describe the desired state, not step-by-step instructions.
+- **Push-based**: The control node initiates all connections.
+
+## Available Skills
+
+| Skill | When to load |
+|-------|-------------|
+| `ansible` | Core playbooks, tasks, vars, loops — this file |
+| `ansible-inventory` | Configuring hosts, groups, group_vars, dynamic inventory |
+| `ansible-roles` | Reusable role structure, Galaxy, Jinja2 templates |
+| `ansible-vault` | Encrypting secrets, vault passwords, vault IDs |
+| `ansible-testing` | Molecule test scenarios, Testinfra, CI integration |
+
+## Install
+
+```bash
+pip install ansible          # recommended via pip
+brew install ansible         # macOS Homebrew alternative
+ansible --version            # verify
+```
+
+## Project Directory Layout
+
+```
+my-project/
+├── ansible.cfg              # project-level config (overrides /etc/ansible/ansible.cfg)
+├── inventory/
+│   ├── hosts.ini            # static inventory
+│   ├── group_vars/
+│   │   ├── all.yml          # vars for every host
+│   │   └── webservers.yml   # vars for the webservers group
+│   └── host_vars/
+│       └── web1.yml         # vars for a specific host
+├── roles/
+│   └── my_role/             # reusable role
+├── playbooks/
+│   └── site.yml             # top-level playbook
+└── requirements.yml         # Galaxy roles/collections to install
+```
+
+## Playbook Anatomy
+
+```yaml
+---
+- name: Configure web servers          # human-readable play name
+  hosts: webservers                    # target group from inventory
+  become: true                         # run tasks as root (sudo)
+  vars:
+    app_port: 8080
+  vars_files:
+    - vars/secrets.yml                 # load vars from a file
+  pre_tasks:
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+  tasks:
+    - name: Install nginx
+      ansible.builtin.package:
+        name: nginx
+        state: present
+      notify: Restart nginx            # trigger handler on change
+  handlers:
+    - name: Restart nginx
+      ansible.builtin.service:
+        name: nginx
+        state: restarted
+  post_tasks:
+    - name: Verify nginx is running
+      ansible.builtin.uri:
+        url: "http://localhost:{{ app_port }}"
+```
+
+## Task Structure
+
+```yaml
+- name: Ensure /var/app exists        # always include a name
+  ansible.builtin.file:               # fully-qualified module name (recommended)
+    path: /var/app
+    state: directory
+    owner: www-data
+    mode: "0755"
+  become: true                        # task-level privilege escalation
+  when: ansible_os_family == "Debian" # conditional
+  register: dir_result                # save task output to a variable
+  notify: Restart app                 # call handler if task changed
+  ignore_errors: true                 # continue even if task fails
+  tags:
+    - setup
+```
+
+## Handlers
+
+Handlers run at the end of a play, only once, and only if notified. Use them for service restarts triggered by config changes.
+
+```yaml
+handlers:
+  - name: Restart nginx
+    ansible.builtin.service:
+      name: nginx
+      state: restarted
+
+  - name: Reload systemd
+    ansible.builtin.systemd:
+      daemon_reload: true
+```
+
+Force handlers to run before the end of the play:
+
+```yaml
+- name: Flush handlers now
+  ansible.builtin.meta: flush_handlers
+```
+
+## Variables
+
+Ansible merges variables from many sources. Higher numbers override lower:
+
+| Precedence | Source |
+|------------|--------|
+| 1 (lowest) | Role defaults (`roles/x/defaults/main.yml`) |
+| 2 | Inventory group_vars |
+| 3 | Inventory host_vars |
+| 4 | Playbook `vars:` block |
+| 5 | `vars_files:` |
+| 6 | `register:` output |
+| 7 (highest) | Extra vars (`-e` flag) |
+
+```yaml
+vars:
+  app_name: myapp
+  app_port: 8080
+  app_config:
+    debug: false
+    workers: 4
+
+tasks:
+  - name: Print app name
+    ansible.builtin.debug:
+      msg: "App: {{ app_name }} on port {{ app_port }}"
+
+  - name: Access nested var
+    ansible.builtin.debug:
+      msg: "{{ app_config.workers }} workers"
+```
+
+## Conditionals
+
+```yaml
+- name: Install on Debian only
+  ansible.builtin.apt:
+    name: curl
+    state: present
+  when: ansible_os_family == "Debian"
+
+- name: Run only if previous task changed
+  ansible.builtin.debug:
+    msg: "Config was updated"
+  when: config_result.changed
+
+- name: Multiple conditions (AND)
+  ansible.builtin.debug:
+    msg: "Production Debian host"
+  when:
+    - ansible_os_family == "Debian"
+    - env == "production"
+
+- name: Either condition (OR)
+  ansible.builtin.debug:
+    msg: "RedHat family"
+  when: ansible_os_family == "RedHat" or ansible_distribution == "Amazon"
+```
+
+## Loops
+
+```yaml
+- name: Install multiple packages
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - git
+    - curl
+    - vim
+
+- name: Create users
+  ansible.builtin.user:
+    name: "{{ item.name }}"
+    groups: "{{ item.groups }}"
+  loop:
+    - { name: alice, groups: sudo }
+    - { name: bob, groups: www-data }
+
+- name: Loop with index
+  ansible.builtin.debug:
+    msg: "{{ loop_index }}: {{ item }}"
+  loop: [a, b, c]
+  loop_control:
+    index_var: loop_index
+    label: "{{ item }}"   # cleaner output in --verbose
+```
+
+## Tags
+
+Run or skip specific tasks without modifying the playbook:
+
+```yaml
+tasks:
+  - name: Install packages
+    ansible.builtin.package:
+      name: nginx
+      state: present
+    tags: [install, packages]
+
+  - name: Configure nginx
+    ansible.builtin.template:
+      src: nginx.conf.j2
+      dest: /etc/nginx/nginx.conf
+    tags: [configure]
+```
+
+```bash
+ansible-playbook site.yml --tags install          # only tagged tasks
+ansible-playbook site.yml --skip-tags configure   # skip tagged tasks
+ansible-playbook site.yml --tags all              # all tasks (default)
+```
+
+## Common CLI Flags
+
+```bash
+ansible-playbook site.yml -i inventory/hosts.ini  # specify inventory
+ansible-playbook site.yml --limit webservers       # target subset of hosts
+ansible-playbook site.yml --check                  # dry run (no changes)
+ansible-playbook site.yml --diff                   # show file diffs
+ansible-playbook site.yml -v / -vv / -vvv          # verbosity levels
+ansible-playbook site.yml -e "env=production"      # extra vars
+ansible-playbook site.yml --start-at-task "Install nginx"  # resume mid-play
+ansible-playbook site.yml --step                   # confirm each task
+```
+
+## References
+
+- **[playbook-patterns.md](references/playbook-patterns.md)** — Multi-play playbooks, import vs include, error handling blocks, delegation, `run_once`

--- a/plugins/tools/ansible/skills/ansible/references/playbook-patterns.md
+++ b/plugins/tools/ansible/skills/ansible/references/playbook-patterns.md
@@ -1,0 +1,235 @@
+# Playbook Patterns
+
+## Multi-Play Playbooks
+
+A single playbook file can contain multiple plays, each targeting different hosts:
+
+```yaml
+---
+# site.yml — full stack deployment
+- name: Configure database servers
+  hosts: dbservers
+  become: true
+  roles:
+    - common
+    - postgresql
+
+- name: Configure web servers
+  hosts: webservers
+  become: true
+  roles:
+    - common
+    - nginx
+    - app
+
+- name: Configure load balancer
+  hosts: loadbalancers
+  become: true
+  roles:
+    - common
+    - haproxy
+```
+
+Run a single play from a multi-play file using `--limit`:
+
+```bash
+ansible-playbook site.yml --limit webservers
+```
+
+## pre_tasks and post_tasks
+
+`pre_tasks` run before roles, `post_tasks` run after handlers. Use them to set up preconditions or run teardown steps that don't belong in roles.
+
+```yaml
+- hosts: webservers
+  become: true
+  pre_tasks:
+    - name: Wait for system to be ready
+      ansible.builtin.wait_for_connection:
+        timeout: 60
+
+    - name: Gather facts after connection
+      ansible.builtin.setup:
+
+  roles:
+    - nginx
+
+  post_tasks:
+    - name: Verify deployment succeeded
+      ansible.builtin.uri:
+        url: http://localhost/healthz
+        status_code: 200
+      retries: 5
+      delay: 3
+```
+
+## import vs include
+
+| Feature | `import_*` (static) | `include_*` (dynamic) |
+|---------|--------------------|-----------------------|
+| Resolved at | Parse time | Runtime |
+| `when:` applies | To each imported task | To the include itself |
+| `tags:` propagate | Yes | Partial |
+| `loop:` supported | No | Yes |
+| `--list-tasks` shows | All tasks | Only the include line |
+
+```yaml
+# Static: use for standard task files, tags propagate correctly
+- ansible.builtin.import_tasks: tasks/install.yml
+
+# Dynamic: use when you need loops or conditionals on the file itself
+- ansible.builtin.include_tasks: "tasks/{{ ansible_os_family }}.yml"
+
+- ansible.builtin.include_tasks: tasks/configure.yml
+  when: configure_enabled | bool
+  loop: "{{ sites }}"
+  loop_control:
+    loop_var: site
+```
+
+## Error Handling with block/rescue/always
+
+```yaml
+- name: Deploy application
+  block:
+    - name: Stop the service
+      ansible.builtin.service:
+        name: myapp
+        state: stopped
+
+    - name: Update the binary
+      ansible.builtin.copy:
+        src: dist/myapp
+        dest: /usr/local/bin/myapp
+        mode: "0755"
+
+    - name: Start the service
+      ansible.builtin.service:
+        name: myapp
+        state: started
+
+  rescue:
+    # Runs only if a task in block fails
+    - name: Roll back binary
+      ansible.builtin.copy:
+        src: dist/myapp.bak
+        dest: /usr/local/bin/myapp
+        mode: "0755"
+
+    - name: Restart service with old binary
+      ansible.builtin.service:
+        name: myapp
+        state: started
+
+    - name: Notify team of failure
+      ansible.builtin.debug:
+        msg: "Deployment failed — rolled back"
+
+  always:
+    # Runs whether block succeeded or failed
+    - name: Collect deployment log
+      ansible.builtin.fetch:
+        src: /var/log/myapp/deploy.log
+        dest: logs/
+```
+
+## Task Delegation
+
+Run a task on a different host than the current play's target. Common for:
+- Registering/deregistering from a load balancer before deploying
+- Running a command on a central DB host while iterating web hosts
+- Creating a local file based on remote facts
+
+```yaml
+- name: Remove from load balancer before update
+  ansible.builtin.uri:
+    url: "http://lb.example.com/api/deregister/{{ inventory_hostname }}"
+    method: POST
+  delegate_to: loadbalancer       # run this task on loadbalancer host
+
+- name: Run migration on db host
+  ansible.builtin.command: /var/app/migrate.sh
+  delegate_to: db1.example.com
+
+- name: Write inventory report locally
+  ansible.builtin.copy:
+    content: "{{ ansible_facts | to_nice_json }}"
+    dest: "/tmp/facts-{{ inventory_hostname }}.json"
+  delegate_to: localhost
+```
+
+## run_once
+
+Execute a task exactly once, regardless of how many hosts are in the play. The task runs on the first host in the batch; Ansible skips all others.
+
+```yaml
+- name: Run database migration (only once for the whole play)
+  ansible.builtin.command: /var/app/manage.py migrate
+  delegate_to: "{{ groups['dbservers'][0] }}"
+  run_once: true
+
+- name: Send deployment notification
+  ansible.builtin.uri:
+    url: https://hooks.slack.com/services/XXX/YYY/ZZZ
+    method: POST
+    body_format: json
+    body:
+      text: "Deployed version {{ app_version }} to {{ inventory_hostname }}"
+  run_once: true
+  delegate_to: localhost
+```
+
+## Rolling Updates with serial
+
+By default Ansible runs each task across all hosts before moving to the next task. Use `serial` to process hosts in batches (rolling deploy):
+
+```yaml
+- hosts: webservers
+  serial: 2              # process 2 hosts at a time
+  # serial: "25%"        # or percentage of total hosts
+  # serial: [1, 5, "50%"]  # progressive: 1 host, then 5, then 50%
+  become: true
+  roles:
+    - app
+```
+
+With `serial`, all tasks run on the first batch before moving to the next, limiting the blast radius if a deployment fails.
+
+## Waiting for Hosts
+
+```yaml
+- name: Wait for SSH to come back after reboot
+  ansible.builtin.wait_for:
+    host: "{{ inventory_hostname }}"
+    port: 22
+    delay: 10
+    timeout: 300
+  delegate_to: localhost
+
+- name: Wait for service port to be open
+  ansible.builtin.wait_for:
+    host: "{{ ansible_host }}"
+    port: 8080
+    state: started
+    timeout: 60
+  delegate_to: localhost
+
+- name: Pause for human confirmation
+  ansible.builtin.pause:
+    prompt: "Press Enter to continue deployment, Ctrl+C to abort"
+```
+
+## Gathering Facts Selectively
+
+Fact gathering runs at the start of each play and adds overhead. Disable or limit it when speed matters:
+
+```yaml
+- hosts: all
+  gather_facts: false           # skip all facts
+
+- hosts: all
+  gather_subset:                # gather only specific subsets
+    - network
+    - hardware
+  # subsets: all, min, hardware, network, virtual, ohai, facter
+```

--- a/plugins/tools/ansible/skills/sources.md
+++ b/plugins/tools/ansible/skills/sources.md
@@ -1,0 +1,76 @@
+# Ansible Plugin Sources
+
+## ansible Skill
+
+- **URL**: https://docs.ansible.com/ansible/latest/getting_started/index.html
+  - **Purpose**: Official getting started guide and quickstart
+  - **Key topics**: Installation, first playbook, project layout, core concepts
+  - **Accessed**: 2026-05-06
+
+- **URL**: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_intro.html
+  - **Purpose**: Playbook structure, tasks, handlers, variables
+  - **Key topics**: Playbook anatomy, task structure, `when:`, `loop:`, `notify:`, tags
+  - **Accessed**: 2026-05-06
+
+- **URL**: https://docs.ansible.com/ansible/latest/reference_appendices/general_precedence.html
+  - **Purpose**: Variable precedence reference
+  - **Key topics**: Variable type order from lowest to highest precedence
+  - **Accessed**: 2026-05-06
+
+## ansible-inventory Skill
+
+- **URL**: https://docs.ansible.com/ansible/latest/inventory_guide/index.html
+  - **Purpose**: Complete inventory documentation
+  - **Key topics**: Static inventory (INI, YAML), host patterns, group_vars, host_vars, connection variables
+  - **Accessed**: 2026-05-06
+
+- **URL**: https://docs.ansible.com/ansible/latest/inventory_guide/intro_dynamic_inventory.html
+  - **Purpose**: Dynamic inventory plugins and scripts
+  - **Key topics**: Inventory plugins, AWS EC2, Azure, GCP, constructing groups
+  - **Accessed**: 2026-05-06
+
+## ansible-roles Skill
+
+- **URL**: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html
+  - **Purpose**: Role structure, usage, and dependencies
+  - **Key topics**: Role directory layout, `import_role:`, `include_role:`, `meta/main.yml`
+  - **Accessed**: 2026-05-06
+
+- **URL**: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_templating.html
+  - **Purpose**: Jinja2 templating in Ansible
+  - **Key topics**: Template syntax, filters, tests, the `template:` module
+  - **Accessed**: 2026-05-06
+
+- **URL**: https://galaxy.ansible.com/docs/
+  - **Purpose**: Ansible Galaxy documentation
+  - **Key topics**: Installing roles and collections, `requirements.yml`, `ansible-galaxy` CLI
+  - **Accessed**: 2026-05-06
+
+## ansible-vault Skill
+
+- **URL**: https://docs.ansible.com/ansible/latest/vault_guide/index.html
+  - **Purpose**: Complete Vault documentation
+  - **Key topics**: Encrypting variables and files, vault IDs, password sources, `ansible-vault` CLI
+  - **Accessed**: 2026-05-06
+
+- **URL**: https://docs.ansible.com/ansible/latest/collections/community/hashi_vault/hashi_vault_lookup.html
+  - **Purpose**: HashiCorp Vault lookup plugin
+  - **Key topics**: Lookup plugin configuration, token auth, AppRole auth
+  - **Accessed**: 2026-05-06
+
+## ansible-testing Skill
+
+- **URL**: https://molecule.readthedocs.io/en/latest/
+  - **Purpose**: Molecule official documentation
+  - **Key topics**: Scenarios, drivers, phases, verify, lint, CI integration
+  - **Accessed**: 2026-05-06
+
+- **URL**: https://ansible-lint.readthedocs.io/
+  - **Purpose**: ansible-lint documentation
+  - **Key topics**: Rule profiles, configuration, CI integration
+  - **Accessed**: 2026-05-06
+
+- **URL**: https://testinfra.readthedocs.io/en/latest/
+  - **Purpose**: Testinfra documentation
+  - **Key topics**: Built-in modules (file, service, package, command), assertion patterns
+  - **Accessed**: 2026-05-06


### PR DESCRIPTION
## Summary

Adds a Claude plugin for working with Ansible covering:

- Core playbooks
- Inventory
- Roles
- Vault secrets
- Molecule testing

## Skills

- **ansible:** playbook anatomy, tasks, handlers, variables, conditionals, loops, tags, and ansible-playbook CLI reference
- **ansible-inventory:** static INI/YAML inventory, host patterns, group_vars/host_vars, connection variables, and dynamic inventory plugins
- **ansible-roles:** role directory structure, defaults vs vars precedence, import_role vs include_role, Jinja2 templates, and Galaxy collections
- **ansible-vault:** ansible-vault CLI, encrypting variables and files, vault IDs, no_log security practices, and external secret backend overview
- **ansible-testing:** Molecule phases, Docker/Podman/delegated drivers, idempotency checks, Testinfra assertions, and GitHub Actions CI integration

## Marketplace Entry

- name: ansible
- source: ./plugins/tools/ansible
- category: tools
- version: 0.1.0
- keywords: ansible, automation, configuration-management, devops, playbooks, molecule

## Notes

- All skills score 11/12 on the quality scorecard.
- Mise test passes.