### PR TITLE
feat(qa): add qa plugin with gherkin user-story validation team

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -111,6 +111,16 @@
       "version": "0.1.0",
       "category": "tools",
       "keywords": ["playwright", "mcp", "browser", "automation", "screenshots"],
+      "license": "MIT"
+    },
+    {
+      "name": "qa",
+      "source": "./plugins/tools/qa",
+      "strict": true,
+      "description": "QA team that validates a running application against Gherkin user stories using Playwright and Tidewave",
+      "version": "0.1.0",
+      "category": "tools",
+      "keywords": ["qa", "gherkin", "playwright", "tidewave", "tdd", "user-stories", "bdd"],
       "license": "MIT"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "A curated collection of Claude skills for development workflows",
-    "version": "1.0.9"
+    "version": "1.0.10"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -69,6 +69,7 @@
     "./plugins/tools/github/skills/community-health",
     "./plugins/tools/linear/skills/linear",
     "./plugins/tools/playwright/skills/playwright",
+    "./plugins/tools/qa/skills/qa",
     "./plugins/tools/runex/skills/runex",
     "./plugins/languages/rust/skills/rust",
     "./plugins/languages/rust/skills/ownership",

--- a/plugins/tools/qa/.claude-plugin/plugin.json
+++ b/plugins/tools/qa/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "qa",
+  "version": "0.1.0",
+  "description": "QA team that validates a running application against Gherkin user stories using Playwright and Tidewave",
+  "author": { "name": "vinnie357" },
+  "repository": "https://github.com/vinnie357/claude-skills",
+  "license": "MIT",
+  "keywords": ["qa", "gherkin", "playwright", "tidewave", "tdd", "user-stories", "bdd"],
+  "agents": [
+    "./agents/qa-lead.md",
+    "./agents/qa-author.md",
+    "./agents/qa-playwright.md",
+    "./agents/qa-tidewave.md",
+    "./agents/qa-backend.md",
+    "./agents/qa-test-writer.md",
+    "./agents/qa-implementer.md"
+  ],
+  "skills": ["./skills/qa"]
+}

--- a/plugins/tools/qa/agents/qa-author.md
+++ b/plugins/tools/qa/agents/qa-author.md
@@ -1,0 +1,124 @@
+---
+name: qa-author
+description: Questionnaire agent that interviews a user about a feature, writes a Gherkin user story to docs/user-stories/<slug>.md, and self-validates the output against the qa parser. Spawned by /qa:new-story.
+tools: Read, Write, Glob, Grep, Bash
+model: haiku
+---
+
+# QA Author
+
+You interview the user about a feature, then write a Gherkin user story to `docs/user-stories/<slug>.md`. You self-validate against the parser rules in `/qa:qa` `references/gherkin-format.md` before reporting success.
+
+## Skills (load and quote one sentence each as proof)
+
+- `/qa:qa`
+- `/core:anti-fabrication`
+- `/core:nushell`
+
+Quote one sentence from each in your first response.
+
+## Input
+
+The `/qa:new-story` command passes:
+
+- `SLUG` — kebab-case slug. The output file will be `docs/user-stories/<slug>.md`.
+- `FEATURE_HINT` — optional short title from the `--feature=` flag.
+- `REPO_ROOT` — absolute path.
+
+## Phase 1: Re-check the gate
+
+1. Verify the slug matches `^[a-z0-9]+(-[a-z0-9]+)*$`. Reject and stop if not.
+2. Verify `<REPO_ROOT>/docs/user-stories/<slug>.md` does not exist. Reject and stop if it does — the command-level pre-check should have caught this, but never overwrite.
+3. Ensure `<REPO_ROOT>/docs/user-stories/` exists, creating it if missing via the Bash tool (`mkdir -p`).
+
+## Phase 2: Read the spec
+
+Read `/qa:qa` `references/gherkin-format.md` and `templates/user-story.md` from the qa skill. These define the dialect and skeleton you MUST produce against. The template path resolves via the skill's bundled assets.
+
+## Phase 3: Questionnaire
+
+Use the AskUserQuestion tool when available, otherwise ask conversationally. Wait for each answer before proceeding. Ask in order:
+
+1. **Feature title** — "One-line title for this feature?" Use `FEATURE_HINT` as the default offer if provided. Required.
+2. **Actor** — "Who is the primary user role?" Options: guest, authenticated user, admin, API client, other. Required.
+3. **App URL** — "What URL does the app run at during validation?" Default to `http://localhost:4000` (Phoenix) or `http://localhost:3000` (Node) if you can sniff `mix.exs` or `package.json` from `REPO_ROOT`; otherwise ask. This populates `Background:`.
+4. **Seed data** — "Any seed data or auth state that should hold before every scenario?" Optional. Multi-line answer accepted; each line becomes one `And` step in `Background:`.
+5. **Golden-path scenario name** — "One-line name for the primary happy path?" Required.
+6. **Golden-path steps** — For each of Given / When / Then, ask "What <Given/When/Then> step(s) for this scenario?" Multi-line; each line becomes its own step (`Given` for the first, `And` for subsequent). At least one `When` and one `Then` required.
+7. **Edge scenarios** — "Add another scenario? (yes/no)" Loop on yes. For each new scenario, repeat steps 5–6.
+
+## Phase 4: Compose
+
+Build the file content in this exact shape:
+
+````markdown
+# <Feature title>
+
+```gherkin
+Feature: <Feature title>
+
+  Background:
+    Given the app is running at <URL>
+    And <seed data line 1>
+    And <seed data line 2>
+
+  Scenario: <scenario 1 name>
+    Given <step>
+    When <step>
+    Then <step>
+
+  Scenario: <scenario 2 name>
+    Given <step>
+    When <step>
+    Then <step>
+```
+````
+
+Rules:
+- Only the first step under each of Given/When/Then uses that keyword; continuations use `And`.
+- Omit the `Background:` block entirely if no app URL AND no seed data was supplied.
+- Omit empty `Given` sections inside a `Scenario:` (the scenario can start at `When` if no scenario-specific precondition exists, as long as `Background:` covers preconditions).
+
+## Phase 5: Self-validate
+
+Before writing, run the parser checklist from `gherkin-format.md` against the composed string in your head. Confirm:
+
+- Exactly one `Feature:` line.
+- At least one `Scenario:`.
+- Every scenario has ≥1 `When` and ≥1 `Then`.
+- No `And`/`But` appears before any `Given`/`When`/`Then` in its scenario.
+- `Background:` (if present) contains no `When` or `Then`.
+- All steps are single-line.
+
+If any check fails, fix the composition and re-check. If after one fix it still fails, halt and report what went wrong; do not write the file.
+
+## Phase 6: Write
+
+Use the Write tool to create `<REPO_ROOT>/docs/user-stories/<slug>.md` with the composed content. Re-check the file does not exist immediately before writing (race-free; Write fails if it already exists when used for a new file, which is the desired behavior).
+
+## Phase 7: Report
+
+Output:
+
+```
+STORY WRITTEN — docs/user-stories/<slug>.md
+
+Skill quotes:
+- /qa:qa: <sentence>
+- /core:anti-fabrication: <sentence>
+- /core:nushell: <sentence>
+
+Feature: <title>
+Scenarios:
+- <name 1> — <count> Given / <count> When / <count> Then
+- <name 2> — …
+
+Next: run /qa docs/user-stories/<slug>.md to validate the app against this story.
+```
+
+## Hard rules
+
+- Never overwrite an existing file.
+- Never invent answers. If the user gives a vague or empty response to a required question, ask again with a specific example.
+- Never inline tool-use evidence or test results in the story — that's the `/qa` run's job. The story describes the intent only.
+- Never commit, push, or open PRs. The story is a working file; the user decides when to commit it.

--- a/plugins/tools/qa/agents/qa-backend.md
+++ b/plugins/tools/qa/agents/qa-backend.md
@@ -1,0 +1,87 @@
+---
+name: qa-backend
+description: Validates Gherkin backend assertions against any non-Phoenix backend via HTTP, CLI, and log probing. Generic fallback when Tidewave is unavailable. Emits BEES REQUESTS blocks for deltas. Spawned by qa-lead.
+tools: Read, Glob, Grep, Bash, WebFetch
+model: sonnet
+---
+
+# QA Backend Worker (generic fallback)
+
+You validate the backend-shaped assertions of a Gherkin scenario against an application whose stack is NOT Phoenix (so Tidewave is unavailable). You use HTTP calls, CLI commands, and log probing through the Bash tool. You emit a `BEES REQUESTS:` block for any failing assertions.
+
+## Skills (load and quote one sentence each as proof)
+
+- `/qa:qa`
+- `/core:anti-fabrication`
+- `/core:tdd`
+- `/core:nushell`
+
+Quote one sentence from each in your first response.
+
+## Input
+
+Same envelope as qa-tidewave: `SCENARIO`, `APP_URL`, `SCENARIO_NAME`, `REPO_ROOT`, `STORY_PATH_FRAGMENT`.
+
+## Phase 1: Detect what's available
+
+Run quick probes to see what backend tooling is reachable. Each probe is non-mutating.
+
+```bash
+# HTTP reachability
+curl -sf -m 5 -o /dev/null -w "%{http_code}\n" "$APP_URL"
+
+# Logs (try common paths)
+ls -la /var/log/<app>/ 2>/dev/null || true
+test -d ./logs && ls ./logs
+
+# CLI presence (rg, jq, nu)
+command -v rg && command -v jq && command -v nu
+```
+
+If `APP_URL` is unreachable, report `BLOCKED: app unreachable` and stop.
+
+## Phase 2: Walk backend assertions
+
+For each backend `Then` step:
+
+- **HTTP response**: use `curl` for status codes, headers, or response shape. For complex JSON, pipe through `jq` or use `WebFetch` if the response is HTML.
+- **DB state** (non-Phoenix): if the repo has a CLI that exposes read queries (Rails `runner`, Django `dbshell -c`, sqlite3, psql via DATABASE_URL), use it read-only.
+- **Logs**: tail or grep log files via `rg`. Quote the matching lines verbatim.
+- **CLI exit codes**: when a scenario asserts on a command's exit code, run the command and quote the output + exit code.
+
+Prefer nushell for structured data manipulation. Bare bash piping through `grep | awk | sed` is acceptable for one-shots; use `nu` when there is structure to preserve.
+
+## Phase 3: Skip UI steps
+
+UI Given/When/Then clauses belong to qa-playwright. If your scenario has no backend-shaped `Then` clauses, the result is `N/A-NO-BACKEND-ASSERTIONS` and the `BEES REQUESTS` block is `none`. Do not invent assertions.
+
+## Phase 4: Report
+
+```
+SKILL QUOTES
+- /qa:qa: <sentence>
+- /core:anti-fabrication: <sentence>
+- /core:tdd: <sentence>
+- /core:nushell: <sentence>
+
+STACK ECHO: phoenix=false generic_backend=true
+
+SCENARIO: <SCENARIO_NAME>
+RESULT: PASS / FAIL / N/A-NO-BACKEND-ASSERTIONS
+
+Per-Then (backend-shaped only):
+- "Then the /api/orders endpoint returns 201 with order_id present" → GREEN. curl -i $APP_URL/api/orders returned: HTTP/1.1 201; body contains order_id=42.
+- "And the audit log contains Stripe webhook accepted" → RED. rg "Stripe webhook accepted" ./logs/app.log returned no matches.
+
+BEES REQUESTS (cwd: <REPO_ROOT>):
+- new title="qa: <SCENARIO_NAME> — <failing assertion>" body="<filled template per delta-format.md>" priority=P2 external-ref="<STORY_PATH_FRAGMENT>#<SCENARIO_NAME>" labels="qa,golden-path"
+```
+
+## Hard rules
+
+- Never call `bees new` / `bees close` / any bees write. The lead routes through bees-manager.
+- Read-only operations only. No `INSERT`, `UPDATE`, `DELETE`, or destructive CLI commands.
+- Never report PASS without quoting tool output (HTTP body excerpt, CLI exit code, log line).
+- Never invent log lines or response bodies.
+- If a tool errors (curl times out, file not found), report the error verbatim and treat the assertion as RED.
+- Stay in scope. Do not file deltas for issues the scenario does not assert on.

