### PR TITLE
fix(claude-code): escape bang-backtick exec markers in claude-skills docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -43,7 +43,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills: plugin marketplace management and validation",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "category": "tools",
       "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark", "skill-update", "output-styles", "statusline"]
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/claude-skills/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-skills/SKILL.md
@@ -148,12 +148,20 @@ Three patterns from the upstream docs guide what to put in the body:
 
 Skills support runtime substitution before content reaches the model. Source: [Claude Code Skills docs](https://code.claude.com/docs/en/skills#inject-dynamic-context).
 
-**Shell injection** — `` !`<command>` `` inline or fenced ` ```! ` blocks run shell commands; output replaces the placeholder before Claude sees the skill:
+**Shell injection** — Claude Code can run shell commands embedded in a skill before the body reaches the model; the command's stdout replaces the placeholder. Two forms:
 
-````markdown
+- **Inline**: a bang character followed by a backtick-quoted command on a single line.
+- **Fenced**: a code fence whose opening line is three backticks followed by a bang.
+
+`````markdown
 ## Current diff
 !`git diff HEAD`
-````
+
+```!
+node --version
+npm --version
+```
+`````
 
 **String substitutions** in skill content:
 - `$ARGUMENTS` — full arguments string

--- a/plugins/tools/claude-code/skills/claude-skills/references/frontmatter-fields.md
+++ b/plugins/tools/claude-code/skills/claude-skills/references/frontmatter-fields.md
@@ -43,7 +43,7 @@ Only `description` is recommended (so Claude knows when to invoke the skill).
 | `agent` | Subagent type when `context: fork`. Built-in: `Explore`, `Plan`, `general-purpose`. Or any custom subagent in `.claude/agents/`. |
 | `hooks` | Hooks scoped to this skill's lifecycle. See `claude-hooks` skill. |
 | `paths` | Glob patterns that limit auto-activation. Comma-separated string or YAML list. Skill loads only when working with matching files. |
-| `shell` | `bash` (default) or `powershell` for `` !`...` `` inline shell. PowerShell requires `CLAUDE_CODE_USE_POWERSHELL_TOOL=1`. |
+| `shell` | `bash` (default) or `powershell` — selects the interpreter for bang-backtick inline command substitution. PowerShell requires `CLAUDE_CODE_USE_POWERSHELL_TOOL=1`. |
 
 ## String substitutions in skill content
 
@@ -60,22 +60,21 @@ Indexed arguments use shell-style quoting. Wrap multi-word values in quotes: `/s
 
 ## Dynamic context injection
 
-Inline shell commands run before the skill content reaches Claude. Output replaces the placeholder:
+Shell commands embedded in skill content run before the body reaches Claude; their stdout replaces the placeholder. Two forms:
 
-```markdown
+- **Inline**: a bang character followed by a backtick-quoted command on a single line.
+- **Fenced**: a code fence whose opening line is three backticks followed by a bang.
+
+`````markdown
 ## Current changes
 !`git diff HEAD`
-```
 
-Multi-line form uses a fenced code block opened with ` ```! `:
-
-````markdown
 ## Environment
 ```!
 node --version
 npm --version
 ```
-````
+`````
 
 Disable across user/project/plugin/additional-directory skills via `"disableSkillShellExecution": true` in settings. Bundled and managed skills are unaffected.
 


### PR DESCRIPTION
- Rewrite SKILL.md shell-injection paragraph to use word-based prose (no literal !-backtick adjacency in unfenced text)
- Rewrite frontmatter-fields.md table cell and Dynamic context injection section the same way
- Wrap working examples in 5-backtick outer fences for parser-shielding parity
- Bump claude-code plugin and all-skills meta-plugin patch versions; sync marketplace.json entry

Resolves /claude-code:claude-skills load failure on Claude Code versions that parse !\`<command>\` and \`\`\`! markers in skill content as live shell-exec templates.