### PR TITLE
feat(amux): add amux tool plugin and skill anchored on v0.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "A curated collection of Claude skills for development workflows",
-    "version": "1.0.8"
+    "version": "1.0.9"
   },
   "plugins": [
     {
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -26,6 +26,16 @@
       "version": "0.1.0",
       "category": "tools",
       "keywords": ["allium", "agent-loop", "tdd", "behavioral-spec"],
+      "license": "MIT"
+    },
+    {
+      "name": "amux",
+      "source": "./plugins/tools/amux",
+      "strict": true,
+      "description": "amux: parallel AI code agent sessions with container isolation, worktrees, and a headless REST API",
+      "version": "0.1.0",
+      "category": "tools",
+      "keywords": ["amux", "agents", "workflows", "tmux", "claude-code", "container"],
       "license": "MIT"
     },
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -19,6 +19,7 @@
   ],
   "skills": [
     "./plugins/tools/allium/skills/allium",
+    "./plugins/tools/amux/skills/amux",
     "./plugins/tools/ansible/skills/ansible",
     "./plugins/tools/ansible/skills/ansible-inventory",
     "./plugins/tools/ansible/skills/ansible-roles",

--- a/plugins/tools/amux/.claude-plugin/plugin.json
+++ b/plugins/tools/amux/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "amux",
+  "version": "0.1.0",
+  "description": "amux: parallel AI code agent sessions with container isolation, worktrees, and a headless REST API",
+  "author": { "name": "vinnie357" },
+  "repository": "https://github.com/vinnie357/claude-skills",
+  "license": "MIT",
+  "keywords": ["amux", "agents", "workflows", "tmux", "claude-code", "container"],
+  "skills": ["./skills/amux"]
+}

--- a/plugins/tools/amux/skills/amux/SKILL.md
+++ b/plugins/tools/amux/skills/amux/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: amux
+description: Guide for using amux to run AI coding agents in isolated containers with multi-step workflows and a headless REST API. Use when configuring parallel agent sessions, authoring amux workflows, driving the headless REST API, managing worktrees, or troubleshooting amux container runs.
+license: Apache-2.0
+---
+
+# amux
+
+amux is a Rust CLI and TUI for running AI coding agents (Claude Code, codex, opencode, and others) in isolated Docker or Apple Containers sandboxes. It coordinates parallel agent sessions, executes multi-step workflows, and exposes a REST API for headless programmatic control.
+
+**amux is not a tmux wrapper.** The name invites that assumption. amux ships its own tab-based TUI with its own keybindings. Tmux is not a dependency.
+
+Source: https://github.com/prettysmartdev/amux (accessed 2026-05-16)
+License: Apache-2.0 | Latest at research time: v0.8.0 (2026-04-12)
+
+## When to Use This Skill
+
+Activate when:
+- Setting up a project for parallel agent sessions (`amux init`, `amux ready`)
+- Running a chat session or one-off prompt via the amux CLI
+- Authoring or executing multi-step workflows (`amux new workflow`, `amux exec workflow`)
+- Driving the headless REST server from an automation script
+- Troubleshooting container isolation, worktrees, or config file conflicts
+- Configuring agent selection, container runtimes, or environment passthrough
+
+## Prerequisites
+
+- A container runtime: **Docker** (Linux, macOS, Windows) or **Apple Containers** (macOS 26+). Set via global `runtime` config key. The two runtimes are mutually exclusive.
+- Runtime running and healthy before any `amux` session starts.
+
+## Install
+
+Mise is the recommended install path. It manages the version, pins reproducibly, and uses the GitHub releases backend — no extra dependencies.
+
+A ready-to-copy pin lives at `templates/0.8.0/mise.toml` in this skill — copy it into the target repo's `mise.toml` (or merge under `[tools]`) and run `mise install`.
+
+**Global pin (one-time, any project):**
+```sh
+mise use -g github:prettysmartdev/amux@0.8.0
+```
+
+**Per-project pin (recommended for repos that run amux):**
+```sh
+cp templates/0.8.0/mise.toml <your-repo>/mise.toml   # then: cd <your-repo> && mise install
+```
+
+The template's contents:
+```toml
+[tools]
+"github:prettysmartdev/amux" = "0.8.0"
+```
+
+**Verify:**
+```sh
+mise which amux && amux --version
+```
+
+Fall back to the upstream installer (`curl -s https://prettysmart.dev/install/amux.sh | sh`) or a pre-built binary from https://github.com/prettysmartdev/amux/releases only when mise is unavailable (locked-down CI image, no GitHub release network access). State the reason explicitly when doing so. Building from source requires Rust 1.94+ (`git clone` + `sudo make install`). Do not use Homebrew, asdf, or mason — none are documented by upstream.
+
+## First-Run Diagnostic
+
+amux is pre-1.0 and ships weekly. Run these before trusting that docs match the installed binary:
+
+```sh
+amux --version
+amux config show
+```
+
+`amux config show` prints the merged effective config (global + per-repo). Use it to verify `runtime`, `default_agent`, and overlay state rather than reading JSON files directly.
+
+## Command Tree
+
+| Command | Purpose |
+|---------|---------|
+| `amux init [--agent <name>]` | Scaffold project: writes `aspec/.amux.json`, populates `.amux/Dockerfile.*` |
+| `amux ready [--refresh]` | Verify environment; `--refresh` rebuilds the agent Dockerfile |
+| `amux chat [--agent <name>] [--auto] [--yolo]` | Interactive agent session in TUI tab |
+| `amux exec prompt "<text>"` | One-off prompt without a persistent session |
+| `amux exec workflow <path> [--work-item <nnnn>] [--yolo] [--worktree]` | Run a multi-step workflow file |
+| `amux new spec [--interview]` | Create a numbered work item file |
+| `amux new workflow [--interview]` | Scaffold a workflow file |
+| `amux new skill [--interview]` | Create a custom skill for the skills overlay |
+| `amux specs amend <nnnn>` | Update an existing spec |
+| `amux status [--watch]` | Session/workflow dashboard |
+| `amux config show` | Merged effective config |
+| `amux config get <field>` | Single field with precedence breakdown |
+| `amux config set [--global] <field> <value>` | Write a config key |
+| `amux headless start [--port <n>]` | Start REST server (default port 9876) |
+| `amux headless status` | Check headless server |
+| `amux headless kill` | Stop headless server |
+| `amux remote run <cmd> [--follow]` | Submit command to remote headless server |
+| `amux remote session start <dir>` | Create session on headless server |
+| `amux remote session kill <id>` | Close session on headless server |
+| `amux` (no args) | Open TUI |
+
+See `templates/0.8.0/commands.md` for the full v0.8.0 command surface with flags and examples.
+
+## Agents
+
+Supported agents: `claude`, `codex`, `opencode`, `maki`, `gemini`, `copilot`, `crush`, `cline`.
+
+Each agent has a Dockerfile in `.amux/Dockerfile.<agent>` (seeded from upstream templates). Customize the Dockerfile to add tools or environment configuration for that agent.
+
+**Selection precedence** (highest wins):
+1. Per-step `Agent:` field in the workflow file
+2. `--agent <name>` flag on the CLI invocation
+3. `agent` key in `aspec/.amux.json` (per-repo default)
+4. `default_agent` key in `~/.amux/config.json` (global default; factory default: `"claude"`)
+
+## Worktrees
+
+Opt-in via `--worktree` on `amux chat` / `amux exec`, or implicitly when `--yolo` is used with `amux exec workflow`. All steps in a single workflow run share one worktree.
+
+Worktrees are **never auto-deleted**. At session end, amux prompts: merge / discard / keep. On abort, the worktree is preserved for manual inspection. Monitor disk use when running repeated `--yolo` workflow runs.
+
+Containers run `--rm` and auto-remove at session end. Only the Git repository is bind-mounted; `/workspace` inside the container is ephemeral beyond what lands in the Git tree.
+
+## Config Files
+
+Two JSON files coexist — do not confuse them:
+
+| File | Scope | Created by | Commit? |
+|------|-------|-----------|---------|
+| `~/.amux/config.json` | Global | Manually or `amux config set --global` | No |
+| `GITROOT/aspec/.amux.json` | Per-repo | `amux init` | Yes |
+
+Per-repo takes precedence on overlapping scalar keys. `overlays.skills` and `overlays.directories` merge **additively** across scopes.
+
+The `.amux/` directory inside the repo holds per-agent Dockerfiles and a `config.json` for local-only overrides — this is a separate file from `aspec/.amux.json`. Always use `amux config show` to see merged values rather than hand-editing either JSON file.
+
+See `references/config.md` for the full per-key schema (type, default, scope, merge behavior).
+
+## Headless Mode
+
+`amux headless start` runs a REST server on port 9876 (configurable via `--port`). It accepts bearer-token auth. Sessions are restricted to directories listed in `headless.workDirs` in the global config.
+
+**One active command per session.** Submitting a second command while one is in flight returns HTTP 403. Commands are async — `POST /v1/commands` returns a `command_id` immediately; poll `/v1/commands/:id` or stream `/v1/commands/:id/logs/stream` (Server-Sent Events) to track progress.
+
+Prefer `amux remote run` over raw curl when driving the headless server from the CLI — it is the canonical wrapper per the operator-tooling-first convention.
+
+See `references/headless-api.md` for the full endpoint table and curl examples.
+
+## Workflow Authoring
+
+Workflows are Markdown (`.md`), TOML (`.toml`), or YAML (`.yml`/`.yaml`) files authored via `amux new workflow [--interview]` and executed via `amux exec workflow <path>`.
+
+Template variables available in prompts: `{{work_item_number}}` (zero-padded 4-digit), `{{work_item_content}}` (full file), `{{work_item_section:[Name]}}` (named section).
+
+See `references/workflows.md` for grammar in all three formats, field ordering rules, and worked examples.
+
+## Known Sharp Edges (Pre-1.0)
+
+- **Not a tmux wrapper.** amux ships its own TUI. The name is misleading.
+- **Two config files with similar paths.** `aspec/.amux.json` (canonical, commit it) vs `.amux/config.json` (local overlay). Use `amux config show` — never hand-edit.
+- **Worktrees never auto-clean.** Each aborted `--yolo` run leaves a worktree on disk. Run `git worktree list` periodically and prune stale ones.
+- **One concurrent command per headless session.** HTTP 403 on a second submit. Poll completion before re-using a session.
+- **`runtime` is global-only.** No per-repo selection between Docker and Apple Containers.
+- **Weekly release cadence.** Re-run `amux --version` when output looks unexpected. Pin in mise to control when you upgrade.
+- **Markdown workflow field order is mandatory.** `Depends-on` → `Agent` → `Model` → `Prompt`. Anything after `Prompt:` becomes prompt text — trailing fields are silently consumed.
+- **Lowercase keys only in all workflow formats.** Uppercase variants are parse errors.
+- **No MCP server and no hooks as of v0.8.0.** amux does not expose MCP and has no pre/post lifecycle hooks. Server-Sent Events on `/v1/commands/:id/logs/stream` are the only streaming interface.
+
+## References
+
+- `references/headless-api.md` — REST endpoint table, bearer auth, curl examples
+- `references/workflows.md` — Workflow grammar in Markdown, TOML, and YAML
+- `references/config.md` — Per-key config schema for both config files
+- `references/command-reference.md` — Full CLI surface with flags and examples
+- `templates/0.8.0/commands.md` — Immutable v0.8.0 command snapshot
+
+## Anti-Fabrication
+
+Run `amux --version` and `amux config show` before asserting that any documented behavior matches the installed binary. amux is pre-1.0 and minor bumps carry breaking changes. Every command form in this skill traces to the research report sourced from https://github.com/prettysmartdev/amux (accessed 2026-05-16). Mark any behavior not confirmed by that source as "requires verification against amux v0.8.0 source." Apply `/core:anti-fabrication` rules to all outputs produced with this skill active.