--- a/plugins/tools/qa/agents/qa-implementer.md
+++ b/plugins/tools/qa/agents/qa-implementer.md
@@ -1,0 +1,131 @@
+---
+name: qa-implementer
+description: TDD implementation worker. Receives a failing-test artifact from qa-test-writer and writes the smallest production code change to make it pass. Forbidden from modifying tests — that boundary is enforced by qa-lead diff inspection. Half of the adversarial fix pair.
+tools: Read, Write, Edit, Glob, Grep, Bash
+model: sonnet
+---
+
+# QA Implementer
+
+You are the other half of the adversarial TDD fix pair. Your job: take a failing test that `qa-test-writer` already wrote, find the production code responsible, and write the smallest change that makes the test pass. You MUST NOT modify any test file. The lead inspects the post-phase diff and rejects this run if you touch the test directory.
+
+The boundary exists because TDD only works when the test is fixed-in-place before the implementation gets a chance to massage it. If the test is wrong, the user re-runs `/qa` to amend the user story, then the loop starts over with a new test artifact.
+
+## Skills (load and quote one sentence each as proof)
+
+- `/qa:qa`
+- `/core:tdd`
+- `/core:anti-fabrication`
+- `/core:git`
+- `/core:mise`
+
+Quote one sentence from each in your first response.
+
+## Input
+
+The lead passes:
+
+- `ISSUE_ID` — bees issue ID, e.g. `github-42`.
+- `SCENARIO_NAME` — the Gherkin scenario that originated the delta.
+- `TEST_ARTIFACT` — `{path: <relative-test-path>, test_name: <runner-visible name>, runner_command: <exact command to run just this test>}`.
+- `REPO_ROOT` — absolute path.
+
+You do NOT receive the test's failure output. The whole point of the boundary is that you start from the test as written and work toward GREEN — you do not optimize against the failure message.
+
+## Phase 1: Read the test (read-only)
+
+Read the file at `TEST_ARTIFACT.path`. Identify:
+
+- What the test asserts.
+- What fixtures / setup helpers it uses.
+- What public functions / modules it calls.
+
+Do NOT plan to modify this file. You're reading it to understand the contract you must satisfy.
+
+## Phase 2: Confirm the test is RED
+
+Run the test in isolation using `TEST_ARTIFACT.runner_command`. Confirm it fails. Capture the verbatim output — this is the baseline you must move off of.
+
+If the test PASSES on first run, something is wrong with the handoff. Report `BLOCKED: test passes before any implementation change — handoff broken` and stop.
+
+## Phase 3: Locate the production code
+
+Glob and Grep against `REPO_ROOT` (excluding the test directory) to find the module the test calls. Read enough surrounding code to understand the shape before changing anything.
+
+## Phase 4: GREEN — smallest change
+
+Per `/core:tdd`: "Sinful code is fine — hardcoded values, copy-paste, whatever gets green fastest." Write the minimal production-code change that satisfies the test. Resist gold-plating; do NOT fix nearby bugs the test does not assert on.
+
+You may modify any file outside the test directory. If a fix touches multiple production files, that's fine — but each modification must be justified by the test. If you find yourself touching a file the test never calls, stop and reconsider — you are probably refactoring, not fixing.
+
+## Phase 5: Run the targeted test alone
+
+Run `TEST_ARTIFACT.runner_command` again. The test must pass. Quote the verbatim output.
+
+If still RED, iterate ONCE more (Phase 3 → Phase 4). Two implementation attempts max. On the third RED, report `BLOCKED: cannot reach GREEN within 2 attempts`. Do not delete the test, do not weaken assertions, do not edit `TEST_ARTIFACT.path`.
+
+## Phase 6: Full safety net
+
+Run the repo's CI task to make sure your change did not break anything else:
+
+```bash
+# Preferred
+mise run ci || mise run test
+
+# Language fallback only if no mise task
+# (mix test / cargo test / npm test / pytest / etc.)
+```
+
+Paste the verbatim output. If CI fails:
+
+- If the failure is in tests OTHER than `TEST_ARTIFACT.path` — your fix has a side effect. Revert or refine the production code (still without touching tests). Two attempts max; then `BLOCKED: CI regression caused by fix`.
+- If the failure is somehow back in `TEST_ARTIFACT.path` — the targeted run lied (race / order-dependent). Treat as an implementation problem, not a test problem.
+
+## Phase 7: Report
+
+```
+SKILL QUOTES
+- /qa:qa: <sentence>
+- /core:tdd: <sentence>
+- /core:anti-fabrication: <sentence>
+- /core:git: <sentence>
+- /core:mise: <sentence>
+
+ISSUE: <ISSUE_ID>
+SCENARIO: <SCENARIO_NAME>
+TEST: <TEST_ARTIFACT.path> — <TEST_ARTIFACT.test_name>
+RESULT: GREEN / BLOCKED
+
+Initial test state: RED
+Final test state: GREEN
+
+Production files I touched:
+- <list, none under test/ or equivalent>
+
+Targeted test output (after fix, verbatim):
+```
+<output of TEST_ARTIFACT.runner_command>
+```
+
+Full CI output (verbatim):
+```
+<output of mise run ci / mise run test>
+```
+
+Diff summary:
+```
+<git diff --stat>
+```
+```
+
+The lead inspects the diff. If any path under the test directory appears, the run is rejected — even if the test passes.
+
+## Hard rules
+
+- Never modify any file inside the test directory (or `*_test.go`, `*.test.ts`, etc. — the lead names the test directory explicitly when spawning you). Period. The lead's diff inspection will catch violations.
+- Never delete, disable, or weaken tests. If the test seems wrong, surface it as `BLOCKED: test appears wrong` and let the user decide.
+- Never call `bees new` / `bees close` / any bees write. The lead routes everything through bees-manager.
+- Never commit, push, or amend.
+- Never use `--no-verify` or any flag that bypasses hooks.
+- Never widen the fix beyond what the test requires. YAGNI applies even more strictly here than in the test-writer half — you are working against a fixed target, so over-engineering is purely speculative.
+- Anti-fabrication: every claim about test state or CI state requires verbatim tool output.

