### PR TITLE
chore(skills): codify 5-tier agent pipeline doctrine

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -53,7 +53,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills: plugin marketplace management and validation",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "category": "tools",
       "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark", "skill-update", "output-styles", "statusline"]
     },
@@ -62,7 +62,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "category": "development",
       "keywords": ["git", "documentation", "code-review", "tools", "beads", "bees", "container", "tdd", "agent-loop"]
     },

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/agent-loop/SKILL.md
+++ b/plugins/core/skills/agent-loop/SKILL.md
@@ -30,6 +30,8 @@ Every agent, regardless of tier, follows these four phases:
 
 ## 6-Tier Prompt Hierarchy
 
+These six tiers describe authority — who reports to whom across an epic. For the orthogonal axis of how a single issue flows through staged agents, see "Five-Tier Decomposition Pipeline" below.
+
 | Tier | Role | Scope | Default Model | Reference |
 |------|------|-------|---------------|-----------|
 | 0 | Epic Author | Write machine-executable epics | human | `references/epic-authoring.md` |
@@ -48,6 +50,36 @@ haiku -> sonnet -> opus
 ```
 
 Maximum 2 promotions per agent. If opus fails, escalate to the upstream tier (sub-lead to lead, lead to user).
+
+## Five-Tier Decomposition Pipeline
+
+The 6-tier hierarchy above describes WHO reports to whom (authority). The five-tier pipeline below describes HOW one work item flows through five sequential agents (process). They are orthogonal: a Sub-team Leader (tier 2 authority) dispatches a five-tier pipeline (process) to deliver one issue.
+
+For complex issues, the Sub-team Leader spawns five distinct Agent invocations in order. No shared context across tiers — each tier is adversarial against the next.
+
+| Pipeline Stage | Model | Responsibility | Forbidden |
+|----------------|-------|----------------|-----------|
+| P1 Test Planner | opus | Translate acceptance criteria into ordered test list + edge cases | Writing code or tests |
+| P2 Test Author | sonnet | Write failing tests against P1's spec | Reading impl source; modifying after handoff |
+| P3 Implementer | sonnet | Make tests pass | Modifying test files; reading P2's chat context |
+| P4 CI Runner | haiku | Run CI, capture verbatim output, report green/red | Judging correctness; touching code |
+| P5 Reviewer | opus | Verify tests exercise AC, no overfit, no missed edges | Authoring fixes (sends back to P2 or P3 with findings) |
+
+### When to apply
+
+Apply for multi-file changes, public API surfaces (HTTP/exported/schema), cross-repo work, or any issue carrying explicit acceptance criteria. Single-agent stays acceptable for one-liners, mechanical refactors, status checks, and log diagnosis. When in doubt, decompose.
+
+### Orchestration rules
+
+- Each stage is a separate Agent invocation (no SendMessage continuations between tiers).
+- The leader verifies stage transitions before dispatching the next: test commit present before P3, test files unmodified before P5.
+- P4 reports verbatim CI output; on red the leader dispatches a fresh P3 (no chat continuity).
+- P5 reads `git diff main...HEAD`, tests, and the acceptance criteria; approves with one line or rejects with a structured findings list.
+- bees issues carry tier labels (`team:opus-planner`...`team:opus-review`). The dispatcher reads these. See `/core:bees`.
+
+### Avoiding pipeline collapse
+
+Single agents tend to merge planning + test-writing + implementation into one pass, defeating the adversarial separation. The leader prompt MUST explicitly name the stage (`You are P2 — test author for issue <id>`) and forbid out-of-stage activity.
 
 ## Core Skills (Mandatory)
 

--- a/plugins/core/skills/bees/SKILL.md
+++ b/plugins/core/skills/bees/SKILL.md
@@ -470,7 +470,22 @@ priority:high, priority:medium, priority:low
 status:wip, status:blocked, status:review
 sprint:42, epic:auth
 skill:git, skill:security, skill:rust
+team:opus-planner, team:sonnet-test, team:sonnet-impl, team:haiku-ci, team:opus-review
+complexity:trivial, complexity:standard
 ```