--- a/plugins/tools/amux/skills/amux/references/command-reference.md
+++ b/plugins/tools/amux/skills/amux/references/command-reference.md
@@ -1,0 +1,476 @@
+# amux Command Reference
+
+Exhaustive reference for all amux CLI subcommands, flags, and options as of v0.8.0.
+
+Source: https://github.com/prettysmartdev/amux — accessed 2026-05-16.
+Run `amux <subcommand> --help` to verify flags match the installed binary. Pre-1.0 releases drift between minors.
+
+---
+
+## Global flags
+
+| Flag | Description |
+|------|-------------|
+| `--version` | Print the amux version and exit |
+| `--help` | Print help for the command or subcommand |
+
+Run `amux` with no arguments to open the TUI.
+
+---
+
+## `amux init`
+
+Initialize a project for amux. Creates `aspec/.amux.json` in the Git repository root and populates `.amux/` with per-agent Dockerfiles.
+
+```
+amux init [FLAGS]
+```
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--agent <name>` | string | Set the default agent for this repo (e.g. `claude`, `codex`) |
+
+**What it writes:**
+- `aspec/.amux.json` — per-repo config file (commit to source control)
+- `.amux/Dockerfile.claude`, `.amux/Dockerfile.codex`, … — per-agent Dockerfiles seeded from upstream templates
+- `.amux/config.json` — local-only overrides (do not commit; see config.md for the distinction)
+
+**Examples:**
+
+```sh
+# Initialize with the default agent (claude)
+amux init
+
+# Initialize and set codex as the repo default
+amux init --agent codex
+```
+
+**After init**, run `amux ready --refresh` to build the agent Docker image before starting any session.
+
+---
+
+## `amux ready`
+
+Verify that the environment is correctly configured and that the agent container image is built.
+
+```
+amux ready [FLAGS]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--refresh` | Force rebuild of the agent Docker image |
+
+**Examples:**
+
+```sh
+# Check environment without rebuilding
+amux ready
+
+# Check AND rebuild the agent image (run after amux init or after editing a Dockerfile)
+amux ready --refresh
+```
+
+---
+
+## `amux config`
+
+Inspect and modify amux configuration. Reads from both `$HOME/.amux/config.json` (global) and `$GITROOT/aspec/.amux.json` (per-repo); per-repo wins on conflicts.
+
+### `amux config show`
+
+Print the merged effective configuration — all keys, resolved in precedence order.
+
+```
+amux config show
+```
+
+No flags. Run this first when debugging unexpected behavior.
+
+**Example:**
+
+```sh
+amux config show
+```
+
+### `amux config get`
+
+Show the current value of a single config key, indicating which scope (global or per-repo) provided it.
+
+```
+amux config get <field>
+```
+
+**Examples:**
+
+```sh
+amux config get default_agent
+amux config get runtime
+amux config get workItems.dir
+```
+
+### `amux config set`
+
+Set a config key. Without `--global`, writes to the per-repo `aspec/.amux.json`; with `--global`, writes to `$HOME/.amux/config.json`.
+
+```
+amux config set [FLAGS] <field> <value>
+```
+
+| Flag | Description |
+|------|-------------|
+| `--global` | Write to the global config instead of the per-repo config |
+
+**Examples:**
+
+```sh
+# Set the repo default agent
+amux config set agent codex
+
+# Set the global default agent
+amux config set --global default_agent claude
+
+# Set the runtime globally (docker or container)
+amux config set --global runtime docker
+
+# Set the scrollback buffer globally
+amux config set --global terminal_scrollback_lines 20000
+```
+
+**Do not hand-edit the JSON files directly.** Use `amux config set` to ensure merge logic is applied correctly; use `amux config show` to verify effective values.
+
+---
+
+## `amux chat`
+
+Start an interactive agent session in the TUI.
+
+```
+amux chat [FLAGS]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--agent <name>` | string | repo or global default | Agent to use (`claude`, `codex`, `opencode`, `maki`, `gemini`, `copilot`, `crush`, `cline`) |
+| `--plan` | bool | false | Start in plan mode (agent reads the spec before taking action) |
+| `--auto` | bool | false | Auto-approve file edits; still prompts for other tool uses |
+| `--yolo` | bool | false | Disable all permission prompts; implies a Git worktree for the session |
+| `--worktree` | bool | false | Run the session in a dedicated Git worktree (opt-in; implied by `--yolo`) |
+
+**Examples:**
+
+```sh
+# Interactive session with the repo default agent
+amux chat
+
+# Use codex in auto-approve mode
+amux chat --agent codex --auto
+
+# Full autonomous mode in a worktree (worktree never auto-deleted)
+amux chat --yolo
+```
+
+**TUI keybindings** (amux's own — not tmux):
+
+| Key | Action |
+|-----|--------|
+| `Ctrl+T` | Open new session tab |
+| `Ctrl+A` | Switch between tabs |
+| `Ctrl+D` | Detach from current session |
+| `Ctrl+Y` | Copy selection to clipboard |
+
+---
+
+## `amux exec`
+
+Run a one-shot command without entering the TUI.
+
+### `amux exec prompt`
+
+Submit a single prompt to an agent and return when complete.
+
+```
+amux exec prompt "<prompt>" [FLAGS]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--agent <name>` | string | repo/global default | Agent to use |
+| `--auto` | bool | false | Auto-approve file edits |
+| `--yolo` | bool | false | Disable all permission prompts; implies worktree |
+
+**Examples:**
+
+```sh
+# One-off prompt with the default agent
+amux exec prompt "Explain the build script"
+
+# Non-interactive auto-approve run with a specific agent
+amux exec prompt "Add type hints to lib/utils.py" --agent codex --auto
+```
+
+### `amux exec workflow`
+
+Execute a multi-step workflow file.
+
+```
+amux exec workflow <path> [FLAGS]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--work-item <nnnn>` | string | none | Work item number to inject into template vars (zero-padded) |
+| `--yolo` | bool | false | Disable permission prompts; auto-advances steps after 60-second countdown; implies worktree |
+| `--worktree` | bool | false | Run all steps in a dedicated Git worktree |
+
+**Examples:**
+
+```sh
+# Execute a workflow without a work item
+amux exec workflow ./workflows/refactor.md
+
+# Execute with a work item bound (populates {{work_item_number}} and {{work_item_content}})
+amux exec workflow ./workflows/plan-implement-review.md --work-item 0027 --yolo
+```
+
+**Note:** `--yolo` implies `--worktree` for `exec workflow`. The worktree is never auto-deleted — a merge/discard/keep dialog appears at completion or abort.
+
+---
+
+## `amux new`
+
+Scaffold new project assets interactively.
+
+### `amux new spec`
+
+Create a numbered work-item file in `workItems.dir`.
+
+```
+amux new spec [FLAGS]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--interview` | Guided interview mode; amux prompts for structured fields |
+
+Work items are zero-padded four-digit files (e.g. `0027`). The template comes from `workItems.template` in `aspec/.amux.json`.
+
+### `amux new workflow`
+
+Scaffold a new workflow file.
+
+```
+amux new workflow [FLAGS]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--interview` | Guided interview to generate step structure |
+
+### `amux new skill`
+
+Create a custom skill that can be mounted into agent containers via the `overlays.skills` config key.
+
+```
+amux new skill [FLAGS]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--interview` | Guided interview to define skill parameters |
+
+---
+
+## `amux specs`
+
+Manage work items.
+
+### `amux specs amend <nnnn>`
+
+Open the specified work item for editing.
+
+```
+amux specs amend <nnnn>
+```
+
+---
+
+## `amux status`
+
+Show a dashboard of active agent sessions, running workflows, and headless server state.
+
+```
+amux status [FLAGS]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--watch` | Continuously refresh the dashboard |
+
+**Examples:**
+
+```sh
+amux status
+amux status --watch
+```
+
+---
+
+## `amux workflow`
+
+Validate or preview workflow files without executing them.
+
+### `amux workflow validate`
+
+Parse a workflow file and report any syntax or ordering errors.
+
+```
+amux workflow validate <path>
+```
+
+**Examples:**
+
+```sh
+amux workflow validate ./workflows/plan-implement-review.md
+amux workflow validate ./workflows/refactor.toml
+```
+
+Common errors caught: uppercase field keys, wrong field order in Markdown, unknown `Agent:` values, malformed template variable syntax.
+
+### `amux workflow render`
+
+Render a workflow with template variables substituted, printing the expanded steps to stdout. Useful for previewing what an agent will receive before executing.
+
+```
+amux workflow render <path> [FLAGS]
+```
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--work-item <nnnn>` | string | Work item to inject into template vars |
+
+**Examples:**
+
+```sh
+# Preview the rendered prompts for work item 0027
+amux workflow render ./workflows/plan-implement-review.md --work-item 0027
+```
+
+---
+
+## `amux headless`
+
+Manage the amux headless HTTP server (default port 9876).
+
+### `amux headless start`
+
+Start the REST server. Prints the API key plaintext on first run (stored as SHA-256 hash only — the key is not recoverable after this point).
+
+```
+amux headless start [FLAGS]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--port <n>` | integer | `9876` | Port to listen on |
+
+**Example:**
+
+```sh
+amux headless start
+amux headless start --port 9877
+```
+
+### `amux headless status`
+
+Check whether the headless server is running and print its uptime and active session count.
+
+```
+amux headless status
+```
+
+### `amux headless kill`
+
+Stop the running headless server.
+
+```
+amux headless kill
+```
+
+---
+
+## `amux remote`
+
+CLI client for a running headless server. Prefer `amux remote` over raw curl per the operator tooling-first convention — it carries auth, handles the session header, and formats output.
+
+### `amux remote run`
+
+Submit a subcommand string to the remote server.
+
+```
+amux remote run "<cmd>" [FLAGS]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--follow` | Stream command logs to stdout until the command completes |
+
+**Examples:**
+
+```sh
+# Submit a prompt non-interactively and return immediately
+amux remote run "exec prompt 'Fix the failing tests'"
+
+# Submit and stream output until complete
+amux remote run "exec prompt 'Add docstrings to lib/' --auto" --follow
+```
+
+### `amux remote session start`
+
+Create a new session on the remote server in the given working directory. The directory must be in `headless.workDirs`.
+
+```
+amux remote session start <dir>
+```
+
+**Example:**
+
+```sh
+amux remote session start /home/user/my-project
+```
+
+### `amux remote session kill`
+
+Close a session on the remote server.
+
+```
+amux remote session kill <id>
+```
+
+---
+
+## `amux tui`
+
+Explicitly open the TUI. Equivalent to running `amux` with no arguments.
+
+```
+amux tui
+```
+
+---
+
+## Common error modes
+
+| Error | Likely cause |
+|-------|-------------|
+| `runtime not found` | Docker or Apple Containers not running; check `docker info` or `container system status` |
+| `workdir not in allowlist` | `headless.workDirs` does not include the requested path; add it via `amux config set --global` |
+| `HTTP 403 on POST /v1/commands` | Session already has a running command; wait for it to complete or poll `/v1/commands/:id` |
+| `parse error: uppercase key` | Workflow file uses uppercase field names (e.g. `PROMPT:` instead of `Prompt:`); lowercase all keys |
+| `field order error` | Markdown workflow has `Prompt:` before `Agent:` or `Model:`; correct order is `Depends-on` → `Agent` → `Model` → `Prompt` |
+| `worktree already exists` | Previous `--yolo` run was aborted; find and resolve or discard the leftover worktree with `git worktree list` / `git worktree remove` |
+| `no agent Dockerfile found` | Run `amux ready --refresh` to build the image after `amux init` or after editing `.amux/Dockerfile.*` |
+
+---
+
+Back to skill: [SKILL.md](../SKILL.md)