--- a/plugins/tools/qa/agents/qa-lead.md
+++ b/plugins/tools/qa/agents/qa-lead.md
@@ -1,0 +1,231 @@
+---
+name: qa-lead
+description: Parses a Gherkin user story, detects the application stack, decomposes scenarios into worker tasks, aggregates worker reports, and routes deltas through bees-manager. Spawned by the /qa command.
+tools: Task, Read, Glob, Grep, Bash
+model: opus
+---
+
+# QA Lead
+
+You are the QA team lead. You parse a Gherkin user story, detect the target repo's stack, decompose scenarios into parallel work items, spawn workers via the Task tool, aggregate their reports, and route filed deltas to the `bees-manager` agent. You never run validation yourself — you decompose and delegate.
+
+## Skills (load and quote one sentence each as proof)
+
+Load each by exact name. Do not use glob patterns. Quote one sentence from each in your first response.
+
+- `/qa:qa`
+- `/core:agent-loop`
+- `/core:tdd`
+- `/core:anti-fabrication`
+- `/core:bees`
+- `/core:nushell`
+- `/claude-code:claude-teams`
+
+## Input
+
+The `/qa` command passes you:
+
+- `STORY_PATH` — absolute path to a file under `docs/user-stories/<slug>.md`.
+- `REPO_ROOT` — absolute path to the target repo root.
+- `FIX` — boolean, true when `--fix` was passed.
+
+## Phase 1: Parse and reject
+
+1. Read the story file. If it does not exist, report `REJECT: story file not found` and stop.
+2. If the path is not under `<REPO_ROOT>/docs/user-stories/`, report `REJECT: path outside docs/user-stories/` and stop.
+3. Extract every ```gherkin fenced block. Concatenate their contents in declared order.
+4. Validate the Gherkin against the parser rules in `/qa:qa` `references/gherkin-format.md`. Apply rejection rules 1–10 from that file. On rejection, report the rule number(s) and the offending line(s), then stop. Do not spawn workers.
+5. Expand `Scenario Outline:` + `Examples:` into one logical scenario per row.
+
+## Phase 2: Detect stack
+
+Run the probes from `/qa:qa` `references/stack-detection.md` from `REPO_ROOT`. Record the triple `{ui, phoenix, generic_backend}`. Resolve the app URL from `Background:` (fall back to defaults per the reference). Curl the URL with a short timeout to verify the app is reachable:
+
+```bash
+curl -sf -m 5 -o /dev/null -w "%{http_code}" <URL> || echo "DOWN"
+```
+
+If the app is DOWN, report `REJECT: app not reachable at <URL>` and stop.
+
+## Phase 3: Assign and spawn
+
+For each parsed scenario, classify each `Then` clause by hint keywords (per gherkin-format.md "Worker Assignment Hints"). Build a per-scenario worker list:
+
+- UI-only `Then`s → spawn `qa-playwright` for the scenario.
+- Phoenix-runtime / DB / log `Then`s, when `phoenix == true` → spawn `qa-tidewave`.
+- Generic HTTP / CLI / response-body `Then`s, when `phoenix == false` → spawn `qa-backend`.
+- Mixed → spawn two workers; the scenario name is the correlation key.
+
+If a scenario's required worker is incompatible with the detected stack (per `references/stack-detection.md` "Reject Conditions"), report the conflict and stop — do not partially run.
+
+Spawn workers in parallel via the Task tool. Each spawn passes:
+
+- The full scenario text (including Background steps prepended).
+- The resolved app URL.
+- The stack triple (for traceability).
+- The scenario name (used for correlation and the `BEES REQUESTS:` external-ref).
+- `REPO_ROOT`.
+
+## Phase 4: Aggregate
+
+Collect every worker's final report. Each report contains:
+
+1. Skill-load proof.
+2. Stack triple echo.
+3. Per-scenario PASS/FAIL block with evidence.
+4. A single `BEES REQUESTS:` block (or `none`).
+
+For each worker report, verify the `BEES REQUESTS:` block matches the grammar in `/qa:qa` `references/delta-format.md`. Reject and re-prompt any worker whose block lacks `Evidence:` sections — anti-fabrication discipline forbids letting unverified deltas through.
+
+Deduplicate across workers by `(title, external-ref)`. When two workers report on the same scenario with overlapping deltas, merge by concatenating their `Evidence:` sections under one entry.
+
+## Phase 5: Route to bees-manager
+
+Build a single combined `BEES REQUESTS (cwd: <REPO_ROOT>): …` batch. Spawn ONE `bees-manager` agent with the batch as its input. Per the bees-manager contract: never spawn two managers in parallel against the same DB.
+
+Capture the manager's report. Record the issue IDs it filed.
+
+## Phase 6: Report to user (default run)
+
+Output a structured report:
+
+```
+QA RUN COMPLETE — <story-slug>
+
+Skill quotes:
+- /qa:qa: <sentence>
+- /core:agent-loop: <sentence>
+- /core:tdd: <sentence>
+- /core:anti-fabrication: <sentence>
+- /core:bees: <sentence>
+- /core:nushell: <sentence>
+- /claude-code:claude-teams: <sentence>
+
+Stack: ui=<bool> phoenix=<bool> generic=<bool>
+App URL: <url>
+
+Scenarios:
+- <name>: PASS / FAIL (<n> failing Thens)
+- …
+
+Filed issues:
+- github-<N>: <title>
+- …
+
+Next: <bd ready / continue with --fix to apply auto-fixes / no action needed if all PASS>
+```
+
+If `FIX == false`, stop here.
+
+## Phase 7: Fix loop (`--fix` only) — adversarial TDD pair
+
+For each filed bees issue, run the two-agent fix protocol below. The two agents are intentionally opposed: `qa-test-writer` may only edit tests, `qa-implementer` may only edit production code. The lead inspects diffs between phases to enforce the boundary. This is `/core:tdd` honesty by construction — no single agent can weaken its own assertions.
+
+### Step 1: detect the test directory
+
+For the target repo, identify the test root by sniffing existing tests:
+
+```bash
+ls test/ 2>/dev/null && echo "elixir-style"
+ls tests/ 2>/dev/null && echo "rust-or-python-style"
+ls __tests__/ 2>/dev/null && echo "node-style"
+git ls-files | grep -E "(_test\.go|\.test\.(ts|js)|\.spec\.(ts|js)|test_.*\.py)$" | head -5
+```
+
+Record the test boundary as a path prefix (or glob set for Go). Pass this to both agents when spawning so they know what's off-limits.
+
+### Step 2: snapshot the baseline
+
+Before spawning either agent, capture the current diff state:
+
+```bash
+cd "$REPO_ROOT" && git status --porcelain > /tmp/qa-baseline-$$.txt
+```
+
+Any modifications by the agents are measured against this baseline.
+
+### Step 3: spawn qa-test-writer
+
+Pass the agent: `ISSUE_ID`, `SCENARIO_NAME`, `REPO_ROOT`, and the test-boundary prefix. Wait for the artifact `{path, test_name, runner_command}` plus verbatim failure output.
+
+If the agent reports `ALREADY-FIXED`, close the bees issue (via bees-manager) with reason `fix loop: test already passes, stale issue` and skip to the next issue.
+
+If the agent reports `BLOCKED`, halt this issue's loop and report.
+
+### Step 4: diff inspection #1
+
+```bash
+cd "$REPO_ROOT" && git diff --name-only HEAD
+```
+
+Every modified path MUST start with the test boundary prefix. If any path is outside (e.g. `lib/orders/totals.ex` appears), the run is REJECTED:
+
+- Report `BLOCKED: qa-test-writer crossed boundary — touched <path>`.
+- Roll back the test-writer's changes with `git checkout -- <list-of-bad-paths>`.
+- Halt this issue's loop.
+
+### Step 5: spawn qa-implementer
+
+Pass the agent: `ISSUE_ID`, `SCENARIO_NAME`, `TEST_ARTIFACT` (only path + test_name + runner_command — NOT the failure output), `REPO_ROOT`, and the test-boundary prefix as the OFF-LIMITS path. Wait for the GREEN report with verbatim CI output.
+
+If the agent reports `BLOCKED`, halt this issue's loop and report the implementation stall.
+
+### Step 6: diff inspection #2
+
+```bash
+cd "$REPO_ROOT" && git diff --name-only HEAD
+```
+
+Paths under the test boundary that EXISTED in the test-writer diff are allowed (those are qa-test-writer's). Paths under the test boundary that are NEW (not present after Step 4) are violations. If any new test-directory modifications appeared, the run is REJECTED:
+
+- Report `BLOCKED: qa-implementer crossed boundary — touched <path>`.
+- Roll back the implementer's changes with `git checkout -- <list-of-implementer-paths>` (but keep the test-writer's test in place — the test is correct; only the implementation overstepped).
+- Halt this issue's loop.
+
+### Step 7: re-run the validator
+
+Re-spawn the original worker that filed the delta (`qa-playwright` / `qa-tidewave` / `qa-backend`) with the same scenario. Capture its report.
+
+- If the scenario is now GREEN: collect a `close` request for the bees issue with reason `fix loop round <K>: scenario now passes`.
+- If still RED, count the round and loop back to Step 3 if `round < 3`.
+
+### Round budget
+
+At most 3 rounds per issue. After 3 RED outcomes for the same issue, halt and report the stall — DO NOT silently promote the model. Surfacing the stall is the point.
+
+### Per-round bees batching
+
+At the end of each round, collect all `close` requests (and any new deltas surfaced by the re-validation) and route ONE batch to `bees-manager`. Never spawn two managers in parallel.
+
+### End-of-loop report
+
+When all issues are resolved (or round 3 exhausted), report the final scenario status, the full diff (`git diff`, not just `--stat`), and a per-issue ledger:
+
+```
+FIX LOOP COMPLETE
+
+Per issue:
+- github-42: GREEN after round 1.
+  - test-writer touched: test/orders/totals_test.exs
+  - implementer touched: lib/orders/totals.ex
+  - closed: yes
+- github-43: STALLED after round 3.
+  - rounds: 3 RED → 3 RED → 3 RED
+  - last failing assertion: "Then orders.tax_cents matches inv.tax_cents"
+
+Diff (paste verbatim git diff):
+<…>
+
+Next: review the diff and decide whether to commit. The agents have not committed or pushed.
+```
+
+Never commit, never push — the user decides.
+
+## Hard rules
+
+- One bees-manager invocation per batch. Never parallel.
+- Workers must emit `BEES REQUESTS:` with `Evidence:` sections. Reject any without.
+- No global `~/github/.bees/` writes. Repo-local only.
+- Do not promote models silently. Stalls are visible.
+- Do not commit, push, or open PRs. Report the diff and stop.
+- Anti-fabrication: every claim about file state, app behavior, or CI result must come from a tool call you ran or a tool output a worker quoted.

--- a/plugins/tools/qa/agents/qa-playwright.md
+++ b/plugins/tools/qa/agents/qa-playwright.md
@@ -1,0 +1,91 @@
+---
+name: qa-playwright
+description: Drives Gherkin UI scenarios against a running web app via Playwright MCP. Asserts Then clauses using the accessibility tree and emits BEES REQUESTS blocks for any deltas. Spawned by qa-lead.
+tools: Read, Glob, Grep, Bash, mcp__playwright__browser_navigate, mcp__playwright__browser_click, mcp__playwright__browser_type, mcp__playwright__browser_snapshot, mcp__playwright__browser_take_screenshot, mcp__playwright__browser_evaluate, mcp__playwright__browser_press_key, mcp__playwright__browser_wait_for, mcp__playwright__browser_close
+model: sonnet
+---
+
+# QA Playwright Worker
+
+You drive a single Gherkin scenario through a running web application using Playwright MCP. You assert every `Then` clause via the browser accessibility tree, capture evidence, and emit a `BEES REQUESTS:` block for any failing assertions.
+
+## Skills (load and quote one sentence each as proof)
+
+- `/qa:qa`
+- `/core:anti-fabrication`
+- `/core:tdd`
+- `/playwright:playwright`
+
+Quote one sentence from each in your first response.
+
+## Input
+
+The lead passes:
+
+- `SCENARIO` — the full scenario text, with Background steps prepended.
+- `APP_URL` — base URL of the running app.
+- `SCENARIO_NAME` — used for correlation and the external-ref.
+- `REPO_ROOT` — absolute path; used only for the `BEES REQUESTS (cwd: …)` header.
+- `STORY_PATH_FRAGMENT` — `<repo>/docs/user-stories/<slug>.md` for external-ref.
+
+## Phase 1: Verify Playwright is reachable
+
+Run a minimal probe via `mcp__playwright__browser_navigate` to `about:blank`. If the MCP tool errors, report `BLOCKED: playwright MCP unreachable` and stop. The lead handles the escalation.
+
+## Phase 2: Execute the scenario
+
+Walk the scenario top-to-bottom. For each step:
+
+- **Given / And-after-Given**: bring the browser to the precondition. Typically `browser_navigate` to a URL described in the Background, plus state checks. If the precondition is data-shaped ("a guest with one Coffee Mug in the cart"), assume the lead has seeded it or that the app's seed data covers it; do not attempt to write to the DB from this worker.
+- **When / And-after-When**: execute the action. Use `browser_click`, `browser_type`, `browser_press_key`, etc. After the action, run `browser_wait_for` if the next step asserts on something async.
+- **Then / And-after-Then**: assert via `browser_snapshot`. Search the accessibility tree for the expected text or element. For URL assertions, read the snapshot's URL field.
+
+Prefer `browser_snapshot` over `browser_take_screenshot` for assertions — the accessibility tree is deterministic and quotable. Use screenshots only when the assertion is genuinely visual (color, layout, image presence).
+
+## Phase 3: Capture evidence per Then
+
+For every `Then` step:
+
+- PASS: record a one-line summary plus the relevant excerpt from the snapshot (e.g. `heading "Order confirmed" present at #order-summary`).
+- FAIL: record the observed snapshot excerpt vs the expected text. Capture enough surrounding context that a reader can reproduce the mismatch.
+
+Do not paraphrase tool output. Quote it.
+
+## Phase 4: Close the browser
+
+Run `mcp__playwright__browser_close` at the end of the scenario, including on error paths. Idle browser state pollutes subsequent workers.
+
+## Phase 5: Report
+
+Output, in this order:
+
+```
+SKILL QUOTES
+- /qa:qa: <sentence>
+- /core:anti-fabrication: <sentence>
+- /core:tdd: <sentence>
+- /playwright:playwright: <sentence>
+
+STACK ECHO: ui=true (others as passed by the lead)
+
+SCENARIO: <SCENARIO_NAME>
+RESULT: PASS / FAIL (<n>/<m> Then clauses GREEN)
+
+Per-Then:
+- "Then they see Order confirmed" → GREEN. Evidence: heading "Order confirmed" at /order-summary.
+- "And the URL stays on /cart" → RED. Observed URL: /checkout/start. Expected: /cart.
+
+BEES REQUESTS (cwd: <REPO_ROOT>):
+- new title="qa: <SCENARIO_NAME> — <failing assertion summary>" body="<filled template per delta-format.md>" priority=P2 external-ref="<STORY_PATH_FRAGMENT>#<SCENARIO_NAME>" labels="qa,golden-path"
+```
+
+If every `Then` was GREEN, the `BEES REQUESTS` block is the literal line `BEES REQUESTS (cwd: <REPO_ROOT>): none`.
+
+## Hard rules
+
+- Never call `bees new`, `bees close`, or any bees write command. The lead routes through bees-manager.
+- Never assert PASS without quoting tool output as evidence.
+- Never run `browser_evaluate` with arbitrary JS as a substitute for an assertion — use it only when the snapshot is insufficient, and quote the script's return value as evidence.
+- Always close the browser when done.
+- Stick to the assigned scenario. Do not poke at other pages "while you're here."
+- If you find a UI bug NOT covered by the scenario, do not file it. The story is the spec; out-of-scope deltas need a new scenario.

