### PR TITLE
chore(elixir): update tidewave to 0.5.6 with MCP setup references

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -80,7 +80,7 @@
       "source": "./plugins/languages/elixir",
       "strict": true,
       "description": "Elixir development skills: Phoenix, OTP, Ports, Ecto, Tidewave MCP, testing, configuration, style",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "category": "language",
       "keywords": ["elixir", "phoenix", "otp", "ports", "ecto", "style", "beam"]
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/languages/elixir/.claude-plugin/plugin.json
+++ b/plugins/languages/elixir/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "elixir",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Elixir development skills: Phoenix, OTP, Ports, Ecto, Tidewave MCP, testing, configuration, style, and anti-patterns",
   "author": {
     "name": "vinnie357"

--- a/plugins/languages/elixir/skills/sources.md
+++ b/plugins/languages/elixir/skills/sources.md
@@ -59,17 +59,17 @@ This file documents the sources used to create the elixir plugin skills.
 ### Tidewave Hex Package
 - **URL**: https://hex.pm/packages/tidewave
 - **Purpose**: Package listing and version information for Tidewave
-- **Date Accessed**: 2026-02-21
-- **Key Topics**: Version history, installation, license (Apache 2.0)
+- **Date Accessed**: 2026-05-16
+- **Key Topics**: Version history, installation, license (Apache 2.0). Current version 0.5.6 (released 2026-03-13)
 
 ### Tidewave Documentation
 - **URL**: https://hexdocs.pm/tidewave
 - **Purpose**: Official Tidewave documentation for MCP dev tools integration
-- **Date Accessed**: 2026-02-21
+- **Date Accessed**: 2026-05-16
 - **Key Topics**:
   - Installation (Igniter and manual)
   - MCP server setup and client configuration
-  - Available MCP tools (project_eval, execute_sql_query, get_ecto_schemas, get_docs, etc.)
+  - Available MCP tools (project_eval, execute_sql_query, get_ecto_schemas, get_ash_resources, get_docs, etc.)
   - Plug configuration options
   - LiveView debug annotations
   - Security considerations
@@ -77,8 +77,32 @@ This file documents the sources used to create the elixir plugin skills.
 ### Tidewave GitHub Repository
 - **URL**: https://github.com/tidewave-ai/tidewave_phoenix
 - **Purpose**: Source code, README, and community documentation
-- **Date Accessed**: 2026-02-21
+- **Date Accessed**: 2026-05-16
 - **Key Topics**: Installation walkthrough, editor-specific MCP setup, troubleshooting
+
+### Tidewave CHANGELOG.md
+- **URL**: https://github.com/tidewave-ai/tidewave_phoenix/blob/main/CHANGELOG.md
+- **Purpose**: Authoritative release notes for version tracking
+- **Date Accessed**: 2026-05-16
+- **Key Topics**:
+  - v0.5.6 (2026-03-13): adds `:extra_apps` config for additional app discovery
+  - v0.5.5 (2026-02-10): Spark metadata in `get_ecto_schemas`, new `get_ash_resources` tool, log level filtering on `get_logs`
+  - v0.4.0 (2025-08-19): switched to streamable HTTP MCP protocol — SSE deprecated
+
+### Tidewave Editor MCP Setup Pages
+- **URLs**:
+  - https://hexdocs.pm/tidewave/mcp_claude_code.html
+  - https://hexdocs.pm/tidewave/mcp_codex.html
+  - https://hexdocs.pm/tidewave/mcp_opencode.html
+- **Purpose**: Per-editor MCP setup commands and JSON snippets extracted into `tidewave/references/mcp-setup.md`
+- **Date Accessed**: 2026-05-16
+- **Key Topics**: `claude mcp add --transport http`, `codex mcp add --url`, opencode `mcp` config block
+
+### Gemini CLI MCP Servers Documentation
+- **URL**: https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md
+- **Purpose**: `httpUrl` field shape for Gemini CLI's `~/.gemini/settings.json` — upstream Tidewave docs do not cover Gemini CLI (no `mcp_gemini_cli.html` page)
+- **Date Accessed**: 2026-05-16
+- **Key Topics**: `mcpServers.<name>.httpUrl` for streamable HTTP, `gemini mcp add --transport http` CLI form, user vs project settings paths
 
 ## OTP Skill
 
@@ -279,4 +303,4 @@ This file documents the sources used to create the elixir plugin skills.
 - **Description**: Elixir development skills: Phoenix, OTP, Ports, Ecto, Style, testing, configuration, anti-patterns, and Tidewave MCP dev tools
 - **Skills**: 9 skills covering Elixir language, framework, and best practices
 - **Created**: 2025-11-15
-- **Updated**: 2026-05-06
+- **Updated**: 2026-05-16

--- a/plugins/languages/elixir/skills/tidewave/SKILL.md
+++ b/plugins/languages/elixir/skills/tidewave/SKILL.md
@@ -8,7 +8,19 @@ license: MIT
 
 Tidewave is a dev tool by Dashbit that connects AI coding assistants to running Phoenix applications via the Model Context Protocol (MCP). It exposes runtime introspection tools: Ecto schemas, code execution, documentation lookup, log inspection, and SQL queries.
 
-Current version: `~> 0.5` (v0.5.6 released 2026-03-13)
+Current version: `~> 0.5` (v0.5.6 released 2026-03-13 — adds `:extra_apps` plug option)
+
+## When connected, prefer MCP tools over web fetches
+
+**When Tidewave MCP is connected to an Elixir/Phoenix project, route documentation, source, and runtime queries through the MCP tools — not WebFetch or hexdocs.pm.**
+
+- `get_docs` instead of WebFetch on `hexdocs.pm/<package>/<Module>.html`
+- `search_package_docs` instead of broader hex-doc searches
+- `get_source_location` instead of reading `deps/<package>/lib/...` with Read
+- `execute_sql_query` instead of shelling into `psql`
+- `project_eval` instead of running `iex -S mix` snippets
+
+Why: MCP tool calls return results pinned to the exact versions in the project's `mix.lock`, complete in a single round-trip, and skip HTML→markdown conversion and page chrome — significantly fewer tokens per lookup than WebFetch, and the answer is guaranteed to match the running app rather than whatever version is on hexdocs.pm today.
 
 ## Installation
 
@@ -55,32 +67,11 @@ Apply the manual steps to the application defining the Phoenix endpoint (typical
 
 ## MCP Server Configuration
 
-Tidewave exposes an MCP server at `/tidewave/mcp` on the Phoenix app's port. The transport type is HTTP (streamable).
+Tidewave exposes an MCP server at `/tidewave/mcp` on the Phoenix app's port. The transport type is HTTP (streamable) — SSE was removed in v0.4.0. Tidewave is unauthenticated; decline any "Authenticate" prompt the editor offers.
 
 Default URL: `http://localhost:4000/tidewave/mcp`
 
-### Claude Code
-
-```bash
-claude mcp add --transport http tidewave http://localhost:4000/tidewave/mcp
-```
-
-Add to `CLAUDE.md` to encourage MCP tool usage:
-
-```markdown
-Always use Tidewave's tools for evaluating code, querying the database, etc.
-Use `get_docs` to access documentation and `get_source_location` to find module/function definitions.
-```
-
-### Other Editors
-
-| Editor | Config File | URL Key |
-|--------|-------------|---------|
-| Cursor | `.cursor/mcp.json` | `mcpServers.tidewave.url` |
-| VS Code | `.vscode/mcp.json` | `servers.tidewave.url` |
-| Zed | Zed `settings.json` | `context_servers.tidewave.settings.url` |
-
-All use URL: `http://localhost:4000/tidewave/mcp`
+See `references/mcp-setup.md` for verbatim setup commands and JSON config for **Claude Code, Codex CLI, Gemini CLI, and opencode**, plus a `curl` ping for raw verification and a troubleshooting table.
 
 ## MCP Tools Reference
 
@@ -99,6 +90,8 @@ All use URL: `http://localhost:4000/tidewave/mcp`
 **Note**: `search_package_docs` may not be available in all frameworks. Verify availability for your setup.
 
 ### Usage Patterns
+
+See "When connected, prefer MCP tools over web fetches" at the top of this skill for the routing rule.
 
 Introspect schemas before writing queries:
 ```
@@ -130,6 +123,7 @@ end
 | `allow_remote_access` | `false` | Allow connections from non-localhost |
 | `inspect_opts` | `[]` | Options passed to `Kernel.inspect/2` for output formatting |
 | `team` | `nil` | Team configuration (e.g., `[id: "my-company"]`) |
+| `extra_apps` | `[]` | Additional OTP apps to include in source/module discovery (v0.5.6+) |
 
 ## CLI App (Standalone MCP Server)
 
@@ -164,7 +158,7 @@ config :phoenix,
   debug_attributes: true
 ```
 
-Requires Phoenix LiveView v1.1+ (current: 1.1.27).
+Requires Phoenix LiveView v1.1+.
 
 ## Security
 

--- a/plugins/languages/elixir/skills/tidewave/references/mcp-setup.md
+++ b/plugins/languages/elixir/skills/tidewave/references/mcp-setup.md
@@ -1,0 +1,123 @@
+# Tidewave MCP — Editor Setup
+
+Why connect: once Tidewave MCP is wired, the assistant calls `get_docs` /
+`search_package_docs` / `get_source_location` directly against the running
+Phoenix app — version-pinned to `mix.lock`, single round-trip, no `hexdocs.pm`
+WebFetch and no `deps/` file-reading. Same applies to `execute_sql_query` and
+`project_eval`. Token savings are largest on Elixir-heavy work.
+
+Default URL: `http://localhost:$PORT/tidewave/mcp` — replace `$PORT` with the
+Phoenix app port (commonly `4000`).
+
+Transport: HTTP streamable. **Do not** select SSE — Tidewave dropped SSE
+support in v0.4.0.
+
+No authentication: Tidewave is dev-only and localhost-only. Decline any
+"Authenticate" prompt — Tidewave implements no auth endpoints.
+
+## Claude Code
+
+CLI:
+
+```bash
+claude mcp add --transport http tidewave http://localhost:4000/tidewave/mcp
+```
+
+Verify: launch `claude`, run `/mcp`, look for `✔ connected` next to
+`tidewave`. If the dialog offers an "Authenticate" option, decline — choosing
+it surfaces an auth error because Tidewave has no auth endpoints.
+
+Encourage MCP tool use by adding to project `CLAUDE.md`:
+
+```markdown
+Always prefer Tidewave's MCP tools for Elixir lookups in this project:
+- `get_docs` over WebFetch on hexdocs.pm
+- `search_package_docs` over broader hex searches
+- `get_source_location` over reading `deps/` source directly
+- `execute_sql_query` and `project_eval` over shelling into `psql` / `iex`
+```
+
+## Codex CLI
+
+CLI:
+
+```bash
+codex mcp add tidewave --url http://localhost:4000/tidewave/mcp
+```
+
+Verify:
+
+```bash
+codex mcp list           # confirm tidewave appears
+codex                    # then /mcp inside the session
+```
+
+## Gemini CLI
+
+Gemini CLI has no Tidewave-specific docs upstream, but supports standard
+streamable HTTP MCP servers via `httpUrl`.
+
+Config file (user-scope `~/.gemini/settings.json` or project-scope
+`.gemini/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "tidewave": {
+      "httpUrl": "http://localhost:4000/tidewave/mcp"
+    }
+  }
+}
+```
+
+The field is `httpUrl` (streamable HTTP), **not** `url` (SSE) — Tidewave only
+speaks streamable HTTP.
+
+CLI alternative:
+
+```bash
+gemini mcp add --transport http tidewave http://localhost:4000/tidewave/mcp
+```
+
+## opencode
+
+Config file (global `~/.config/opencode/opencode.json` or project
+`./opencode.json`):
+
+```json
+{
+  "mcp": {
+    "tidewave": {
+      "type": "remote",
+      "url": "http://localhost:4000/tidewave/mcp",
+      "enabled": true
+    }
+  }
+}
+```
+
+## Verification (all editors)
+
+Raw MCP ping — answers `200 OK` with a JSON-RPC result when Tidewave is
+serving:
+
+```bash
+curl -v http://localhost:4000/tidewave/mcp \
+  --header 'Content-Type: application/json' \
+  --header 'Accept: application/json, text/event-stream' \
+  --data '{"jsonrpc":"2.0","id":1,"method":"ping"}'
+```
+
+End-to-end probe — ask the assistant to run `SELECT 1` via
+`execute_sql_query`. A successful round-trip confirms transport, auth (none),
+and DB wiring.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `405 Method Not Allowed` | Editor configured as SSE | Reconfigure as HTTP streamable (Tidewave dropped SSE in 0.4.0) |
+| `Authenticate` prompt then error | Editor offered auth flow; Tidewave has none | Decline the prompt |
+| `Connection refused` | Phoenix not running, or wrong port | `mix phx.server`; confirm `$PORT` matches `endpoint.ex` config |
+| Tools missing from `/mcp` list | `plug Tidewave` placed after `code_reloading?` block | Move the plug before `code_reloading?` and restart |
+| MCP works on macOS, fails over the network | `allow_remote_access: false` (default) | Set `allow_remote_access: true` on the plug, **only** on trusted networks |


### PR DESCRIPTION
- Add top-level "prefer MCP tools over web fetches" callout to SKILL.md (route doc/source/runtime queries through Tidewave MCP, not WebFetch on hexdocs.pm)
- New references/mcp-setup.md with verbatim setup for claude-code, codex, gemini-cli, opencode (CLI commands + JSON config + curl ping + troubleshooting table)
- Collapse SKILL.md's MCP Server Configuration section to a brief overview pointing at the new reference
- Add extra_apps row to Plug Configuration Options (new in tidewave 0.5.6)
- Drop hardcoded LiveView 1.1.27 version pin
- Refresh sources.md: bump access dates, add entries for CHANGELOG.md, editor MCP pages, and Gemini CLI MCP docs
- Bump elixir plugin 0.1.8 -> 0.1.9 and all-skills meta 0.4.7 -> 0.4.8