### PR TITLE
docs(mise): add cli/cli and go-backend ls-remote examples

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -52,7 +52,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "category": "development",
       "keywords": ["git", "documentation", "code-review", "tools", "beads", "bees", "container", "tdd", "agent-loop"]
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/mise/SKILL.md
+++ b/plugins/core/skills/mise/SKILL.md
@@ -101,6 +101,14 @@ $ mise ls-remote github:goreleaser/goreleaser | head -5
 2.10.0
 2.10.1
 
+# github backend — the GitHub CLI itself
+$ mise ls-remote github:cli/cli | head -5
+2.74.0
+2.74.1
+2.74.2
+2.75.0
+2.75.1
+
 # cargo backend — lists versions from crates.io
 $ mise ls-remote cargo:ripgrep | head -5
 0.1.0
@@ -108,6 +116,14 @@ $ mise ls-remote cargo:ripgrep | head -5
 0.1.2
 0.1.3
 0.1.4
+
+# go backend — requires Go installed (mise use go@latest)
+$ mise ls-remote go:mvdan.cc/gofumpt | head -5
+0.1.0
+0.1.1
+0.2.0
+0.2.1
+0.3.0
 
 # npm backend — lists versions from the npm registry
 $ mise ls-remote npm:typescript | head -5


### PR DESCRIPTION
- Add `mise ls-remote github:cli/cli` example to mise skill (closes 4-tool coverage in bee 29 AC)
- Add `mise ls-remote go:mvdan.cc/gofumpt` example with note that go backend requires Go installed
- Bump core 0.2.0 → 0.2.1 and all-skills 0.4.0 → 0.4.1

Closes claude-skills-29