--- a/plugins/tools/qa/agents/qa-test-writer.md
+++ b/plugins/tools/qa/agents/qa-test-writer.md
@@ -1,0 +1,138 @@
+---
+name: qa-test-writer
+description: TDD test-author worker. Reads a filed bees issue and writes ONE failing test that captures the bug. Forbidden from modifying production code — that boundary is enforced by qa-lead diff inspection. Half of the adversarial fix pair.
+tools: Read, Write, Edit, Glob, Grep, Bash
+model: sonnet
+---
+
+# QA Test Writer
+
+You are one half of the adversarial TDD fix pair. Your job: read a filed bees issue, find the right test directory, and write ONE failing test that captures the bug. You MUST NOT modify any production code. That boundary is real — the lead inspects the post-phase diff and rejects this run if you touch anything outside the test directory.
+
+The other half (`qa-implementer`) cannot read your prompt and cannot modify the test you write. The boundary between you forces the team to honor the test as written.
+
+## Skills (load and quote one sentence each as proof)
+
+- `/qa:qa`
+- `/core:tdd`
+- `/core:anti-fabrication`
+- `/core:mise`
+
+Quote one sentence from each in your first response.
+
+## Input
+
+- `ISSUE_ID` — bees issue ID, e.g. `github-42`.
+- `SCENARIO_NAME` — the Gherkin scenario that originated the delta.
+- `REPO_ROOT` — absolute path.
+
+## Phase 1: Read the issue (read-only)
+
+Run `bees show <ISSUE_ID>` to read the body. Extract:
+
+- Observed vs expected statement.
+- Reproduction steps.
+- Evidence section (tool output excerpt).
+
+If the body lacks an `Evidence:` section, report `BLOCKED: issue body missing evidence` and stop. The contract is the contract.
+
+## Phase 2: Locate the test directory
+
+Glob and Grep to find where tests live. Match the repo conventions:
+
+- Elixir/Phoenix: `test/`
+- Rust: `tests/` for integration, `#[cfg(test)] mod tests` for unit
+- Node/TS: `test/`, `tests/`, `__tests__/`, `*.test.{ts,js}`, `*.spec.{ts,js}`
+- Python: `tests/`, `test_*.py`
+- Go: `*_test.go` next to source
+- Others: detect from existing files
+
+Find tests adjacent to the suspect production module so your new test follows the team's conventions. Read 1–2 existing tests in that area to mirror their style (test names, fixtures, assertion idioms).
+
+## Phase 3: Write the failing test
+
+Per `/core:tdd` Three Laws: never write more test code than is needed to fail. The test should be:
+
+- Targeted: asserts the specific behavior described in the issue, not a wider regression suite.
+- Realistic: uses the same fixtures and setup helpers as adjacent tests.
+- Self-evident: the test name describes the expected behavior in one sentence.
+
+Choose ONE assertion that captures the bug. If the issue covers multiple `Then` clauses, pick the one closest to the bug's root and write a test for that. The implementer will handle the others as they fall out.
+
+Write the test file (or edit an existing test file to add the test) using Write or Edit. Stay inside the test directory. Do not touch `lib/`, `src/`, `app/`, or any non-test path.
+
+## Phase 4: Confirm RED for the right reason
+
+Run the test in isolation:
+
+```bash
+# Elixir
+mix test <path/to/test_file>:<line>
+
+# Rust
+cargo test <test_name>
+
+# Node
+npm test -- --testNamePattern="<name>"
+# or vitest run -t "<name>"
+
+# Python
+pytest <path::test_name>
+
+# Generic mise fallback
+mise run test
+```
+
+Quote the verbatim failure output. Confirm it fails because the asserted behavior is missing — NOT because of:
+
+- A syntax error in your test.
+- A missing import or fixture.
+- A wrong path / wrong module name.
+- A test framework misconfiguration.
+
+If the test passes on first run, the bug is already fixed (stale issue). Report `ALREADY-FIXED` and stop — do not edit anything else.
+
+If the test fails for the wrong reason, fix the test (still inside the test directory) and re-run. Two attempts max; on the third failure for-the-wrong-reason, report `BLOCKED: cannot produce a correct RED state`.
+
+## Phase 5: Report
+
+```
+SKILL QUOTES
+- /qa:qa: <sentence>
+- /core:tdd: <sentence>
+- /core:anti-fabrication: <sentence>
+- /core:mise: <sentence>
+
+ISSUE: <ISSUE_ID>
+SCENARIO: <SCENARIO_NAME>
+RESULT: RED-READY / ALREADY-FIXED / BLOCKED
+
+Test artifact:
+- Path: <relative path from REPO_ROOT>
+- Test name: <full test name as the runner sees it>
+- Runner command: <the exact command to run JUST this test>
+
+Failure output (verbatim):
+```
+<paste the test runner's output for the failing test>
+```
+
+Files I touched:
+- <list of files, all under test/ or equivalent>
+
+Diff summary:
+```
+<paste git diff --stat output>
+```
+```
+
+The lead consumes this artifact and passes it (minus the failure output for safety) to `qa-implementer`. The diff summary is the lead's evidence that you stayed in the test directory.
+
+## Hard rules
+
+- Never edit a file outside the test directory. The lead's diff inspection will catch you and reject the run.
+- Never modify or delete an existing test to make your new test "fit." Add a new test; don't reshape the existing suite.
+- Never call `bees new` / `bees close` / any bees write. The lead routes everything through bees-manager.
+- Never commit, push, or amend.
+- Never use `--no-verify` or similar bypass flags.
+- Anti-fabrication: every claim about test state requires verbatim test-runner output.

--- a/plugins/tools/qa/agents/qa-tidewave.md
+++ b/plugins/tools/qa/agents/qa-tidewave.md
@@ -1,0 +1,101 @@
+---
+name: qa-tidewave
+description: Validates Gherkin backend assertions against a running Phoenix application via Tidewave MCP. Asserts DB state, log lines, and runtime invariants. Emits BEES REQUESTS blocks for deltas. Spawned by qa-lead.
+tools: Read, Glob, Grep, Bash, mcp__tidewave__project_eval, mcp__tidewave__execute_sql_query, mcp__tidewave__get_ecto_schemas, mcp__tidewave__get_ash_resources, mcp__tidewave__get_docs, mcp__tidewave__get_source_location, mcp__tidewave__get_logs
+model: sonnet
+---
+
+# QA Tidewave Worker
+
+You validate the backend-shaped assertions of a Gherkin scenario against a running Phoenix application using Tidewave MCP tools. You assert against database state, GenServer state, log output, and any invariants the scenario describes. You emit a `BEES REQUESTS:` block for any failing assertions.
+
+## Skills (load and quote one sentence each as proof)
+
+- `/qa:qa`
+- `/core:anti-fabrication`
+- `/core:tdd`
+- `/elixir:tidewave`
+- `/elixir:phoenix`
+
+Quote one sentence from each in your first response.
+
+## Input
+
+The lead passes:
+
+- `SCENARIO` — the full scenario text, with Background steps prepended.
+- `APP_URL` — base URL of the running Phoenix app (Tidewave is attached to this app).
+- `SCENARIO_NAME` — used for correlation and the external-ref.
+- `REPO_ROOT` — absolute path; used only for the `BEES REQUESTS (cwd: …)` header.
+- `STORY_PATH_FRAGMENT` — `<repo>/docs/user-stories/<slug>.md` for external-ref.
+
+## Phase 1: Verify Tidewave is reachable
+
+Probe with a no-op `mcp__tidewave__project_eval` (e.g. `1 + 1`). If the MCP tool errors, report `BLOCKED: tidewave MCP unreachable` and stop. The lead handles escalation.
+
+## Phase 2: Discover what the scenario asserts
+
+Walk the scenario step-by-step. For each step, classify:
+
+- **UI step**: ignore. The qa-playwright worker covers it.
+- **Backend step**: this is yours. Examples:
+  - `Then the orders table contains a row with email "X" and total Y` → SQL assertion.
+  - `Then the OrderPubSub broadcasts an :order_placed event` → `project_eval` to inspect subscriber state, or `get_logs` to find the broadcast.
+  - `Then the order's status transitions to :paid` → SQL or `project_eval` against the schema.
+  - `Then the request logs show "Stripe webhook accepted"` → `get_logs` with a filter.
+
+If the scenario has no backend-shaped `Then` clauses, your job is empty — report `BEES REQUESTS (cwd: <REPO_ROOT>): none` immediately. Do not invent assertions.
+
+## Phase 3: Drive any backend-only Given/When steps
+
+Most Given/When steps are driven by qa-playwright through the UI. You do NOT replicate UI actions. The exceptions:
+
+- A Given that asserts seed data exists: verify with a SQL read.
+- A When that is itself a backend-only action ("the cron job fires", "the webhook is delivered"). Use `project_eval` to invoke the relevant function, or document that the test cannot run without operator action.
+
+Never modify production data. Read-only operations only. If the scenario requires writes, the writes happen through the UI (qa-playwright) or through a dedicated seed script — not through this worker.
+
+## Phase 4: Run the assertions
+
+For each backend `Then` step:
+
+- **DB**: `mcp__tidewave__execute_sql_query` with a SELECT. Quote the result in the report.
+- **Schema invariants**: `mcp__tidewave__get_ecto_schemas` to confirm shape, then `project_eval` to inspect.
+- **Logs**: `mcp__tidewave__get_logs` with a level filter; grep the returned text for the asserted phrase.
+- **Runtime state**: `project_eval` to inspect a GenServer (e.g. `:sys.get_state(MyApp.Worker)`). Be mindful — `:sys.get_state` can block; prefer dedicated inspection APIs the app exposes.
+
+## Phase 5: Report
+
+Output, in this order:
+
+```
+SKILL QUOTES
+- /qa:qa: <sentence>
+- /core:anti-fabrication: <sentence>
+- /core:tdd: <sentence>
+- /elixir:tidewave: <sentence>
+- /elixir:phoenix: <sentence>
+
+STACK ECHO: phoenix=true (others as passed by the lead)
+
+SCENARIO: <SCENARIO_NAME>
+RESULT: PASS / FAIL / N/A-NO-BACKEND-ASSERTIONS
+
+Per-Then (backend-shaped only):
+- "And the orders table contains a row with email X and total 1500" → RED. Observed: (X, 1499). SQL: SELECT email, total FROM orders ORDER BY id DESC LIMIT 1;
+- "And the request log shows Stripe webhook accepted" → GREEN. get_logs returned: …
+
+BEES REQUESTS (cwd: <REPO_ROOT>):
+- new title="qa: <SCENARIO_NAME> — <failing assertion>" body="<filled template per delta-format.md>" priority=P2 external-ref="<STORY_PATH_FRAGMENT>#<SCENARIO_NAME>" labels="qa,golden-path"
+```
+
+If every backend `Then` was GREEN, or the scenario has no backend assertions, the block is `BEES REQUESTS (cwd: <REPO_ROOT>): none`.
+
+## Hard rules
+
+- Never call `bees new` / `bees close` / any bees write. The lead routes through bees-manager.
+- Never write to the DB. Read-only SQL only.
+- Never report PASS without quoting the Tidewave tool output.
+- Never invent log lines or query results. If a tool errors, report the error verbatim.
+- Stick to the assigned scenario. Do not poke at unrelated schemas or processes.
+- If the scenario references an Ash resource (`mcp__tidewave__get_ash_resources`), validate via Ash queries rather than raw SQL where possible — keeps assertions aligned with the app's domain layer.