+
+### Tier labels for the five-tier pipeline
+
+For issue topology see `/core:agent-loop` "Five-Tier Decomposition Pipeline". The label tells the dispatcher which model to spawn:
+
+- `team:opus-planner` / `team:opus-review` → opus
+- `team:sonnet-test` / `team:sonnet-impl` → sonnet
+- `team:haiku-ci` → haiku
+- `complexity:trivial` (no `team:*`) → haiku, single-agent
+
+Apply with `bees update <id> --labels "..."` not `bees label add` — only `bees update --labels` syncs the priority field with the `priority:pN` label.
+
+A complex epic decomposes into FIVE chained bees issues per slice (one per stage), with `bees dep add` enforcing P1→P2→P3→P4→P5 order.
 
 ### Dependencies
 

--- a/plugins/core/skills/bees/agents/bees-worker.md
+++ b/plugins/core/skills/bees/agents/bees-worker.md
@@ -64,6 +64,33 @@ bees ready                       # Find next issue
 
 ---
 
+## Tier-Aware Dispatch
+
+See `/core:agent-loop` "Five-Tier Decomposition Pipeline" for stage definitions and `/core:bees` "Tier labels for the five-tier pipeline" for label vocabulary.
+
+On `bees ready` pickup, route by tier label. `team:*` labels take precedence over `complexity:trivial` when both present.
+
+```bash
+LABELS=$(bees show <id> --json | jq -r '.labels | join(",")')
+case "$LABELS" in
+  *team:opus-planner*|*team:opus-review*)        MODEL=opus    ;;
+  *team:sonnet-test*|*team:sonnet-impl*)         MODEL=sonnet  ;;
+  *team:haiku-ci*|*complexity:trivial*)          MODEL=haiku   ;;
+  *) MODEL=unlabeled ;;
+esac
+```
+
+Unlabeled issue → comment + `bees update --status blocked` + escalate. Do not guess tier.
+
+Dispatch each stage as a separate `Task` invocation (no shared context across tiers). Name the stage in the spawn prompt (`You are P2 — test author for bees issue <id>`).
+
+Inter-stage verification before dispatching the next tier:
+- P3 dispatch: P2 issue closed AND test commit on branch.
+- P5 dispatch: P4 reported green AND `git diff <P2-sha>..HEAD -- <test-paths>` is empty.
+- Verification failure → comment + escalate, do not auto-correct.
+
+---
+
 ### Automated Workflow (Direct Commits)
 
 Use for non-code tasks or when PRs aren't required.
@@ -130,7 +157,7 @@ Continue until `bees ready --json` returns empty.
 
 Before dispatching work, activate any suggested skills from the `skill:` labels. Load the corresponding skill context so domain-specific knowledge is available during execution.
 
-Match issue pattern to action:
+Issues with `team:*` labels route via "Tier-Aware Dispatch" above. Untiered or `complexity:trivial` issues use the pattern-match table below.
 
 | Pattern | Action |
 |---------|--------|

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/claude-skills/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-skills/SKILL.md
@@ -259,6 +259,12 @@ Refine based on real-world usage and evaluation data:
 
 For description optimization techniques, see `references/evaluation-guide.md`.
 
+## Five-tier authoring pipeline
+
+If a skill defines or modifies agent behavior (dispatch patterns, model selection, multi-agent coordination), cross-link `/core:agent-loop` "Five-Tier Decomposition Pipeline" — the canonical decomposition for complex tasks.
+
+Skill updates that only edit markdown skip P2 (test author) — content-grep tests on markdown are tautological. Updates touching agent definitions (`agents/*.md` with dispatch logic) follow the full five-tier pipeline since those files are executable specifications.
+
 ## Best Practices
 
 ### Evaluation-Driven Development


### PR DESCRIPTION
- plugins/core/skills/agent-loop/SKILL.md: new "Five-Tier Decomposition Pipeline" section (table + when-to-apply + orchestration rules + avoiding pipeline collapse) + cross-link from 6-Tier Hierarchy
- plugins/core/skills/bees/SKILL.md: tier + complexity labels added to example block + new "Tier labels for the five-tier pipeline" section
- plugins/core/skills/bees/agents/bees-worker.md: new "Tier-Aware Dispatch" H2 + tier-label branch note in Execute Work
- plugins/tools/claude-code/skills/claude-skills/SKILL.md: new "Five-tier authoring pipeline" cross-link section
- plugins/core/.claude-plugin/plugin.json: 0.2.3 → 0.2.4
- plugins/tools/claude-code/.claude-plugin/plugin.json: 0.2.1 → 0.2.2
- .claude-plugin/marketplace.json: core 0.2.3 → 0.2.4, claude-code 0.2.1 → 0.2.2

Refs: VIN-303