### PR TITLE
docs(skills/core/nushell): document bare-main double-invocation gotcha

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "A curated collection of Claude skills for development workflows",
-    "version": "1.0.7"
+    "version": "1.0.8"
   },
   "plugins": [
     {
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -52,7 +52,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "category": "development",
       "keywords": ["git", "documentation", "code-review", "tools", "beads", "bees", "container", "tdd", "agent-loop"]
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/nushell/SKILL.md
+++ b/plugins/core/skills/nushell/SKILL.md
@@ -885,6 +885,35 @@ if true {
 print $x  # Works
 ```
 
+### Bare `main` Call After `def main` (Double-Invocation)
+
+Nushell auto-invokes `def main` when a script is executed via `nu script.nu`. A script that defines `def main` AND has a bare `main` line at the end of the file runs `main` **twice**, silently doubling every side effect (HTTP posts, file writes, subprocess spawns, workflow submissions).
+
+```nu
+# WRONG — fires main twice
+def main [] {
+  http post $url $body
+  print "done"
+}
+
+main  # ← Nushell already invoked this; the explicit call duplicates work
+```
+
+```nu
+# CORRECT — Nushell handles the invocation
+def main [] {
+  http post $url $body
+  print "done"
+}
+# (no bare `main` line — script ends with the def)
+```
+
+**Why it matters:** silent duplication is hard to debug. The classic symptom is "this single-step workflow somehow fired two HTTP requests." Confirmed via instrumented print counters: the file parses once but the `main` entry counter increments twice.
+
+**Detection:** `grep -nE '^main(\s|$)' script.nu` flags any bare invocations at column 0. Add this as a CI lint rule for repos that contain multiple Nushell scripts — chained workflows multiply the impact (each chain hop doubles the next).
+
+**Reference:** Nushell script execution model — when invoking `nu script.nu`, the runtime auto-calls `main` if defined. Do not double up.
+
 ## Key Principles
 
 - **Structured data first**: Think in terms of tables and records, not text


### PR DESCRIPTION
- Add "Bare \`main\` Call After \`def main\`" subsection to /core:nushell Common Pitfalls
- Bump core plugin 0.2.0 → 0.2.1 in plugin.json + marketplace.json
- Bump all-skills meta-plugin 0.4.0 → 0.4.1 to match

Closes #63

**Diagnostic incident:** VantageEx/Runex build chain dogfood, 2026-05-09. Haiku ae84d711c7b2b1bde instrumented `submit-build-app.nu` (test run 1085) — file-top printed once, main-entry printed twice. Cascaded through 6+ chain hops doubling at each level.

**Affected downstream PRs (parallel sonnets, single-line removal of bare `main` invocation):**

- runex repo: chain-fix PR for `bundles/build-runex/scripts/submit-build-app.nu`
- runex-workflows repo: chain-fix PR for `bundles/build-app/scripts/build-bundle-handoff.nu` + `bundles/build-app/scripts/deploy-handoff.nu`