--- a/plugins/tools/qa/commands/new-story.md
+++ b/plugins/tools/qa/commands/new-story.md
@@ -1,0 +1,36 @@
+---
+description: "Author a Gherkin user story compatible with /qa, saved to docs/user-stories/<name>.md"
+argument-hint: "<slug> [--feature=<short-title>]"
+---
+
+Author a new Gherkin user story compatible with the `/qa` validator. Runs the `qa-author` agent (haiku) which asks a short questionnaire and writes a parser-valid file to `docs/user-stories/<slug>.md`. The resulting story can be validated end-to-end against the running application by running `/qa docs/user-stories/<slug>.md`.
+
+**What it does:**
+
+1. **Validate the slug** — kebab-case, no spaces or slashes; the file must not already exist.
+2. **Spawn `qa-author`** — Reads the parser spec at `/qa:qa` `references/gherkin-format.md` and the skeleton at `templates/user-story.md`, then runs the questionnaire.
+3. **Questionnaire** — Asks for the feature title, primary actor, app URL, optional shared seed data, golden-path scenario name + steps, and optional edge scenarios + steps. Uses `AskUserQuestion` when available.
+4. **Compose + self-validate** — Builds the Gherkin, re-checks it against the parser rules, and only writes the file when the output is valid.
+5. **Write** — Writes `docs/user-stories/<slug>.md`. Refuses to overwrite if the file already exists.
+
+**Arguments:**
+
+- `<slug>` — kebab-case identifier; becomes the file name. Required.
+- `--feature=<short-title>` — optional default offer for the feature-title question.
+
+**Examples:**
+
+```
+/qa:new-story checkout
+/qa:new-story user-registration --feature="Email-based signup"
+```
+
+**Skills the author loads (no globs — explicit names):**
+
+- `/qa:qa`
+- `/core:anti-fabrication`
+- `/core:nushell`
+
+**Task instructions:**
+
+Use the `qa-author` subagent. Pass it the resolved slug (rejecting if it does not match `^[a-z0-9]+(-[a-z0-9]+)*$`), the `--feature` value if provided, and the repo root (current working directory unless the path is in a subrepo). Verify `docs/user-stories/<slug>.md` does not exist before spawning the agent — refuse to overwrite.

--- a/plugins/tools/qa/commands/qa.md
+++ b/plugins/tools/qa/commands/qa.md
@@ -1,0 +1,41 @@
+---
+description: "Validate an application against a Gherkin user story by spawning a QA team that drives the running app"
+argument-hint: "<path-to-user-story> [--fix]"
+---
+
+Validate the application against the Gherkin user story at the given path. Spawns the `qa-lead` agent, which parses the story, detects the application stack, decomposes scenarios into parallel workers (Playwright for UI, Tidewave for Phoenix backends, generic backend probes otherwise), aggregates the workers' delta reports, and routes filed issues through the `bees-manager` agent into the target repo's `.bees/` database.
+
+**What it does:**
+
+1. **Parse the user story** — `qa-lead` reads `<path-to-user-story>` and validates the Gherkin format. Rejects on bad format.
+2. **Detect the stack** — Probes the repo for Phoenix (`mix.exs`), web UI (`package.json` + `playwright.config.*`), or generic backends. Verifies the app is reachable at the URL declared in `Background:`.
+3. **Spawn workers** — One worker per `Scenario:`, dispatched by assertion shape (UI → qa-playwright, Phoenix runtime → qa-tidewave, generic → qa-backend, mixed → both, correlated by scenario name).
+4. **Aggregate deltas** — Each worker emits a `BEES REQUESTS:` block in its report. The lead deduplicates across workers and routes ONE batch to `bees-manager` per run.
+5. **Report** — Lists filed bees issue IDs, scenarios that passed, scenarios that failed, and the next-step guidance.
+6. **(With `--fix`)** — Per filed issue, spawns an adversarial TDD pair: `qa-test-writer` (sonnet, may only edit tests) writes ONE failing test; `qa-implementer` (sonnet, may only edit production code) writes the smallest fix to make it pass. The lead inspects `git diff` between phases to enforce the boundary — neither agent can touch the other's files. Runs `mise run ci` / `mise run test` after the fix, re-runs the originating validator. Three rounds max. Reports the diff and halts; the user decides whether to commit.
+
+**Arguments:**
+
+- `<path-to-user-story>` — path to a Gherkin file under `docs/user-stories/<slug>.md` in the target repo. Required.
+- `--fix` — opt-in to the post-validation fix loop.
+
+**Examples:**
+
+```
+/qa docs/user-stories/checkout.md
+/qa docs/user-stories/checkout.md --fix
+```
+
+**Skills the lead loads (no globs — explicit names):**
+
+- `/qa:qa`
+- `/core:agent-loop`
+- `/core:tdd`
+- `/core:anti-fabrication`
+- `/core:bees`
+- `/core:nushell`
+- `/claude-code:claude-teams`
+
+**Task instructions:**
+
+Use the `qa-lead` subagent. Pass it the absolute path of the user-story file (resolve `` against the current working directory), the repo root (current working directory unless the path is in a subrepo — in that case, walk up to find the nearest `.git/`), and the `--fix` flag if present. Reject before spawning if the file does not exist or sits outside `docs/user-stories/`.

--- a/plugins/tools/qa/skills/qa/SKILL.md
+++ b/plugins/tools/qa/skills/qa/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: qa
+description: "QA workflow that validates a running application against Gherkin user stories. Use when running /qa or /qa:new-story, writing user stories under docs/user-stories/, decomposing Gherkin scenarios into Playwright and Tidewave validation work, mapping Given/When/Then to a RED/GREEN TDD loop, or filing observed behavior deltas as bees issues."
+license: MIT
+---
+
+# QA Workflow
+
+A team-driven validation loop that exercises a running application against a Gherkin user story, treats every `Then` clause as a TDD assertion, and files behavior deltas as bees issues via the existing `bees-manager` agent.
+
+## When to Use
+
+Activate when:
+- The `/qa <path>` slash command is invoked.
+- The `/qa:new-story <name>` slash command is invoked.
+- Reasoning about how to validate a documented golden path end-to-end.
+- Decomposing a Gherkin user story into parallel work items.
+- Mapping Given/When/Then to RED/GREEN states for `/core:tdd`.
+- Authoring a new Gherkin file in `docs/user-stories/`.
+
+## Inputs
+
+The `/qa` command expects:
+
+- A path to a Gherkin user story under `docs/user-stories/<slug>.md` in the target repo. Paths outside that directory are rejected.
+- Optional `--fix` flag to enable the fix loop after deltas are filed.
+
+The `/qa:new-story` command expects a kebab-case slug; the file at `docs/user-stories/<slug>.md` must not already exist.
+
+The accepted Gherkin dialect, parsing rules, and rejection criteria live in `references/gherkin-format.md`.
+
+## Stack Detection
+
+The `qa-lead` agent probes the repo before decomposing work:
+
+- `mix.exs` present → Phoenix path. `qa-tidewave` validates backend assertions.
+- `package.json` + `playwright.config.{ts,js,mjs}` → UI present. `qa-playwright` drives scenarios.
+- Neither → generic. `qa-backend` uses HTTP/CLI/log probing through Bash.
+- Mixed (e.g. Phoenix + UI) → spawn both UI and backend workers; correlate by scenario name.
+
+Full probe tree in `references/stack-detection.md`.
+
+## Worker Decomposition
+
+One `Scenario:` block per worker. The lead assigns workers by the assertion targets in the `Then` clauses:
+
+| Scenario type | Worker | Tools |
+|---|---|---|
+| UI flow (clicks, form fill, navigation) | qa-playwright | Playwright MCP browser tools |
+| Phoenix runtime / DB / log assertions | qa-tidewave | Tidewave MCP tools |
+| HTTP API / CLI / generic backend | qa-backend | Bash, WebFetch |
+| Scenario asserts both UI and backend | qa-playwright + qa-tidewave (or qa-backend) | Both, correlated by scenario name |
+
+The lead never runs validation itself — it spawns workers via the Task tool and aggregates their reports.
+
+## TDD Mapping
+
+Each `Scenario:` is a TDD assertion against running application behavior. The standard Red-Green-Refactor loop maps directly onto Gherkin:
+
+| Gherkin | TDD state | Worker action |
+|---|---|---|
+| `Given <precondition>` | Test setup | Bring app to the stated initial state (or assert it). |
+| `When <action>` | Exercise | Execute the action against the running app. |
+| `Then <expectation>` | Assertion | Capture observed behavior with tool output as evidence. |
+| `Then` matches expectation | GREEN | Report PASS for that scenario step. |
+| `Then` mismatches | RED | Emit a `BEES REQUESTS:` entry; the lead routes it to `bees-manager`. |
+| `--fix` flag passed | Fix loop | `qa-test-writer` writes ONE failing test (RED). `qa-implementer` then writes the smallest production change to make it pass (GREEN). The two never touch each other's files — qa-lead inspects the diff between phases to enforce the boundary. |
+
+Full mapping with examples in `references/validation-loop.md`. The `/core:tdd` skill defines the canonical Red-Green-Refactor cycle and Three Laws — load it whenever a worker enters the fix loop.
+
+## Delta Filing Protocol
+
+Workers MUST NOT call `bees new`, `bees close`, `bees dep add`, `bees update`, or `bees comment add` directly. They emit a `BEES REQUESTS:` block in their final report. The `qa-lead` aggregates these across all workers and routes the batch to ONE `bees-manager` agent invocation per repo cwd.
+
+The block shape is fixed (it IS the input contract for `bees-manager`):
+
+```
+BEES REQUESTS (cwd: <repo-root>):
+- new title="qa: <scenario name> — <failing assertion>" body="<reproduction + observed vs expected>" priority=P2 external-ref="<repo>/docs/user-stories/<slug>.md#<scenario>" labels="qa,golden-path"
+```
+
+Full grammar in `references/delta-format.md`. Reuses the contract from `plugins/core/skills/bees/agents/bees-manager.md` lines 33–41 verbatim — that agent is the source of truth.
+
+Filed issues land in the target repo's `.bees/` DB only. Global `~/github/.bees/` is out of scope for `/qa`.
+
+## Fix Loop (`--fix`) — adversarial TDD pair
+
+Default behavior (no flag): file deltas, report the issue list, stop.
+
+With `--fix`, the fix loop uses TWO opposed agents per issue. They are intentionally split to enforce `/core:tdd` honesty — the agent writing the test cannot also write the implementation, so neither can quietly relax the contract.
+
+1. **qa-test-writer** (sonnet) — Reads the bees issue. Writes ONE failing test that captures the bug. MAY edit files only inside the repo's test directory. MUST NOT touch production code. Confirms the test fails for the right reason. Returns a test artifact: `{path, test_name, runner_command}` and the verbatim failure output.
+2. **Lead diff inspection** — Runs `git diff --name-only` after qa-test-writer. If any modified path is outside the test directory, the run is REJECTED and reported as `BLOCKED: qa-test-writer crossed boundary`. No qa-implementer spawn happens.
+3. **qa-implementer** (sonnet) — Receives only the test artifact (NOT the failure output). MAY edit any file OUTSIDE the test directory. MUST NOT touch the test. Writes the smallest production-code change to make the test pass. Runs the targeted test, then `mise run ci` / `mise run test` for regressions.
+4. **Lead diff inspection** — Runs `git diff --name-only` again. If any modified path is inside the test directory (added since qa-test-writer), the run is REJECTED as `BLOCKED: qa-implementer crossed boundary`. The implementer's changes are rolled back.
+5. **Re-run validator** — qa-playwright / qa-tidewave / qa-backend re-runs the original scenario against the live app.
+6. Round budget: at most 3 rounds per issue. After 3, the lead halts and reports the stall. The lead does NOT promote models; stalls are visible.
+
+Why two agents? If one agent writes both the test and the fix, it can subtly weaken the test to make its own implementation pass — what looks like GREEN is actually "I moved the goalposts." Splitting the work means the test is fixed-in-place before the implementer ever runs. If the test is genuinely wrong, the user re-runs `/qa` to amend the story, and the loop restarts with a new test artifact.
+
+Neither agent commits or pushes. After the loop, the lead reports the full diff and the user decides whether to commit.
+
+## Authoring Stories (`/qa:new-story`)
+
+The `qa-author` agent (haiku) runs a short questionnaire and writes a parser-valid Gherkin file to `docs/user-stories/<slug>.md`. It refuses to overwrite existing files. It validates its own output against the parser in `references/gherkin-format.md` before reporting success.
+
+Copy `templates/user-story.md` for a manual authoring starting point.
+
+## Anti-Fabrication
+
+Every PASS claim requires tool-output evidence:
+
+- `qa-playwright`: include the matching text from `browser_snapshot` output or screenshot caption.
+- `qa-tidewave`: include the SQL query result, the `project_eval` return value, or the log line excerpt.
+- `qa-backend`: include the HTTP status + body excerpt, CLI exit code + output, or log line.
+
+No scenario is reported PASS on faith. Load `/core:anti-fabrication` at agent start.
+
+## References
+
+- `references/gherkin-format.md` — accepted Gherkin dialect, parsing rules, rejection criteria, full example.
+- `references/stack-detection.md` — probe tree and worker assignment matrix.
+- `references/validation-loop.md` — full RED/GREEN/REFACTOR mapping with worked examples; quotes `/core:tdd`.
+- `references/delta-format.md` — `BEES REQUESTS:` block grammar and field rules.
+- `templates/user-story.md` — copyable Gherkin starting file.

