### PR TITLE
fix(plan-epic): emit plain ## Skills without YAML fence

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -98,7 +98,7 @@
       "source": "./plugins/tools/linear",
       "strict": true,
       "description": "Linear project management: MCP/GraphQL API, VantageEx epic authoring, auditing, and grooming",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "category": "tools",
       "keywords": ["linear", "project-management", "epics", "graphql", "vantageex", "mcp"],
       "license": "MIT"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/linear/.claude-plugin/plugin.json
+++ b/plugins/tools/linear/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "linear",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Linear project management: MCP/GraphQL API, VantageEx epic authoring, auditing, and grooming",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/linear/skills/linear/references/epic-format.md
+++ b/plugins/tools/linear/skills/linear/references/epic-format.md
@@ -44,16 +44,14 @@ Bad: "Make auth work better"
 
 ### `## Skills`
 
-Domain-specific skills needed for this epic. Listed as a comma-separated list or YAML array.
+Domain-specific skills needed for this epic. Listed as a comma-separated list.
 
 Core skills are always loaded and must NOT be listed:
 - anti-fabrication, git, tdd, twelve-factor, security, mise, nushell
 
 Only list domain-specific extras:
 
-```yaml
-skills: [elixir, oauth, security]
-```
+elixir, oauth, security
 
 Skills must exist in the marketplace at: https://github.com/vinnie357/claude-skills/blob/main/.claude-plugin/marketplace.json
 
@@ -215,7 +213,7 @@ automatically. All auth endpoints pass OWASP top-10 checks.
 
 ## Skills
 
-skills: [elixir, oauth, security]
+elixir, oauth, security
 
 ## Repos
 

--- a/plugins/tools/linear/skills/linear/templates/0.1.0/epic.md
+++ b/plugins/tools/linear/skills/linear/templates/0.1.0/epic.md
@@ -25,9 +25,7 @@ slug: [epic-slug]
 > Domain-specific skills only.
 > Core skills (anti-fabrication, git, tdd, twelve-factor, security, mise, nushell) are always loaded.
 
-```yaml
-skills: [skill-1, skill-2]
-```
+skill-1, skill-2
 
 ## Repos
 


### PR DESCRIPTION
## Summary
- Remove ```yaml ... ``` wrapping from ## Skills section in linear/plan-epic template
- Pairs with vantageex-290 fix that defensively strips fences in the parser

## Test plan
- [x] grep -rn '```yaml' plugins/tools/linear/skills/linear/ returns no hits for Skills section
- [ ] Operator runs /linear:plan-epic end-to-end; output has plain ## Skills