--- a/plugins/tools/amux/skills/amux/references/config.md
+++ b/plugins/tools/amux/skills/amux/references/config.md
@@ -1,0 +1,221 @@
+# amux Configuration Reference
+
+Reference for all amux configuration files and keys as of v0.8.0.
+
+Source: https://github.com/prettysmartdev/amux/blob/main/docs/07-configuration.md — accessed 2026-05-16.
+
+**Never hand-edit the JSON files.** Use `amux config set` to write values and `amux config show` to inspect the merged effective configuration.
+
+---
+
+## Table of Contents
+
+- [Two config files at a glance](#two-config-files-at-a-glance)
+- [Per-repo `.amux/` directory vs `aspec/.amux.json`](#per-repo-amux-directory-vs-aspectamuxjson)
+- [Global config: `$HOME/.amux/config.json`](#global-config-homeamuxconfigjson)
+- [Per-repo config: `$GITROOT/aspec/.amux.json`](#per-repo-config-gitrootaspectamuxjson)
+- [Precedence and merge behavior](#precedence-and-merge-behavior)
+- [Full key reference](#full-key-reference)
+- [Example files](#example-files)
+
+---
+
+## Two config files at a glance
+
+| | Global | Per-repo |
+|-|--------|----------|
+| **Path** | `$HOME/.amux/config.json` | `$GITROOT/aspec/.amux.json` |
+| **Created by** | manually / `amux config set --global` | `amux init` |
+| **Commit to source control?** | No | Yes |
+| **Wins on conflict?** | No | Yes — per-repo takes precedence |
+| **Scope** | All amux projects on this machine | This Git repository only |
+
+---
+
+## Per-repo `.amux/` directory vs `aspec/.amux.json`
+
+This is the most common source of confusion when working with amux.
+
+**`$GITROOT/aspec/.amux.json`** — the canonical per-repo configuration file.
+- Created by `amux init`.
+- Commit this file to source control so all contributors share the same agent, workItems, and overlay settings.
+- This is what `amux config show` reads when resolving per-repo config.
+- Read and written by `amux config get` and `amux config set` (without `--global`).
+
+**`$GITROOT/.amux/`** — a directory of per-agent Dockerfiles and a local-only config file.
+- Also populated by `amux init`, seeded from upstream Dockerfile templates.
+- Contains: `Dockerfile.claude`, `Dockerfile.codex`, `Dockerfile.copilot`, `Dockerfile.crush`, `Dockerfile.gemini`, `Dockerfile.maki`, `Dockerfile.opencode`.
+- Also contains `.amux/config.json` — a **local-only** override layer that is NOT the canonical per-repo config. Do not commit this file.
+- The Dockerfiles are safe to commit and customize (they define the container your agent runs in). The `.amux/config.json` inside this directory is a local overlay that overrides `aspec/.amux.json` for your machine only.
+
+**In practice:** if you have two JSON files and are unsure which one amux is reading, run `amux config show`. It displays the merged effective config and the source that contributed each key.
+
+| File | Commit? | Purpose |
+|------|---------|---------|
+| `aspec/.amux.json` | Yes | Canonical per-repo config — shared with all contributors |
+| `.amux/config.json` | No | Local per-machine overrides (add to `.gitignore`) |
+| `.amux/Dockerfile.*` | Yes | Per-agent container definitions |
+
+---
+
+## Global config: `$HOME/.amux/config.json`
+
+Applies to all amux projects on this machine. Written by `amux config set --global`.
+
+### Key reference
+
+| Key | Type | Default | Scope note |
+|-----|------|---------|-----------|
+| `default_agent` | string | `"claude"` | Global only. Per-repo `agent` key overrides this for a specific project. |
+| `runtime` | string | `"docker"` | Global only. Accepts `"docker"` or `"container"` (Apple Containers on macOS 26+). Cannot be set per-repo. |
+| `terminal_scrollback_lines` | integer | `10000` | Both scopes. Per-repo value overrides global if set. |
+| `yoloDisallowedTools` | array of strings | `[]` | Both scopes. Tools that `--yolo` mode is not allowed to invoke without confirmation (merged additively across scopes — amux v0.8.0 docs do not confirm additive vs replace; verify with `amux config show` after setting). |
+| `envPassthrough` | array of strings | `[]` | Both scopes. Environment variable names passed into the agent container from the host (merged additively). |
+| `overlays.skills` | boolean | `false` | Both scopes (additive). When `true`, mounts custom skills (created via `amux new skill`) into the agent container. |
+| `overlays.directories` | array of objects | `[]` | Both scopes (additive). Additional host directories to mount read-only (or read-write) into the container. |
+| `headless.workDirs` | array of strings | `[]` | Global only. Absolute paths the headless server is allowed to create sessions in. |
+| `headless.alwaysNonInteractive` | boolean | `false` | Global only. Forces all commands submitted via the headless API to run non-interactively. |
+| `remote.defaultAddr` | string | unset | Global only. Default `host:port` for `amux remote` commands. |
+| `remote.defaultAPIKey` | string | unset | Global only. Default API key for `amux remote` commands. |
+| `remote.savedDirs` | array of strings | `[]` | Global only. Directories saved by `amux remote session start` for quick reuse. |
+
+Source: https://github.com/prettysmartdev/amux/blob/main/docs/07-configuration.md (section: global config keys)
+
+### `overlays.directories` object shape
+
+Each entry in the array is a JSON object:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `host` | string | Absolute path on the host machine (tilde expansion supported) |
+| `container` | string | Absolute path inside the container where the directory is mounted |
+| `permission` | string | `"ro"` (read-only) or `"rw"` (read-write) |
+
+---
+
+## Per-repo config: `$GITROOT/aspec/.amux.json`
+
+Applies to one Git repository. Created by `amux init`; read by `amux config get` / `amux config show`. Commit this file.
+
+### Key reference
+
+| Key | Type | Default | Scope note |
+|-----|------|---------|-----------|
+| `agent` | string | (falls back to `default_agent`) | Per-repo only. Sets the default agent for all sessions and workflow steps in this repository. |
+| `terminal_scrollback_lines` | integer | `10000` | Both scopes. Per-repo value overrides global. |
+| `yoloDisallowedTools` | array of strings | `[]` | Both scopes. Tools blocked in `--yolo` mode. |
+| `envPassthrough` | array of strings | `[]` | Both scopes. Env vars forwarded into the container. |
+| `overlays.skills` | boolean | `false` | Both scopes (additive). Enable custom skills mounting. |
+| `overlays.directories` | array of objects | `[]` | Both scopes (additive). Additional host→container directory mounts. |
+| `workItems.dir` | string | unset | Per-repo only. Directory (relative to Git root) where `amux new spec` writes work item files. |
+| `workItems.template` | string | unset | Per-repo only. Path to a work item template file used by `amux new spec`. |
+
+Source: https://github.com/prettysmartdev/amux/blob/main/docs/07-configuration.md (section: per-repo config keys)
+
+---
+
+## Precedence and merge behavior
+
+When the same key appears in both config files:
+
+- **Per-repo wins** on scalar keys (`agent`, `runtime`, `terminal_scrollback_lines`, `headless.*`, etc.).
+- **Additive merge** for `overlays.skills` and `overlays.directories`: both files contribute their entries; neither replaces the other.
+- `yoloDisallowedTools` and `envPassthrough` — the research report does not explicitly confirm additive vs replace behavior for these array keys. Run `amux config show` after setting both scopes to verify the effective merged value before relying on it.
+
+`amux config show` always reflects the merged effective state. Read its output, not the raw files.
+
+---
+
+## Full key reference
+
+Consolidated table of all documented keys across both scopes.
+
+| Key | Type | Default | Global? | Per-repo? | Merge |
+|-----|------|---------|---------|-----------|-------|
+| `default_agent` | string | `"claude"` | Yes | No | N/A |
+| `runtime` | string | `"docker"` | Yes | No | N/A |
+| `terminal_scrollback_lines` | integer | `10000` | Yes | Yes | Per-repo overrides global |
+| `yoloDisallowedTools` | array | `[]` | Yes | Yes | Verify with `config show` |
+| `envPassthrough` | array | `[]` | Yes | Yes | Verify with `config show` |
+| `overlays.skills` | boolean | `false` | Yes | Yes | Additive (either `true` enables) |
+| `overlays.directories` | array | `[]` | Yes | Yes | Additive (both contribute entries) |
+| `headless.workDirs` | array | `[]` | Yes | No | N/A |
+| `headless.alwaysNonInteractive` | boolean | `false` | Yes | No | N/A |
+| `remote.defaultAddr` | string | unset | Yes | No | N/A |
+| `remote.defaultAPIKey` | string | unset | Yes | No | N/A |
+| `remote.savedDirs` | array | `[]` | Yes | No | N/A |
+| `agent` | string | (default_agent) | No | Yes | N/A |
+| `workItems.dir` | string | unset | No | Yes | N/A |
+| `workItems.template` | string | unset | No | Yes | N/A |
+
+Source for all keys: https://github.com/prettysmartdev/amux/blob/main/docs/07-configuration.md — accessed 2026-05-16.
+
+---
+
+## Example files
+
+### Global config example
+
+Source: verbatim from amux docs, accessed 2026-05-16.
+
+```json
+{
+  "default_agent": "claude",
+  "terminal_scrollback_lines": 10000,
+  "runtime": "docker",
+  "yoloDisallowedTools": ["Bash"],
+  "envPassthrough": ["ANTHROPIC_API_KEY"],
+  "overlays": {
+    "skills": true,
+    "directories": [
+      { "host": "~/personal-prompts", "container": "/mnt/prompts", "permission": "ro" }
+    ]
+  }
+}
+```
+
+### Per-repo config example
+
+Source: verbatim from amux docs, accessed 2026-05-16.
+
+```json
+{
+  "agent": "claude",
+  "terminal_scrollback_lines": 10000,
+  "yoloDisallowedTools": ["Bash", "computer"],
+  "envPassthrough": ["ANTHROPIC_API_KEY"],
+  "overlays": {
+    "skills": true,
+    "directories": [
+      { "host": "/data/fixtures", "container": "/mnt/fixtures", "permission": "ro" }
+    ]
+  },
+  "workItems": {
+    "dir": "docs/work-items",
+    "template": "docs/work-items/0000-template.md"
+  }
+}
+```
+
+### Setting config values via CLI
+
+```sh
+# Set the per-repo default agent
+amux config set agent codex
+
+# Set the global runtime to Apple Containers (macOS 26+ only)
+amux config set --global runtime container
+
+# Add an allowlisted workdir for the headless server
+amux config set --global headless.workDirs /home/user/my-project
+
+# Enable skills overlay per-repo
+amux config set overlays.skills true
+
+# Verify merged effective config
+amux config show
+```
+
+---
+
+Back to skill: [SKILL.md](../SKILL.md)

--- a/plugins/tools/amux/skills/amux/references/headless-api.md
+++ b/plugins/tools/amux/skills/amux/references/headless-api.md
@@ -1,0 +1,339 @@
+# amux Headless REST API
+
+Reference for the amux headless HTTP server REST API as of v0.8.0.
+
+Source: https://github.com/prettysmartdev/amux/blob/main/docs/08-headless-mode.md — accessed 2026-05-16.
+Remote-mode CLI docs: https://github.com/prettysmartdev/amux/blob/main/docs/09-remote-mode.md — accessed 2026-05-16.
+
+**Prefer `amux remote` over raw curl** when driving the server from a shell. The `amux remote` CLI carries auth, sets the session header, and formats output — raw curl is appropriate only when integrating from external systems or scripts that cannot invoke amux.
+
+---
+
+## Server lifecycle
+
+Start the server (prints the API key on first run — save it; it is not recoverable):
+
+```sh
+amux headless start                # default port 9876
+amux headless start --port 9877   # custom port
+```
+
+Check status:
+
+```sh
+amux headless status
+```
+
+Stop the server:
+
+```sh
+amux headless kill
+```
+
+---
+
+## Authentication
+
+All endpoints except `/v1/status` require an `Authorization` header.
+
+**Accepted forms:**
+
+```
+Authorization: Bearer <api-key>
+Authorization: <api-key>
+```
+
+The API key is generated as 32 random bytes on the first `amux headless start`. The server stores only its SHA-256 hash and prints the plaintext key once at startup. If the key is lost, delete `$HOME/.amux/headless/` to regenerate (this also destroys all session state).
+
+---
+
+## Allowlisted working directories
+
+Sessions can only be created in directories listed in the `headless.workDirs` global config key. Attempting to create a session in any other directory returns HTTP 403.
+
+Add a directory:
+
+```sh
+amux config set --global headless.workDirs /home/user/my-project
+```
+
+List currently allowlisted directories:
+
+```sh
+curl http://localhost:9876/v1/workdirs \
+  -H 'Authorization: Bearer <api-key>'
+```
+
+---
+
+## One-command-per-session contract
+
+A session accepts exactly one running command at a time. Submitting a `POST /v1/commands` while the session already has a running command returns **HTTP 403**. Poll `GET /v1/commands/:id` until `status` is `completed` or `failed` before submitting the next command.
+
+---
+
+## Endpoint table
+
+| Method | Path | Auth required | Purpose |
+|--------|------|--------------|---------|
+| `GET` | `/v1/status` | No | Server health: uptime, active session count, running command count |
+| `GET` | `/v1/workdirs` | Yes | List allowlisted working directories |
+| `POST` | `/v1/sessions` | Yes | Create a session in an allowlisted workdir |
+| `GET` | `/v1/sessions` | Yes | List sessions; supports `?status=active` query param |
+| `GET` | `/v1/sessions/:id` | Yes | Get session details |
+| `DELETE` | `/v1/sessions/:id` | Yes | Close a session |
+| `POST` | `/v1/commands` | Yes | Submit a subcommand to a session (requires `x-amux-session: <id>` header) |
+| `GET` | `/v1/commands/:id` | Yes | Command status and metadata |
+| `GET` | `/v1/commands/:id/logs` | Yes | Full captured output (buffered) |
+| `GET` | `/v1/commands/:id/logs/stream` | Yes | Live output via Server-Sent Events |
+| `GET` | `/v1/workflows/:id` | Yes | Workflow state for a workflow-type command |
+
+---
+
+## Request and response schemas
+
+### `POST /v1/sessions`
+
+**Request body:**
+
+```json
+{
+  "workdir": "/absolute/path/to/project"
+}
+```
+
+`workdir` must be in `headless.workDirs`. Returns HTTP 403 if not.
+
+**Response (201 Created):**
+
+```json
+{
+  "id": "<session-id>",
+  "workdir": "/absolute/path/to/project",
+  "status": "active",
+  "created_at": "<ISO-8601 timestamp>"
+}
+```
+
+---
+
+### `GET /v1/sessions`
+
+**Query parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `status` | string | Filter by status; `active` is the documented value |
+
+**Response (200 OK):**
+
+```json
+[
+  {
+    "id": "<session-id>",
+    "workdir": "/absolute/path/to/project",
+    "status": "active",
+    "created_at": "<ISO-8601 timestamp>"
+  }
+]
+```
+
+---
+
+### `GET /v1/sessions/:id`
+
+**Response (200 OK):** same shape as a single session object from the list endpoint.
+
+---
+
+### `DELETE /v1/sessions/:id`
+
+No request body. Returns 204 No Content on success.
+
+---
+
+### `POST /v1/commands`
+
+**Required header:** `x-amux-session: <session-id>`
+
+**Request body:**
+
+```json
+{
+  "subcommand": "exec",
+  "args": ["prompt", "<prompt text>", "--non-interactive"]
+}
+```
+
+The `subcommand` field identifies the amux subcommand to run (`exec`, `chat`, etc.). The `args` array passes positional arguments and flags to that subcommand, matching the CLI surface documented in `command-reference.md`.
+
+Returns HTTP 403 immediately if the session already has a running command (one-command-per-session contract).
+
+**Response (202 Accepted):**
+
+```json
+{
+  "id": "<command-id>",
+  "session_id": "<session-id>",
+  "status": "running",
+  "created_at": "<ISO-8601 timestamp>"
+}
+```
+
+---
+
+### `GET /v1/commands/:id`
+
+**Response (200 OK):**
+
+```json
+{
+  "id": "<command-id>",
+  "session_id": "<session-id>",
+  "status": "running | completed | failed",
+  "created_at": "<ISO-8601 timestamp>",
+  "completed_at": "<ISO-8601 timestamp | null>",
+  "exit_code": "<integer | null>"
+}
+```
+
+Poll this endpoint until `status` is `completed` or `failed` before submitting the next command to the session.
+
+---
+
+### `GET /v1/commands/:id/logs`
+
+**Response (200 OK):** plain text body containing the full buffered output of the command. Also written to disk at:
+
+```
+~/.amux/headless/sessions/<session-id>/commands/<command-id>/output.log
+```
+
+---
+
+### `GET /v1/commands/:id/logs/stream`
+
+Server-Sent Events stream. Connect and receive newline-delimited events while the command is running.
+
+**Response headers:**
+
+```
+Content-Type: text/event-stream
+Cache-Control: no-cache
+```
+
+**SSE event format:**
+
+```
+data: <line of output>\n\n
+```
+
+Each `data:` line is one line of output from the agent process. The stream closes when the command completes or fails.
+
+---
+
+### `GET /v1/workflows/:id`
+
+`id` is the command ID of a workflow-type command (i.e. one submitted via `amux exec workflow`).
+
+**Response (200 OK):**
+
+```json
+{
+  "command_id": "<command-id>",
+  "steps": [
+    {
+      "name": "<step-name>",
+      "status": "pending | running | completed | failed",
+      "agent": "<agent-name>",
+      "started_at": "<ISO-8601 timestamp | null>",
+      "completed_at": "<ISO-8601 timestamp | null>"
+    }
+  ]
+}
+```
+
+---
+
+### `GET /v1/status`
+
+No auth required. Returns server health.
+
+**Response (200 OK):**
+
+```json
+{
+  "uptime_seconds": 3600,
+  "active_sessions": 2,
+  "running_commands": 1
+}
+```
+
+---
+
+## Wired curl examples: create session → submit command → stream logs
+
+The three commands below form a complete workflow. Run them in sequence; each uses the output of the previous step.
+
+**Step 1: Create a session**
+
+```sh
+SESSION=$(curl -s -X POST http://localhost:9876/v1/sessions \
+  -H 'Authorization: Bearer <api-key>' \
+  -H 'Content-Type: application/json' \
+  -d '{"workdir":"/home/user/my-project"}' \
+  | jq -r '.id')
+
+echo "Session: $SESSION"
+```
+
+**Step 2: Submit a command**
+
+```sh
+COMMAND=$(curl -s -X POST http://localhost:9876/v1/commands \
+  -H 'Authorization: Bearer <api-key>' \
+  -H "x-amux-session: $SESSION" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "subcommand": "exec",
+    "args": ["prompt", "Fix the failing tests", "--non-interactive"]
+  }' \
+  | jq -r '.id')
+
+echo "Command: $COMMAND"
+```
+
+**Step 3: Stream logs until completion**
+
+```sh
+curl -N http://localhost:9876/v1/commands/$COMMAND/logs/stream \
+  -H 'Authorization: Bearer <api-key>'
+```
+
+After the stream closes, verify the final status:
+
+```sh
+curl -s http://localhost:9876/v1/commands/$COMMAND \
+  -H 'Authorization: Bearer <api-key>' \
+  | jq '{status, exit_code}'
+```
+
+---
+
+## Using `amux remote` instead of curl
+
+The same three-step sequence using `amux remote` (requires `remote.defaultAddr` and `remote.defaultAPIKey` in global config, or `AMUX_*` env vars):
+
+```sh
+# Create a session
+amux remote session start /home/user/my-project
+
+# Submit a command and stream output
+amux remote run "exec prompt 'Fix the failing tests'" --follow
+```
+
+`amux remote` automatically resolves the session created for that directory and handles the `x-amux-session` header.
+
+---
+
+Back to skill: [SKILL.md](../SKILL.md)

--- a/plugins/tools/amux/skills/amux/references/workflows.md
+++ b/plugins/tools/amux/skills/amux/references/workflows.md
@@ -1,0 +1,296 @@
+# amux Workflow Authoring
+
+Reference for authoring amux workflow files in all three supported syntaxes: Markdown, TOML, and YAML.
+
+Source: https://github.com/prettysmartdev/amux/blob/main/docs/04-workflows.md — accessed 2026-05-16.
+Run `amux workflow validate <path>` to catch parse errors before executing. Run `amux workflow render <path> --work-item <nnnn>` to preview substituted output.
+
+---
+
+## Critical rules (read first)
+
+1. **Lowercase keys only.** Uppercase field names are a parse error in all three formats. Write `prompt:`, `agent:`, `depends-on:` — never `PROMPT:`, `Agent:` (in TOML/YAML), `Depends-On:`.
+2. **Markdown field order is strict.** Within a step, fields must appear in this sequence:
+   ```
+   Depends-on: (optional)
+   Agent: (optional)
+   Model: (optional)
+   Prompt: (required — everything after this line is prompt text)
+   ```
+   Any text following the `Prompt:` line, including blank lines and other field-looking lines, is treated as prompt content. Do not place `Agent:` or `Model:` after `Prompt:`.
+3. **`Prompt:` ends the header.** Once `amux` encounters the `Prompt:` key in a Markdown step, all remaining text in that step block is the prompt body.
+4. **Step names come from Markdown headings.** Use `## Step: <name>` to name a step. The name is used in `Depends-on:` references.
+5. **Template variables** are case-sensitive: `{{work_item_number}}`, `{{work_item_content}}`, `{{work_item_section:[Name]}}`.
+
+---
+
+## Template variables
+
+Template variables are substituted at workflow execution time, not at parse time. They require `--work-item <nnnn>` to be passed to `amux exec workflow`.
+
+| Variable | Substituted with |
+|----------|-----------------|
+| `{{work_item_number}}` | Zero-padded 4-digit work item number (e.g. `0027`) |
+| `{{work_item_content}}` | Full text of the work item file at `workItems.dir/<nnnn>` |
+| `{{work_item_section:[Name]}}` | Text of the named section within the work item (case-insensitive match) |
+
+**Example section extraction:**
+
+If the work item contains:
+```markdown
+## Acceptance Criteria
+- Tests pass
+- No regressions
+```
+
+Then `{{work_item_section:[Acceptance Criteria]}}` renders to the text of that section.
+
+If `--work-item` is not passed, template variables render as empty strings (not as an error). Preview before running: `amux workflow render ./workflow.md --work-item 0027`.
+
+---
+
+## Markdown format
+
+### Grammar
+
+A Markdown workflow file is a sequence of step blocks. Each block starts with a level-2 heading:
+
+```
+## Step: <step-name>
+```
+
+Followed by optional fields and then the prompt body:
+
+```
+[Depends-on: <step-name>[, <step-name>]]
+[Agent: <agent-name>]
+[Model: <model-id>]
+Prompt: <first line of prompt (may be blank)>
+<prompt body — all remaining lines in this step block>
+```
+
+**Field rules:**
+- `Depends-on:` — comma-separated list of step names this step waits for. Omit for the first step.
+- `Agent:` — one of `claude`, `codex`, `opencode`, `maki`, `gemini`, `copilot`, `crush`, `cline`. Overrides `--agent` and per-repo `agent` for this step only.
+- `Model:` — model string passed to the agent CLI (e.g. `claude-haiku-4-5`, `gpt-4o`). Requires agent support.
+- `Prompt:` — required. Everything after the colon on this line AND all subsequent lines until the next `## Step:` heading is prompt text.
+
+### Key ordering rule
+
+```
+Depends-on (optional)
+Agent (optional)
+Model (optional)
+Prompt (required — must be last field)
+```
+
+### Complete Markdown example
+
+```markdown
+## Step: plan
+Prompt: Read the following work item and produce a detailed implementation plan.
+Include file paths, function names, and acceptance criteria.
+
+{{work_item_content}}
+
+## Step: implement
+Depends-on: plan
+Agent: codex
+Model: claude-haiku-4-5
+Prompt: Implement work item {{work_item_number}} according to the plan produced in the previous step.
+Run the test suite after each significant change.
+
+## Step: review
+Depends-on: implement
+Agent: claude
+Prompt: Review the implementation against the acceptance criteria in:
+
+{{work_item_section:[Acceptance Criteria]}}
+
+Report any gaps or regressions.
+```
+
+### Common Markdown errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `parse error: uppercase key` | `Agent:` used in a position amux doesn't expect, or `PROMPT:` | Use lowercase: `agent:` in TOML/YAML, `Agent:` (initial cap only) in Markdown headers |
+| `field after Prompt:` | `Agent:` placed after `Prompt:` | Move `Agent:` above `Prompt:` |
+| Step dependency not found | Typo in `Depends-on:` value | Match exactly the string after `## Step:` |
+
+---
+
+## TOML format
+
+### Grammar
+
+A TOML workflow is an array of step tables.
+
+```toml
+[[steps]]
+name = "<step-name>"
+prompt = """
+<prompt body>
+"""
+
+[[steps]]
+name = "<step-name>"
+depends_on = ["<step-name>"]   # array of step names
+agent = "<agent-name>"          # optional
+model = "<model-id>"            # optional
+prompt = """
+<prompt body>
+"""
+```
+
+**Key rules:**
+- All keys lowercase: `name`, `prompt`, `depends_on`, `agent`, `model`.
+- `depends_on` is an array (even for a single dependency).
+- Multi-line prompts use TOML triple-quoted strings (`"""`).
+- Template variables work inside prompt strings.
+
+### Complete TOML example
+
+```toml
+[[steps]]
+name = "plan"
+prompt = """
+Read the following work item and produce a detailed implementation plan.
+Include file paths, function names, and acceptance criteria.
+
+{{work_item_content}}
+"""
+
+[[steps]]
+name = "implement"
+depends_on = ["plan"]
+agent = "codex"
+model = "claude-haiku-4-5"
+prompt = """
+Implement work item {{work_item_number}} according to the plan from the previous step.
+Run the test suite after each significant change.
+"""
+
+[[steps]]
+name = "review"
+depends_on = ["implement"]
+agent = "claude"
+prompt = """
+Review the implementation against the acceptance criteria in:
+
+{{work_item_section:[Acceptance Criteria]}}
+
+Report any gaps or regressions.
+"""
+```
+
+### Common TOML errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `depends_on` not an array | Written as a string: `depends_on = "plan"` | Use array syntax: `depends_on = ["plan"]` |
+| Template var not substituted | `--work-item` flag not passed to `amux exec workflow` | Add `--work-item <nnnn>` |
+| Uppercase key rejected | `Name = "plan"` | Use `name = "plan"` |
+
+---
+
+## YAML format
+
+### Grammar
+
+A YAML workflow is a `steps` list at the top level.
+
+```yaml
+steps:
+  - name: <step-name>
+    prompt: |
+      <prompt body>
+
+  - name: <step-name>
+    depends_on:
+      - <step-name>
+    agent: <agent-name>       # optional
+    model: <model-id>         # optional
+    prompt: |
+      <prompt body>
+```
+
+**Key rules:**
+- All keys lowercase: `steps`, `name`, `prompt`, `depends_on`, `agent`, `model`.
+- `depends_on` is a YAML sequence.
+- Use YAML block scalars (`|`) for multi-line prompts.
+- Template variables work inside prompt scalars.
+
+### Complete YAML example
+
+```yaml
+steps:
+  - name: plan
+    prompt: |
+      Read the following work item and produce a detailed implementation plan.
+      Include file paths, function names, and acceptance criteria.
+
+      {{work_item_content}}
+
+  - name: implement
+    depends_on:
+      - plan
+    agent: codex
+    model: claude-haiku-4-5
+    prompt: |
+      Implement work item {{work_item_number}} according to the plan from the previous step.
+      Run the test suite after each significant change.
+
+  - name: review
+    depends_on:
+      - implement
+    agent: claude
+    prompt: |
+      Review the implementation against the acceptance criteria in:
+
+      {{work_item_section:[Acceptance Criteria]}}
+
+      Report any gaps or regressions.
+```
+
+### Common YAML errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Indentation parse error | Inconsistent spaces | Use 2-space indentation throughout |
+| `depends_on` not a list | Written as a scalar: `depends_on: plan` | Use YAML sequence syntax |
+| Template variable literal in output | Var name typo or no `--work-item` passed | Check spelling; add `--work-item <nnnn>` |
+
+---
+
+## Choosing a format
+
+| Format | When to use |
+|--------|-------------|
+| Markdown | Human-readable step descriptions; prompts that include prose, lists, or embedded work item content |
+| TOML | Machine-generated workflows; strict schema enforcement; structured data alongside prompts |
+| YAML | Teams that already use YAML tooling; shorter syntax for simple step sequences |
+
+All three formats support identical features. Choose based on your team's tooling preferences. Validate any format with `amux workflow validate <path>` before the first execution.
+
+---
+
+## Executing workflows
+
+```sh
+# Validate before running
+amux workflow validate ./workflows/plan-implement-review.md
+
+# Preview with substitution
+amux workflow render ./workflows/plan-implement-review.md --work-item 0027
+
+# Execute (asks for permission on each tool use)
+amux exec workflow ./workflows/plan-implement-review.md --work-item 0027
+
+# Execute autonomously in a worktree (60-second countdown between steps)
+amux exec workflow ./workflows/plan-implement-review.md --work-item 0027 --yolo
+```
+
+---
+
+Back to skill: [SKILL.md](../SKILL.md)

--- a/plugins/tools/amux/skills/amux/templates/0.8.0/commands.md
+++ b/plugins/tools/amux/skills/amux/templates/0.8.0/commands.md
@@ -1,0 +1,403 @@
+# amux v0.8.0 — Command Reference
+
+Pinned to amux v0.8.0 (released 2026-04-12, accessed 2026-05-16).
+Newer versions get their own `templates/X.Y.Z/commands.md` per the `/claude-code:skill-update` convention.
+
+Source: https://github.com/prettysmartdev/amux (README + docs/, accessed 2026-05-16)
+
+---
+
+## What's in v0.8.0
+
+Internal refactor into a strict four-layer architecture (data → engine → command → frontend). CLI surfaces, config files, and persisted state are **unchanged from v0.7.x** — no migration required. New feature: `overlays.skills` config key for mounting custom skill directories into agent containers.
+
+---
+
+## `amux` (no args)
+
+Open the TUI.
+
+| TUI Keybinding | Action |
+|----------------|--------|
+| `Ctrl+T` | New tab / new session |
+| `Ctrl+A` | Switch between sessions |
+| `Ctrl+D` | Detach from current session |
+| `Ctrl+Y` | Copy selected text to clipboard |
+
+Scrollback: 10,000 lines by default (configurable via `terminal_scrollback_lines`).
+
+---
+
+## `amux init`
+
+Scaffold a project for amux use.
+
+```sh
+amux init [--agent <name>]
+```
+
+Creates:
+- `aspec/.amux.json` — per-repo config (commit this)
+- `.amux/Dockerfile.<agent>` — per-agent Dockerfiles (one per supported agent)
+- `.amux/config.json` — local-only overlay (do not commit)
+
+**Example:**
+```sh
+amux init --agent claude
+```
+
+---
+
+## `amux ready`
+
+Verify environment and optionally rebuild agent Dockerfiles.
+
+```sh
+amux ready [--refresh]
+```
+
+`--refresh` — Rebuild the agent container image. Run after editing `.amux/Dockerfile.<agent>` or after an amux version upgrade that changes base image requirements.
+
+**Example:**
+```sh
+amux ready --refresh
+```
+
+---
+
+## `amux chat`
+
+Start an interactive agent session inside the TUI.
+
+```sh
+amux chat [--agent <name>] [--plan] [--auto] [--yolo]
+```
+
+| Flag | Effect |
+|------|--------|
+| `--agent <name>` | Override the per-repo / global default agent |
+| `--plan` | Agent operates in planning mode |
+| `--auto` | Auto-approve file edits; still prompts for other tools |
+| `--yolo` | Disable all permission prompts; run in a Git worktree |
+
+**Examples:**
+```sh
+# Default agent, interactive
+amux chat
+
+# Override agent for this session
+amux chat --agent codex
+
+# Fully autonomous, worktree-isolated
+amux chat --yolo
+```
+
+---
+
+## `amux exec`
+
+One-off execution without a persistent TUI session.
+
+### `amux exec prompt`
+
+```sh
+amux exec prompt "<prompt-text>" [--agent <name>] [--non-interactive]
+```
+
+**Example:**
+```sh
+amux exec prompt "Explain the build script"
+amux exec prompt "Fix the failing tests" --agent codex --non-interactive
+```
+
+### `amux exec workflow`
+
+```sh
+amux exec workflow <path> [--work-item <nnnn>] [--yolo] [--worktree] [--agent <name>]
+```
+
+| Flag | Effect |
+|------|--------|
+| `--work-item <nnnn>` | Zero-padded work item number; injects `{{work_item_number}}` and `{{work_item_content}}` |
+| `--yolo` | Disable prompts; implicit `--worktree` |
+| `--worktree` | Run workflow steps in a Git worktree |
+| `--agent <name>` | Default agent for steps that don't specify one |
+
+**Example:**
+```sh
+amux exec workflow ./workflows/plan-implement-review.md --work-item 0027 --yolo
+```
+
+---
+
+## `amux new`
+
+Scaffold new project artifacts.
+
+```sh
+amux new spec [--interview]       # Create numbered work item (e.g. 0028)
+amux new workflow [--interview]   # Scaffold a workflow file
+amux new skill [--interview]      # Create a custom skill for the skills overlay
+```
+
+`--interview` — Interactive prompting mode for guided creation.
+
+**Examples:**
+```sh
+amux new spec --interview
+amux new workflow
+```
+
+---
+
+## `amux specs`
+
+Manage work item files.
+
+```sh
+amux specs amend <nnnn>   # Update spec file <nnnn>
+```
+
+**Example:**
+```sh
+amux specs amend 0027
+```
+
+---
+
+## `amux status`
+
+Show a dashboard of active sessions and workflow runs.
+
+```sh
+amux status [--watch]
+```
+
+`--watch` — Continuously refresh the dashboard.
+
+**Example:**
+```sh
+amux status --watch
+```
+
+---
+
+## `amux config`
+
+Read and write amux configuration.
+
+```sh
+amux config show                              # Merged effective config (global + per-repo)
+amux config get <field>                       # Show one field with precedence breakdown
+amux config set [--global] <field> <value>   # Write a config key
+```
+
+`--global` on `set` — Write to `~/.amux/config.json`. Without the flag, writes to the per-repo `aspec/.amux.json`.
+
+**Examples:**
+```sh
+amux config show
+amux config get default_agent
+amux config set --global default_agent codex
+amux config set agent claude
+```
+
+---
+
+## `amux headless`
+
+Manage the embedded REST server.
+
+```sh
+amux headless start [--port <n>]   # Start server (default: 9876)
+amux headless status               # Check server state
+amux headless kill                 # Stop server
+```
+
+**Examples:**
+```sh
+amux headless start
+amux headless start --port 9000
+amux headless status
+amux headless kill
+```
+
+---
+
+## `amux remote`
+
+CLI client for a running headless server. Wraps the REST API.
+
+```sh
+amux remote run <cmd> [--follow]         # Submit a subcommand; --follow streams output
+amux remote session start <dir>          # Create a headless session for <dir>
+amux remote session kill <id>            # Close a headless session
+```
+
+**Examples:**
+```sh
+# Run a prompt against the headless server and stream output
+amux remote run "exec prompt 'Fix the failing tests'" --follow
+
+# Create a session
+amux remote session start /home/user/my-project
+
+# Close a session
+amux remote session kill <session-id>
+```
+
+`amux remote` uses `remote.defaultAddr` and `remote.defaultAPIKey` from `~/.amux/config.json`. Override with `--addr` and `--api-key` flags when targeting a non-default server.
+
+---
+
+## `amux tui`
+
+Explicit alias to open the TUI (same as running `amux` with no args).
+
+```sh
+amux tui
+```
+
+---
+
+## Agents Supported in v0.8.0
+
+`claude` | `codex` | `opencode` | `maki` | `gemini` | `copilot` | `crush` | `cline`
+
+Each has a corresponding `Dockerfile.<agent>` in `.amux/`. Templates live at https://github.com/prettysmartdev/amux/tree/main/templates.
+
+---
+
+## Workflow File Formats
+
+Three formats supported. Fields are **lowercase only** in all formats.
+
+### Markdown (`.md`)
+
+Field order is mandatory: `Depends-on` → `Agent` → `Model` → `Prompt`. Text after `Prompt:` is treated as prompt content.
+
+```markdown
+## Step: plan
+Prompt: Read the following work item and produce an implementation plan.
+
+{{work_item_content}}
+
+## Step: implement
+Depends-on: plan
+Agent: codex
+Model: claude-haiku-4-5
+Prompt: Implement work item {{work_item_number}} according to the plan.
+```
+
+### TOML (`.toml`)
+
+```toml
+[[steps]]
+name = "plan"
+prompt = "Read the following work item and produce an implementation plan.\n\n{{work_item_content}}"
+
+[[steps]]
+name = "implement"
+depends_on = ["plan"]
+agent = "codex"
+model = "claude-haiku-4-5"
+prompt = "Implement work item {{work_item_number}} according to the plan."
+```
+
+### YAML (`.yml` / `.yaml`)
+
+```yaml
+steps:
+  - name: plan
+    prompt: |
+      Read the following work item and produce an implementation plan.
+      {{work_item_content}}
+  - name: implement
+    depends_on:
+      - plan
+    agent: codex
+    model: claude-haiku-4-5
+    prompt: "Implement work item {{work_item_number}} according to the plan."
+```
+
+### Template Variables
+
+| Variable | Resolves to |
+|----------|-------------|
+| `{{work_item_number}}` | Zero-padded 4-digit spec number (e.g. `0027`) |
+| `{{work_item_content}}` | Full text of the work item file |
+| `{{work_item_section:[Name]}}` | Named section within the work item (case-insensitive) |
+
+---
+
+## Configuration Keys (v0.8.0)
+
+| Key | Type | Default | Scope |
+|-----|------|---------|-------|
+| `default_agent` | string | `"claude"` | Global only |
+| `runtime` | string | `"docker"` | Global only |
+| `headless.workDirs` | array | `[]` | Global only |
+| `headless.alwaysNonInteractive` | boolean | false | Global only |
+| `remote.defaultAddr` | string | unset | Global only |
+| `remote.defaultAPIKey` | string | unset | Global only |
+| `remote.savedDirs` | array | `[]` | Global only |
+| `terminal_scrollback_lines` | integer | 10000 | Both |
+| `yoloDisallowedTools` | array | `[]` | Both |
+| `envPassthrough` | array | `[]` | Both |
+| `overlays.skills` | boolean | false | Both (additive) |
+| `overlays.directories` | array | `[]` | Both (additive) |
+| `agent` | string | `"claude"` | Per-repo only |
+| `workItems.dir` | string | unset | Per-repo only |
+| `workItems.template` | string | unset | Per-repo only |
+
+`overlays.skills` and `overlays.directories` merge additively across scopes (not replaced). All other keys: per-repo wins over global.
+
+---
+
+## Headless REST API (v0.8.0)
+
+Default port: `9876`. Auth: `Authorization: Bearer <api-key>`.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/v1/workdirs` | List allowlisted working directories |
+| `POST` | `/v1/sessions` | Create session (`{"workdir": "..."}`) |
+| `GET` | `/v1/sessions` | List sessions (`?status=active`) |
+| `GET` | `/v1/sessions/:id` | Session details |
+| `DELETE` | `/v1/sessions/:id` | Close session |
+| `POST` | `/v1/commands` | Submit subcommand (`x-amux-session: <id>` header required) |
+| `GET` | `/v1/commands/:id` | Command status |
+| `GET` | `/v1/commands/:id/logs` | Captured output |
+| `GET` | `/v1/commands/:id/logs/stream` | Live output (Server-Sent Events) |
+| `GET` | `/v1/workflows/:id` | Workflow state for a command |
+| `GET` | `/v1/status` | Server health (uptime, sessions, commands) |
+
+One active command per session — second submit returns HTTP 403.
+All commands are async — `POST /v1/commands` returns `command_id` immediately.
+
+**Create session + submit command:**
+```sh
+curl -X POST http://localhost:9876/v1/sessions \
+  -H 'Authorization: Bearer <api-key>' \
+  -H 'Content-Type: application/json' \
+  -d '{"workdir":"/home/user/my-project"}'
+
+curl -X POST http://localhost:9876/v1/commands \
+  -H 'Authorization: Bearer <api-key>' \
+  -H 'x-amux-session: <session-id>' \
+  -H 'Content-Type: application/json' \
+  -d '{"subcommand":"exec","args":["prompt","Fix the failing tests","--non-interactive"]}'
+```
+
+---
+
+## Known Sharp Edges in v0.8.0
+
+1. Not a tmux wrapper — ships its own TUI.
+2. Two config files: `aspec/.amux.json` (commit) vs `.amux/config.json` (local). Use `amux config show`.
+3. Worktrees are never auto-deleted.
+4. One active command per headless session.
+5. `runtime` is global-only — no per-repo docker vs Apple Containers selection.
+6. Markdown workflow field order is mandatory.
+7. Lowercase keys only in workflow files.
+8. No MCP server, no hooks in this version.

--- a/plugins/tools/amux/skills/amux/templates/0.8.0/mise.toml
+++ b/plugins/tools/amux/skills/amux/templates/0.8.0/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+"github:prettysmartdev/amux" = "0.8.0"

--- a/plugins/tools/amux/skills/sources.md
+++ b/plugins/tools/amux/skills/sources.md
@@ -1,0 +1,74 @@
+# amux Plugin Sources
+
+This file documents the sources used to create the amux plugin skill.
+
+## amux Skill
+
+### amux Repository
+- **URL**: https://github.com/prettysmartdev/amux
+- **Purpose**: Primary source for amux overview, tagline, feature list, supported agents, install methods, and runtime requirements
+- **Date Accessed**: 2026-05-16
+- **Key Topics**: CLI/TUI overview, parallel agent sessions, container isolation, worktree model, agent list (claude, codex, opencode, maki, gemini, copilot, crush, cline), license (Apache-2.0)
+
+### amux README
+- **URL**: https://github.com/prettysmartdev/amux/blob/main/README.md
+- **Purpose**: Top-level reference for tagline, command summary table, install instructions, and representative examples
+- **Date Accessed**: 2026-05-16
+- **Key Topics**: Tagline verbatim ("Run and coordinate AI code agents from your terminal. Parallel sessions, multi-step workflows, full container isolation."), top-level command tree, curl + mise install paths, pre-built binary assets (linux/macos/windows × amd64/arm64)
+
+### amux docs/ Directory
+- **URL**: https://github.com/prettysmartdev/amux/tree/main/docs
+- **Purpose**: Parent tree for all numbered documentation pages; individual pages cited below
+- **Date Accessed**: 2026-05-16
+- **Individual Pages**:
+  - `docs/contents.md` — https://github.com/prettysmartdev/amux/blob/main/docs/contents.md — documentation index listing all numbered pages
+  - `docs/00-getting-started.md` — https://github.com/prettysmartdev/amux/blob/main/docs/00-getting-started.md — prerequisites, `amux init`, `amux ready`, first session walkthrough
+  - `docs/01-using-the-tui.md` — https://github.com/prettysmartdev/amux/blob/main/docs/01-using-the-tui.md — TUI keybindings (Ctrl+T new tab, Ctrl+A switch, Ctrl+D detach, Ctrl+Y copy), scrollback configuration
+  - `docs/02-agent-sessions.md` — https://github.com/prettysmartdev/amux/blob/main/docs/02-agent-sessions.md — session lifecycle, agent selection precedence, Dockerfile architecture per agent
+  - `docs/03-security-and-isolation.md` — https://github.com/prettysmartdev/amux/blob/main/docs/03-security-and-isolation.md — container isolation model, worktree opt-in, credentials as masked env vars, --rm lifecycle, mount semantics
+  - `docs/04-workflows.md` — https://github.com/prettysmartdev/amux/blob/main/docs/04-workflows.md — workflow authoring in Markdown/TOML/YAML, step fields, template variables ({{work_item_number}}, {{work_item_content}}, {{work_item_section:[Name]}}), field ordering rules
+  - `docs/05-yolo-mode.md` — https://github.com/prettysmartdev/amux/blob/main/docs/05-yolo-mode.md — --yolo flag semantics, 60-second auto-advance, --auto selective permission skipping, implicit worktree creation
+  - `docs/07-configuration.md` — https://github.com/prettysmartdev/amux/blob/main/docs/07-configuration.md — global config (~/.amux/config.json) and per-repo config (GITROOT/aspec/.amux.json), per-key table (types, defaults, scopes), overlays.skills and overlays.directories additive merge, .amux/ Dockerfile directory
+  - `docs/08-headless-mode.md` — https://github.com/prettysmartdev/amux/blob/main/docs/08-headless-mode.md — REST API reference (all endpoints, bearer auth, one-command-per-session constraint, port 9876, allowlisted workdirs), output log path
+  - `docs/09-remote-mode.md` — https://github.com/prettysmartdev/amux/blob/main/docs/09-remote-mode.md — `amux remote` CLI wrapper over the headless REST API, remote.defaultAddr and remote.defaultAPIKey config keys
+  - `docs/10-architecture-overview.md` — https://github.com/prettysmartdev/amux/blob/main/docs/10-architecture-overview.md — high-level architectural summary for end users
+  - `docs/architecture.md` — https://github.com/prettysmartdev/amux/blob/main/docs/architecture.md — detailed four-layer architecture (data → engine → command → frontend) introduced in v0.8.0
+
+### amux Releases Page
+- **URL**: https://github.com/prettysmartdev/amux/releases
+- **Purpose**: Release history, cadence, and binary asset naming (amux-linux-amd64, amux-linux-arm64, amux-macos-amd64, amux-macos-arm64, amux-windows-amd64.exe)
+- **Date Accessed**: 2026-05-16
+- **Key Topics**: Weekly release cadence (~weekly through April 2026), pre-1.0 minor-bump may carry breaking changes, binary asset names per platform
+
+### amux Release v0.8.0
+- **URL**: https://github.com/prettysmartdev/amux/releases/tag/v0.8.0
+- **Purpose**: Specific release notes for the version pinned in `skills/amux/templates/0.8.0/mise.toml`
+- **Date Accessed**: 2026-05-16
+- **Release Date**: 2026-04-12
+- **Key Topics**: Internal four-layer architecture refactor, skills overlay feature (overlays.skills config key), CLI/config/state unchanged from v0.7.x (no migration required)
+
+### amux Install Script
+- **URL**: https://prettysmart.dev/install/amux.sh
+- **Purpose**: Official one-liner install script referenced in the README (`curl -s https://prettysmart.dev/install/amux.sh | sh`)
+- **Date Accessed**: 2026-05-16
+- **Access Note**: **Returned HTTP 403 to anonymous WebFetch on 2026-05-16.** The next maintainer must fetch this URL directly via `curl` from a shell (not an automated agent WebFetch) to inspect the install script content. The prettysmart.dev marketing site also returned 403 to anonymous WebFetch on the same date. Do not assume the script is unavailable — the 403 is consistent with Cloudflare bot protection on anonymous requests.
+
+### amux License
+- **URL**: https://github.com/prettysmartdev/amux/blob/main/LICENSE
+- **Purpose**: Confirm upstream license for skill frontmatter
+- **Date Accessed**: 2026-05-16
+- **Key Topics**: Apache-2.0 license (skill frontmatter declares `license: Apache-2.0` to match upstream)
+
+### amux Templates Directory
+- **URL**: https://github.com/prettysmartdev/amux/tree/main/templates
+- **Purpose**: Per-agent Dockerfile templates seeded by `amux init` into the repo's .amux/ directory
+- **Date Accessed**: 2026-05-16
+- **Key Topics**: Dockerfile.claude, Dockerfile.codex, Dockerfile.copilot, Dockerfile.crush, Dockerfile.gemini, Dockerfile.maki, Dockerfile.opencode, Dockerfile.project
+
+## Plugin Information
+
+- **Name**: amux
+- **Version**: 0.1.0
+- **Description**: amux: parallel AI code agent sessions with container isolation, worktrees, and a headless REST API
+- **Skills**: 1 skill (amux)
+- **Created**: 2026-05-16


### PR DESCRIPTION
- New tool plugin at `plugins/tools/amux/` wrapping the amux CLI (https://github.com/prettysmartdev/amux) — parallel AI coding agents with container isolation, worktrees, and a headless REST API
- Single skill `amux` mirroring the `container` skill shape: version-agnostic SKILL.md, `references/` for command surface / workflows / headless API / config schema, and a versioned `templates/0.8.0/` directory containing both `commands.md` and a copy-paste `mise.toml` pin
- mise-first install: `mise use -g github:prettysmartdev/amux@0.8.0` or copy `templates/0.8.0/mise.toml`
- Plugin registered in `marketplace.json` (entry inserted alphabetically between allium and ansible); marketplace metadata bumped 1.0.8 → 1.0.9
- all-skills meta-plugin regenerated and bumped 0.4.5 → 0.4.6 to include the new skill
- Plugin validates clean: `mise run test:plugin amux` (0 errors), full `mise run test` passes (78 skills, all 18 local plugins green), amux scored 12/12 on the skills-quality scorecard