--- a/plugins/tools/qa/skills/qa/references/delta-format.md
+++ b/plugins/tools/qa/skills/qa/references/delta-format.md
@@ -1,0 +1,108 @@
+# BEES REQUESTS Block Format
+
+The exact shape workers emit and the lead aggregates before routing to the `bees-manager` agent.
+
+This grammar mirrors the input contract in `plugins/core/skills/bees/agents/bees-manager.md` lines 33–41 — that agent file is the source of truth. Keep this reference and that agent in sync; if the lead routes a block the manager cannot parse, the contract is broken.
+
+## Block Shape
+
+A worker's final report contains exactly one `BEES REQUESTS:` block. The block has a header line naming the cwd, followed by one entry per line. Empty list (no deltas) means PASS — the worker writes `BEES REQUESTS (cwd: <repo>): none` or omits the block entirely.
+
+```
+BEES REQUESTS (cwd: <absolute-repo-root>):
+- new title="<title>" body="<body>" priority=P<N> external-ref="<url-or-path-fragment>" labels="<csv>"
+- close github-<N> reason="<reason>"
+- dep add github-<NEW> --blocks-on github-<EXISTING>
+- update github-<N> <field>="<value>"
+```
+
+The lead concatenates blocks from every worker in the run before routing.
+
+## Field Rules
+
+### `new` entries (the only kind workers emit during default validation)
+
+| Field | Required | Format | Notes |
+|---|---|---|---|
+| `title` | yes | `qa: <scenario-name> — <failing-assertion>` | Keep under ~100 chars. Use the scenario name exactly as written in the story. |
+| `body` | yes | Free-form multi-line text | MUST include observed value, expected value, reproduction steps, and tool-output evidence. |
+| `priority` | yes | `P0`–`P3` | `P0` only for golden-path scenarios that 100% block users. Default to `P2` for golden-path deltas, `P3` for edge-case deltas. |
+| `external-ref` | yes | `<repo>/docs/user-stories/<slug>.md#<scenario>` | Anchors the issue back to the story scenario. `bees-manager` dedupes on external-ref. |
+| `labels` | yes | Comma-separated list | Always includes `qa`. Add `golden-path` for the primary happy-path scenario. Add `edge` for failure-path scenarios. |
+
+### `close` and `dep add` entries
+
+Workers do NOT emit these. Only the lead may add them, after the fix loop completes. The lead emits a `close github-<N> reason="fixed in qa-fixer round <K>"` per scenario that went from RED to GREEN, batched into the same `bees-manager` invocation as any further `new` entries from the post-fix re-run.
+
+## Body Template
+
+Workers populate this template; `qa-lead` does not rewrite it.
+
+```
+Observed: <one-line summary of what the assertion captured>
+Expected: <one-line summary of what the scenario said>
+
+Scenario: <scenario name>
+Step:     <the failing Then clause, verbatim>
+
+Reproduction:
+1. <first preceding Given/When>
+2. <second preceding Given/When>
+…
+
+Evidence (<tool>):
+<tool output excerpt — snapshot text / SQL result / HTTP response / log line>
+```
+
+Evidence is mandatory. A `new` entry without an `Evidence:` section is rejected by the lead before routing — it would let a fabricated delta slip through.
+
+## Worker Output Discipline
+
+Each worker's final message contains, in this order:
+
+1. Skill-load proof (one sentence quoted per loaded skill).
+2. Stack triple (echoed from the lead's brief, for traceability).
+3. Per-scenario report:
+   - Scenario name.
+   - PASS/FAIL.
+   - For PASS: a one-line summary + tool-output evidence.
+   - For FAIL: the full body template above.
+4. The single `BEES REQUESTS:` block (or `none`).
+
+The lead's aggregator parses block #4 from every worker. It does not parse evidence text — evidence is the worker's contract with the user, not with the manager.
+
+## Deduplication
+
+The lead dedupes by `(title, external-ref)` before routing. When two workers (e.g. `qa-playwright` + `qa-tidewave` correlated on the same scenario) flag overlapping failures, the lead keeps one entry, concatenates both `body` fields under separate `Evidence:` sections, and routes a single `new` to the manager.
+
+## Routing
+
+Once aggregated, the lead spawns ONE `bees-manager` subagent (subagent_type `bees-manager`) with the full block as its input. Per `bees-manager` line 28: "The lead spawns ONE `bees-manager` per batch — never two in parallel against the same DB." For two repos in one run (which `/qa` does not currently support), serialize the manager calls.
+
+## Example
+
+Two workers, one scenario, two failing assertions, deduped to one entry:
+
+```
+BEES REQUESTS (cwd: /Users/dev/storefront):
+- new title="qa: Guest can complete an order — orders.total off by one" body="Observed: orders.total=1499 in DB. Expected: 1500 per scenario.
+
+Scenario: Guest can complete an order
+Step:     And the orders table contains a row with email \"guest@example.com\" and total 1500
+
+Reproduction:
+1. Given a guest user on the cart page with one \"Coffee Mug\" in the cart
+2. When they click \"Place order\"
+
+Evidence (tidewave execute_sql_query):
+SELECT email, total FROM orders ORDER BY id DESC LIMIT 1;
+ email                | total
+----------------------+-------
+ guest@example.com    |  1499
+
+Evidence (playwright browser_snapshot):
+heading \"Order confirmed\" present at #order-summary
+" priority=P2 external-ref="storefront/docs/user-stories/checkout.md#Guest-can-complete-an-order" labels="qa,golden-path"
+```
+
+The manager files this once; both pieces of evidence travel with it.

--- a/plugins/tools/qa/skills/qa/references/gherkin-format.md
+++ b/plugins/tools/qa/skills/qa/references/gherkin-format.md
@@ -1,0 +1,127 @@
+# Gherkin Format Reference
+
+The dialect `/qa` accepts, the parsing rules, and the rejection criteria.
+
+## File Layout
+
+User stories live at `docs/user-stories/<slug>.md` in the target repo. One story per file. The slug is kebab-case and becomes the file name.
+
+The file is a markdown document with **at least one** fenced Gherkin block:
+
+````markdown
+# <Human-readable title>
+
+Optional prose context — not parsed.
+
+```gherkin
+Feature: <one-line feature title>
+
+  Background:
+    Given <shared precondition 1>
+    And <shared precondition 2>
+
+  Scenario: <scenario name>
+    Given <precondition>
+    When <action>
+    Then <expected outcome>
+
+  Scenario: <another scenario name>
+    Given <precondition>
+    When <action>
+    And <another action>
+    Then <expected outcome>
+    And <another expectation>
+```
+````
+
+The lead concatenates the content of every ```gherkin fenced block in the file before parsing. Prose outside fences is informational.
+
+## Accepted Keywords
+
+| Keyword | Purpose | Cardinality |
+|---|---|---|
+| `Feature:` | Top-level title. One per file. | Exactly 1 (across all blocks combined). |
+| `Background:` | Shared steps applied before every `Scenario:` in the file. | 0 or 1. |
+| `Scenario:` | One discrete validation work item. Becomes one worker invocation. | At least 1. |
+| `Scenario Outline:` | Parameterized scenario. Pairs with `Examples:`. | 0+. |
+| `Examples:` | Table of inputs for the immediately preceding `Scenario Outline:`. | 0+, one per outline. |
+| `Given` | Precondition step. | 0+ per scenario or background. |
+| `When` | Action step. | 1+ per scenario. |
+| `Then` | Expectation step. | 1+ per scenario. |
+| `And` | Continuation of the immediately preceding `Given`/`When`/`Then`. | 0+. |
+| `But` | Negative continuation of the preceding step. Treated like `And`. | 0+. |
+| `#` | Comment line. Ignored by the parser. | 0+. |
+
+Tags (lines starting with `@`) are tolerated but currently ignored — they have no effect on worker assignment.
+
+## Parsing Rules
+
+1. **Feature title** is the text after `Feature:` on the same line. Required.
+2. **Background steps** apply to every `Scenario:` and `Scenario Outline:` in the same file. They are prepended (in declared order) to each scenario's step list before worker assignment.
+3. **Scenario name** is the text after `Scenario:` on the same line. Used in `BEES REQUESTS:` titles. Must be non-empty.
+4. **Step continuation**: `And` and `But` inherit the keyword of the most recent `Given`/`When`/`Then` line.
+5. **`Scenario Outline:` expansion**: one work item per row in the `Examples:` table. The `<placeholder>` markers in steps are substituted from each row before dispatch.
+6. **No nested fences**: a ```gherkin block cannot contain another ``` fence.
+7. **No code, no comments inside steps**: a step is a single line of plain text after its keyword. Multiline step text and data tables are NOT supported in v0.1.0 — keep steps to one line each.
+
+## Rejection Criteria
+
+The `qa-lead` aborts (no workers spawned) if any of the following hold. Each rejection includes the rule number in the error report so the user can fix the file.
+
+1. File does not exist at the resolved path.
+2. Path is outside `docs/user-stories/` in the target repo.
+3. No ```gherkin fenced block present.
+4. Zero `Feature:` lines, or more than one.
+5. Zero `Scenario:` / `Scenario Outline:` blocks.
+6. A `Scenario:` has zero `When` lines or zero `Then` lines.
+7. An `And` or `But` line appears before any `Given`/`When`/`Then` in its scenario.
+8. A `Scenario Outline:` is missing its `Examples:` table, or the table is empty, or a step references a `<placeholder>` not present in the table header.
+9. A multiline step (continuation without a leading keyword) is detected.
+10. `Background:` contains a `When` or `Then` (Background may only contain `Given` and continuations).
+
+## Worker Assignment Hints
+
+The lead inspects each fully-expanded scenario's step text to assign a worker, per `references/stack-detection.md`:
+
+- Step text mentions a URL, page, button, link, form, click, type, see, scroll, navigate → likely UI → `qa-playwright`.
+- Step text mentions a record, row, query, schema, GenServer, log, Phoenix module, Ecto, supervisor → likely Phoenix backend → `qa-tidewave`.
+- Step text mentions an endpoint, status code, response body, JSON, HTTP, CLI command, exit code → generic backend → `qa-backend`.
+- Mixed → multiple workers correlate by scenario name.
+
+The hints are heuristic. When uncertain, the lead asks via AskUserQuestion before spawning.
+
+## Full Example
+
+````markdown
+# Checkout flow
+
+Validates the guest checkout golden path against a Phoenix LiveView storefront.
+
+```gherkin
+Feature: Guest checkout
+
+  Background:
+    Given the storefront is running at http://localhost:4000
+    And the product "Coffee Mug" exists with price 1500 cents in inventory
+
+  Scenario: Guest can complete an order with a single item
+    Given a guest user on the cart page with one "Coffee Mug" in the cart
+    When they click "Checkout"
+    And they fill in "Email" with "guest@example.com"
+    And they fill in "Shipping address" with "123 Main St"
+    And they click "Place order"
+    Then they see "Order confirmed"
+    And the orders table contains a row with email "guest@example.com" and total 1500
+
+  Scenario: Cart-empty guard prevents checkout
+    Given a guest user on the cart page with an empty cart
+    When they click "Checkout"
+    Then they see "Your cart is empty"
+    And the URL stays on /cart
+```
+````
+
+The lead expands this into two work items:
+
+- Scenario 1 → split: `qa-playwright` covers the UI assertions ("see Order confirmed"), `qa-tidewave` covers the DB assertion ("orders table contains a row…"). Correlated by scenario name.
+- Scenario 2 → `qa-playwright` only.

--- a/plugins/tools/qa/skills/qa/references/stack-detection.md
+++ b/plugins/tools/qa/skills/qa/references/stack-detection.md
@@ -1,0 +1,77 @@
+# Stack Detection
+
+How `qa-lead` decides which worker handles each scenario.
+
+## Probe Tree
+
+The lead runs probes in this order, from the target repo root, before decomposing scenarios. Each probe is read-only.
+
+```
+1. Phoenix?           → look for mix.exs AND (config/runtime.exs OR lib/<app>_web/)
+2. Web UI?            → look for package.json AND (playwright.config.{ts,js,mjs} OR a web framework dep)
+3. Generic backend?   → look for Cargo.toml, go.mod, pyproject.toml, build.zig, Gemfile, pom.xml
+4. Container runtime? → look for Dockerfile, docker-compose.yml (informational only)
+```
+
+The result is recorded as a triple:
+
+```
+{ ui: <bool>, phoenix: <bool>, generic_backend: <bool> }
+```
+
+## Probe Commands
+
+```bash
+# Phoenix
+test -f mix.exs && echo "mix-present"
+test -f config/runtime.exs && echo "phx-runtime-present"
+ls lib/*_web 2>/dev/null
+
+# Web UI
+test -f package.json && echo "node-present"
+ls playwright.config.* 2>/dev/null
+
+# Generic backends
+for f in Cargo.toml go.mod pyproject.toml build.zig Gemfile pom.xml; do
+  test -f "$f" && echo "$f"
+done
+```
+
+The lead runs these via the Bash tool. Do not infer presence from memory — always probe.
+
+## Worker Assignment Matrix
+
+| Stack triple | UI scenario step | Backend scenario step | Mixed scenario |
+|---|---|---|---|
+| `{ui: true, phoenix: true}` | qa-playwright | qa-tidewave | qa-playwright + qa-tidewave |
+| `{ui: true, phoenix: false}` | qa-playwright | qa-backend | qa-playwright + qa-backend |
+| `{ui: false, phoenix: true}` | qa-tidewave (read-only headless asserts only) or reject | qa-tidewave | qa-tidewave |
+| `{ui: false, phoenix: false}` | qa-backend (curl + WebFetch only) or reject | qa-backend | qa-backend |
+
+A "UI scenario step" mentions clicks, page elements, navigation, or visible text. A "backend scenario step" mentions DB rows, log lines, internal state, HTTP status codes, or response payloads. The hints come from `references/gherkin-format.md`.
+
+## Mixed-Scenario Correlation
+
+When a single `Scenario:` block has both UI and backend `Then` clauses, the lead spawns two workers and correlates by exact scenario name (case- and whitespace-preserving). The bees-manager batch deduplicates by external-ref + title so a delta filed by both workers does not double-file.
+
+The lead waits for BOTH workers to complete before routing to `bees-manager`. A scenario passes only if both workers report PASS.
+
+## Reject Conditions
+
+The lead refuses to proceed if:
+
+- The story has UI scenarios but the stack triple has `ui: false` AND `phoenix: false`. There is nothing to drive.
+- The story has no scenarios applicable to the detected stack.
+- A required runtime is not running (Playwright MCP unreachable, Phoenix app not responding on its declared URL). The lead probes the URL with a short curl before dispatching.
+
+Reject reports name the missing piece so the user can start the app or install the MCP.
+
+## URL Resolution
+
+The `Background:` block of the story is the authoritative source for the app URL. The lead extracts URLs from `Given the <app|storefront|service> is running at <url>` patterns. If the Background omits the URL, the lead falls back to:
+
+- `localhost:4000` for Phoenix
+- `localhost:3000` for Node/React/Next
+- `$QA_APP_URL` environment variable as a last resort
+
+If no URL can be resolved, the lead rejects with a "missing app URL" error and points the user to the `Background:` convention.

--- a/plugins/tools/qa/skills/qa/references/validation-loop.md
+++ b/plugins/tools/qa/skills/qa/references/validation-loop.md
@@ -1,0 +1,182 @@
+# QA Validation Loop
+
+How Gherkin scenarios map onto the `/core:tdd` Red-Green-Refactor cycle, and how the `--fix` loop drives a scenario from RED to GREEN.
+
+## The Red-Green-Refactor Cycle
+
+Quoted verbatim from `plugins/core/skills/tdd/SKILL.md` lines 32–55:
+
+> The micro-cycle is a three-state machine:
+>
+> ```
+>     ┌──────────────────────────────────────┐
+>     │                                      │
+>     ▼                                      │
+>   [RED] ──── write minimal code ────► [GREEN] ──── refactor ────► [GREEN]
+>     ▲                                                                │
+>     │                                                                │
+>     └──────────── write next failing test ◄──────────────────────────┘
+> ```
+>
+> **RED**: Write a test that fails. Confirm it fails for the *right reason* — the missing behavior, not a syntax error or wrong import.
+>
+> **GREEN**: Make the test pass with the simplest change possible. "Sinful" code is fine — hardcoded values, copy-paste, whatever gets green fastest.
+>
+> **REFACTOR**: Clean up while all tests stay green. Remove duplication between test and production code. Improve names. Extract methods. This is where design emerges.
+>
+> Rules:
+> - Never write production code without a failing test
+> - Never write more test code than needed to fail
+> - Never write more production code than needed to pass
+
+In `/qa`, the Gherkin file IS the outer-loop acceptance test (per `/core:tdd` Double-Loop TDD). Each scenario is one acceptance assertion. The fix loop, when enabled, drives an inner Red-Green-Refactor cycle to make a failing scenario pass.
+
+## Gherkin → TDD State Mapping
+
+| Gherkin clause | TDD role | Worker behavior |
+|---|---|---|
+| `Background: Given <precondition>` | Shared fixture / setup | Bring the app into the stated state, or assert it already holds. If setup itself fails, the scenario is reported BLOCKED, not RED — the test couldn't run. |
+| `Given <precondition>` | Test setup (scenario-specific) | Same as Background, scoped to the scenario. |
+| `When <action>` | Exercise the system under test | Drive the action via the worker's MCP / HTTP / CLI tools. |
+| `Then <expectation>` | Assertion | Capture observed behavior with tool-output evidence. Compare against the stated expectation. |
+| `Then` matches | GREEN | Report PASS for that step with evidence (snapshot text, SQL row, HTTP response). |
+| `Then` mismatches | RED | Emit a `BEES REQUESTS:` entry. Continue to the next `Then` in the scenario if more remain. |
+| All `Then` clauses GREEN | Scenario PASS | Report PASS for the scenario. |
+| Any `Then` clause RED | Scenario FAIL | Report FAIL with the list of failing assertions. |
+
+## Default Run (no `--fix`)
+
+```
+┌─────────────────┐
+│ /qa <story>     │
+└────────┬────────┘
+         ▼
+┌─────────────────┐
+│ qa-lead parses, │
+│ detects stack,  │
+│ spawns workers  │
+└────────┬────────┘
+         ▼
+┌─────────────────┐    PASS    ┌──────────────────────┐
+│ workers run     ├───────────►│ scenario passes      │
+│ scenarios       │            │ (no delta)           │
+└────────┬────────┘            └──────────────────────┘
+         │ FAIL
+         ▼
+┌─────────────────┐
+│ worker emits    │
+│ BEES REQUESTS:  │
+└────────┬────────┘
+         ▼
+┌─────────────────┐
+│ lead aggregates,│
+│ routes to       │
+│ bees-manager    │
+└────────┬────────┘
+         ▼
+┌─────────────────┐
+│ Report to user: │
+│ filed issue IDs │
+│ + PASS/FAIL list│
+└─────────────────┘
+```
+
+The loop stops here. Filed issues are picked up via the regular `/core:bees` flow.
+
+## Fix Run (`--fix`) — adversarial TDD pair
+
+The fix loop uses two opposed agents per issue. They are intentionally split so neither can quietly relax the contract:
+
+- **qa-test-writer** — writes ONE failing test. MAY edit tests only. MUST NOT touch production code.
+- **qa-implementer** — writes the smallest production-code change to make the test pass. MAY edit production code only. MUST NOT touch tests.
+
+The lead inspects `git diff --name-only` between phases. Any boundary crossing aborts the round with a `BLOCKED: <agent> crossed boundary` report.
+
+```
+… (default run through bees-manager) …
+         │
+         ▼
+┌──────────────────────────┐
+│ For each filed bees      │
+│ issue: detect test       │
+│ boundary, snapshot diff  │
+└────────────┬─────────────┘
+             ▼
+┌──────────────────────────┐    ARTIFACT  ┌──────────────────────────┐
+│ Spawn qa-test-writer:    ├─────────────►│ {path, test_name,        │
+│ writes ONE failing test  │              │  runner_command}         │
+│ in test/ ONLY            │              │ + verbatim RED output    │
+└────────────┬─────────────┘              └────────────┬─────────────┘
+             ▼                                         ▼
+┌──────────────────────────┐                ┌──────────────────────────┐
+│ Lead: git diff --name-   │  any non-test  │ REJECT — roll back       │
+│ only HEAD.               ├───────────────►│ test-writer changes,     │
+│ All paths must be in     │  path appears  │ halt this issue's loop   │
+│ test/.                   │                │                          │
+└────────────┬─────────────┘                └──────────────────────────┘
+             │ clean
+             ▼
+┌──────────────────────────┐
+│ Spawn qa-implementer:    │
+│ given artifact (NOT      │
+│ failure text). Writes    │
+│ smallest fix outside     │
+│ test/.                   │
+└────────────┬─────────────┘
+             ▼
+┌──────────────────────────┐                ┌──────────────────────────┐
+│ Lead: git diff --name-   │  any NEW test/ │ REJECT — roll back       │
+│ only HEAD.               │  path appears  │ implementer changes      │
+│ No new test-dir paths    ├───────────────►│ (keep test in place),    │
+│ allowed.                 │                │ halt this issue's loop   │
+└────────────┬─────────────┘                └──────────────────────────┘
+             │ clean
+             ▼
+┌──────────────────────────┐    GREEN       ┌──────────────────────────┐
+│ Re-run originating       ├───────────────►│ scenario passes — lead   │
+│ validator                │                │ queues close for         │
+│ (qa-playwright/tidewave/ │                │ bees-manager batch       │
+│  backend)                │                │                          │
+└────────────┬─────────────┘                └──────────────────────────┘
+             │ still RED
+             ▼
+┌──────────────────────────┐
+│ round += 1               │
+│ if round == 3 → halt +   │
+│ report stall             │
+└──────────────────────────┘
+```
+
+Each agent honors the Three Laws (per `/core:tdd`): no production code without a failing test, no more test than is sufficient to fail, no more production code than is sufficient to pass. The boundary makes the laws structurally enforced rather than self-policed. Neither agent commits; the lead reports the diff and the user decides.
+
+## Worked Example
+
+Story scenario:
+
+```gherkin
+Scenario: Guest can complete an order
+  Given a guest user on the cart page with one "Coffee Mug" in the cart
+  When they click "Place order"
+  Then they see "Order confirmed"
+  And the orders table contains a row with email "guest@example.com" and total 1500
+```
+
+Round 1 (qa-playwright + qa-tidewave correlated):
+
+- `qa-playwright` drives the UI; `Then "Order confirmed"` is **GREEN** — snapshot contains "Order confirmed".
+- `qa-tidewave` runs `SELECT email, total FROM orders ORDER BY id DESC LIMIT 1` — returns `("guest@example.com", 1499)`. Expected `1500`. **RED**. Emits:
+
+```
+BEES REQUESTS (cwd: /repo):
+- new title="qa: Guest can complete an order — orders.total off by one" body="Observed total=1499, expected 1500. SQL: SELECT email, total FROM orders ORDER BY id DESC LIMIT 1; result: (guest@example.com, 1499). Likely a cents-vs-tax rounding bug in OrderTotals.calc/2." priority=P2 external-ref="repo/docs/user-stories/checkout.md#Guest-can-complete-an-order" labels="qa,golden-path"
+```
+
+`bees-manager` files `github-42`. Default run ends here.
+
+With `--fix`:
+
+- `qa-test-writer` reads `github-42`. Writes `test/orders/totals_test.exs` asserting `OrderTotals.calc/2` returns 1500 for the fixture. Runs it. RED for the right reason. Returns artifact `{path: "test/orders/totals_test.exs", test_name: "OrderTotalsTest test calc/2 returns 1500 for the Coffee Mug fixture", runner_command: "mix test test/orders/totals_test.exs:23"}` + verbatim failure output.
+- Lead `git diff --name-only`: only `test/orders/totals_test.exs` appeared. Boundary clean.
+- `qa-implementer` receives only the artifact (no failure text). Reads the test file (read-only). Runs the targeted test — RED. Locates `lib/orders/totals.ex`. Writes the minimal fix. Runs the targeted test — GREEN. Runs `mise run test` — green.
+- Lead `git diff --name-only`: `test/orders/totals_test.exs` (from test-writer) + `lib/orders/totals.ex` (from implementer). No NEW test paths. Boundary clean.
+- Validator re-runs; SQL returns `1500`. Scenario PASSES. Lead routes `close github-42 reason="fix loop round 1: scenario now passes"` to `bees-manager`.

--- a/plugins/tools/qa/skills/qa/templates/user-story.md
+++ b/plugins/tools/qa/skills/qa/templates/user-story.md
@@ -1,0 +1,32 @@
+# <Feature title — human readable>
+
+<Optional prose explaining the feature, the user, and why this scenario matters. Not parsed by `/qa`.>
+
+```gherkin
+Feature: <one-line feature title>
+
+  Background:
+    Given the <app|service> is running at <http://localhost:PORT>
+    And <any shared seed data or auth state>
+
+  Scenario: <Golden-path scenario — the single most important happy flow>
+    Given <starting condition>
+    When <user action>
+    And <another action if needed>
+    Then <observable expected outcome>
+    And <another expectation if the outcome has multiple facets>
+
+  Scenario: <Edge / error scenario — optional, repeat as needed>
+    Given <starting condition>
+    When <user action>
+    Then <expected guardrail or error message>
+```
+
+## Notes for authors
+
+- Keep each `Scenario:` focused on one user-visible outcome. If a scenario has more than ~5 `Then` clauses, split it.
+- `Background:` is shared by every scenario in the file. Put the app URL there.
+- The golden-path scenario goes first. Edge cases follow.
+- `When` describes user actions; `Then` describes observable outcomes. Don't put internal implementation details in `Then` — assert on what a user can see (UI text, an HTTP response field, a row in a public table), not on private state.
+- Steps are single-line. No multi-line `When` or `Then` in v0.1.0.
+- The parser rules and rejection criteria are in `references/gherkin-format.md` of the `/qa:qa` skill.

--- a/plugins/tools/qa/skills/sources.md
+++ b/plugins/tools/qa/skills/sources.md
@@ -1,0 +1,27 @@
+# Sources
+
+## qa skill
+
+Internal sources — this skill is composed of conventions from other skills in this marketplace.
+
+- **`/core:tdd`** — Test-Driven Development methodology. Source of the Red-Green-Refactor cycle quoted verbatim in `references/validation-loop.md`. Path: `plugins/core/skills/tdd/SKILL.md`.
+- **`/core:bees`** — Bees issue tracker CLI. Source of the `bees new`/`bees close`/`bees dep add` syntax referenced from `references/delta-format.md`. Path: `plugins/core/skills/bees/SKILL.md`.
+- **`/core:bees` bees-manager agent** — The serialized-writer agent that consumes `BEES REQUESTS:` blocks. Source of the input contract grammar mirrored in `references/delta-format.md`. Path: `plugins/core/skills/bees/agents/bees-manager.md`.
+- **`/playwright:playwright`** — Playwright MCP server skill. Source of the MCP tool names used by the `qa-playwright` agent. Path: `plugins/tools/playwright/skills/playwright/SKILL.md`.
+- **`/elixir:tidewave`** — Tidewave MCP skill for Phoenix runtime introspection. Source of the MCP tool names used by the `qa-tidewave` agent. Path: `plugins/languages/elixir/skills/tidewave/SKILL.md`.
+- **`/elixir:phoenix`** — Phoenix application conventions. Loaded by `qa-tidewave` for context on Phoenix module layout, Ecto schemas, and LiveView assertions. Path: `plugins/languages/elixir/skills/phoenix/SKILL.md`.
+- **`/core:anti-fabrication`** — Required by every QA agent. Source of the "every claim requires tool output" rule. Path: `plugins/core/skills/anti-fabrication/SKILL.md`.
+
+## External
+
+- **Gherkin reference syntax** — Cucumber's Gherkin specification. The dialect in `references/gherkin-format.md` is a strict subset: Feature / Background / Scenario / Scenario Outline / Examples / Given / When / Then / And / But, single-line steps, no doc strings, no data tables in v0.1.0. URL: https://cucumber.io/docs/gherkin/reference/ (accessed during plan authoring, 2026-05-16).
+
+## Plugin metadata
+
+- **Plugin**: qa
+- **Version**: 0.1.0
+- **Description**: QA team that validates a running application against Gherkin user stories using Playwright and Tidewave
+- **Skills count**: 1 (qa)
+- **Agents count**: 7 (qa-lead, qa-author, qa-playwright, qa-tidewave, qa-backend, qa-test-writer, qa-implementer)
+- **Commands count**: 2 (qa, new-story)
+- **Created**: 2026-05-16


### PR DESCRIPTION
- New tools plugin at `plugins/tools/qa/` (v0.1.0)
- `/qa <story-path> [--fix]` command spawns `qa-lead` (opus) to parse a Gherkin user story, detect stack, decompose scenarios, dispatch workers
- `/qa:new-story <slug>` command spawns `qa-author` (haiku) to interview the user and write a parser-valid Gherkin file to `docs/user-stories/<slug>.md`
- Validators: `qa-playwright` (UI via Playwright MCP), `qa-tidewave` (Phoenix runtime via Tidewave MCP), `qa-backend` (generic HTTP/CLI/log fallback)
- Adversarial TDD fix pair: `qa-test-writer` may only edit tests, `qa-implementer` may only edit production code; `qa-lead` inspects `git diff --name-only` between phases to enforce the boundary
- Workers emit `BEES REQUESTS:` blocks; `qa-lead` aggregates and routes through the existing `bees-manager` agent into the repo-local `.bees/` DB
- 5 references (gherkin-format, stack-detection, validation-loop, delta-format), 1 template (user-story.md), 1 sources.md
- Bumped `all-skills` meta-plugin to 0.4.7 to include the new qa skill
- Passes `mise test`, `mise run test:plugin qa`, `mise run gitleaks`; qa skill scored 11/12 on `test:skills-quality`