### PR TITLE
chore(skills): correct 5-tier doctrine — fan-out is dispatch-time, not bees-side

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -53,7 +53,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills: plugin marketplace management and validation",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "category": "tools",
       "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark", "skill-update", "output-styles", "statusline"]
     },
@@ -62,7 +62,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "category": "development",
       "keywords": ["git", "documentation", "code-review", "tools", "beads", "bees", "container", "tdd", "agent-loop"]
     },

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/agent-loop/SKILL.md
+++ b/plugins/core/skills/agent-loop/SKILL.md
@@ -69,13 +69,15 @@ For complex issues, the Sub-team Leader spawns five distinct Agent invocations i
 
 Apply for multi-file changes, public API surfaces (HTTP/exported/schema), cross-repo work, or any issue carrying explicit acceptance criteria. Single-agent stays acceptable for one-liners, mechanical refactors, status checks, and log diagnosis. When in doubt, decompose.
 
+Fan-out happens at the Sub-team Leader, not at the epic decomposer or the bees-worker. Decomposition produces one bees issue per slice; the leader picking up the issue is the one that spawns the five stages.
+
 ### Orchestration rules
 
 - Each stage is a separate Agent invocation (no SendMessage continuations between tiers).
 - The leader verifies stage transitions before dispatching the next: test commit present before P3, test files unmodified before P5.
 - P4 reports verbatim CI output; on red the leader dispatches a fresh P3 (no chat continuity).
 - P5 reads `git diff main...HEAD`, tests, and the acceptance criteria; approves with one line or rejects with a structured findings list.
-- bees issues carry tier labels (`team:opus-planner`...`team:opus-review`). The dispatcher reads these. See `/core:bees`.
+- bees issues carry a single `complexity:complex` or `complexity:trivial` label, not tier labels. The Sub-team Leader picks up the issue, reads complexity, and (for complex) dispatches the five stages internally — each Task spawn prompt names its tier (`team:opus-planner` ... `team:opus-review`) as dispatch-time metadata. Tier labels never land on bees rows. See `/core:bees`.
 
 ### Avoiding pipeline collapse
 

--- a/plugins/core/skills/bees/SKILL.md
+++ b/plugins/core/skills/bees/SKILL.md
@@ -470,22 +470,21 @@ priority:high, priority:medium, priority:low
 status:wip, status:blocked, status:review
 sprint:42, epic:auth
 skill:git, skill:security, skill:rust
-team:opus-planner, team:sonnet-test, team:sonnet-impl, team:haiku-ci, team:opus-review
-complexity:trivial, complexity:standard
+complexity:trivial, complexity:complex
 ```
 
-### Tier labels for the five-tier pipeline
+### Complexity labels (drives the pipeline decision)
 
-For issue topology see `/core:agent-loop` "Five-Tier Decomposition Pipeline". The label tells the dispatcher which model to spawn:
+Bees issues carry one of two complexity labels. The label tells the picker whether to dispatch a single agent or the full five-tier pipeline:
 
-- `team:opus-planner` / `team:opus-review` → opus
-- `team:sonnet-test` / `team:sonnet-impl` → sonnet
-- `team:haiku-ci` → haiku
-- `complexity:trivial` (no `team:*`) → haiku, single-agent
+- `complexity:trivial` → dispatch one haiku worker (see "Workflow Examples")
+- `complexity:complex` → dispatch the five-tier pipeline internally (see `/core:agent-loop` "Five-Tier Decomposition Pipeline")
 
-Apply with `bees update <id> --labels "..."` not `bees label add` — only `bees update --labels` syncs the priority field with the `priority:pN` label.
+Apply with `bees update <id> --labels "..."`, not `bees label add` — only `bees update --labels` keeps the priority field synced with the `priority:pN` label.
 
-A complex epic decomposes into FIVE chained bees issues per slice (one per stage), with `bees dep add` enforcing P1→P2→P3→P4→P5 order.
+Bees never carries `team:*` labels. The five tier names (`team:opus-planner`, `team:sonnet-test`, `team:sonnet-impl`, `team:haiku-ci`, `team:opus-review`) are dispatch-time strings the Sub-team Leader puts inside each Task spawn prompt. They identify the stage being dispatched, not the bees row.
+
+One bees issue == one slice. A complex slice still gets ONE bees issue; the five pipeline stages produce intermediate artifacts (bees comments on the same issue, git commits, PR comments), not five chained bees rows.
 
 ### Dependencies
 

--- a/plugins/core/skills/bees/agents/bees-worker.md
+++ b/plugins/core/skills/bees/agents/bees-worker.md
@@ -64,30 +64,56 @@ bees ready                       # Find next issue
 
 ---
 
-## Tier-Aware Dispatch
+## Complexity-Aware Dispatch
 
-See `/core:agent-loop` "Five-Tier Decomposition Pipeline" for stage definitions and `/core:bees` "Tier labels for the five-tier pipeline" for label vocabulary.
+See `/core:agent-loop` "Five-Tier Decomposition Pipeline" for stage definitions and `/core:bees` "Complexity labels" for the bees-side vocabulary.
 
-On `bees ready` pickup, route by tier label. `team:*` labels take precedence over `complexity:trivial` when both present.
+On `bees ready` pickup, route by complexity label. The bees-worker IS the Sub-team Leader for that issue — it owns the pipeline dispatch internally.
 
 ```bash
 LABELS=$(bees show <id> --json | jq -r '.labels | join(",")')
 case "$LABELS" in
-  *team:opus-planner*|*team:opus-review*)        MODEL=opus    ;;
-  *team:sonnet-test*|*team:sonnet-impl*)         MODEL=sonnet  ;;
-  *team:haiku-ci*|*complexity:trivial*)          MODEL=haiku   ;;
-  *) MODEL=unlabeled ;;
+  *complexity:complex*) MODE=pipeline ;;
+  *complexity:trivial*) MODE=solo     ;;
+  *)                    MODE=unlabeled ;;
 esac
 ```
 
-Unlabeled issue → comment + `bees update --status blocked` + escalate. Do not guess tier.
+Unlabeled issue → classify (see "Complexity classification" below) or comment + `bees update --status blocked` + escalate. Do not guess.
 
-Dispatch each stage as a separate `Task` invocation (no shared context across tiers). Name the stage in the spawn prompt (`You are P2 — test author for bees issue <id>`).
+### Pipeline mode (complexity:complex)
 
-Inter-stage verification before dispatching the next tier:
-- P3 dispatch: P2 issue closed AND test commit on branch.
-- P5 dispatch: P4 reported green AND `git diff <P2-sha>..HEAD -- <test-paths>` is empty.
-- Verification failure → comment + escalate, do not auto-correct.
+Spawn five sequential `Task` invocations from the bees-worker process. Each is a separate Agent with no shared context. Name the stage in the spawn prompt — these are dispatch-time identifiers, not bees labels:
+
+| Stage | Model | Spawn prompt opens with |
+|-------|-------|-------------------------|
+| P1 planner   | opus   | `You are team:opus-planner for bees issue <id>. Stage P1 — write test list + spec.` |
+| P2 test author | sonnet | `You are team:sonnet-test for bees issue <id>. Stage P2 — write failing tests against P1's spec. Do NOT read implementation.` |
+| P3 implementer | sonnet | `You are team:sonnet-impl for bees issue <id>. Stage P3 — make tests pass. Do NOT modify test files.` |
+| P4 CI runner   | haiku  | `You are team:haiku-ci for bees issue <id>. Stage P4 — run mise run ci, paste verbatim output.` |
+| P5 reviewer    | opus   | `You are team:opus-review for bees issue <id>. Stage P5 — verify tests exercise AC, no overfit.` |
+
+Intermediate artifacts go to bees comments on the SAME issue and git commits on the feature branch. Do NOT create new bees issues for stage progression.
+
+Between dispatches the bees-worker verifies the previous stage's artifact before spawning the next:
+- Before P3: P2 stage left a test-only commit on the branch (`git log --oneline` shows it).
+- Before P4: P3's commit doesn't touch test files (`git diff <P2-sha>..HEAD -- <test-paths>` is empty).
+- Before P5: P4 reported green CI in its bees comment.
+- Verification failure → comment on the issue + escalate, do not auto-correct.
+
+### Solo mode (complexity:trivial)
+
+Dispatch one haiku Agent following the 9-step Agent Worker Execution Order in `/core:agent-loop`. Single Task invocation, no pipeline.
+
+### Complexity classification (unlabeled issues)
+
+If no `complexity:*` label is present, apply the threshold from `/core:agent-loop` "When to apply":
+- Multi-file change touching the issue body's referenced files
+- Public API surface (HTTP, exported, schema)
+- Cross-repo work
+- Explicit acceptance criteria
+
+Any hit → label `complexity:complex` and proceed in pipeline mode. None hit → label `complexity:trivial` and proceed in solo mode. If classification is ambiguous, comment + block + escalate; do not guess.
 
 ---
 
@@ -157,7 +183,7 @@ Continue until `bees ready --json` returns empty.
 
 Before dispatching work, activate any suggested skills from the `skill:` labels. Load the corresponding skill context so domain-specific knowledge is available during execution.
 
-Issues with `team:*` labels route via "Tier-Aware Dispatch" above. Untiered or `complexity:trivial` issues use the pattern-match table below.
+Issues with `complexity:*` labels route via "Complexity-Aware Dispatch" above. Untiered issues that classify as trivial use the pattern-match table below.
 
 | Pattern | Action |
 |---------|--------|

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/claude-skills/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-skills/SKILL.md
@@ -265,6 +265,8 @@ If a skill defines or modifies agent behavior (dispatch patterns, model selectio
 
 Skill updates that only edit markdown skip P2 (test author) — content-grep tests on markdown are tautological. Updates touching agent definitions (`agents/*.md` with dispatch logic) follow the full five-tier pipeline since those files are executable specifications.
 
+The pipeline runs inside ONE bees issue per skill update slice. The Sub-team Leader (or bees-worker acting as one) spawns the five stages as separate Task invocations; intermediate artifacts go to bees comments on that issue and git commits on the feature branch. Skill updates do not produce five chained bees rows.
+
 ## Best Practices
 
 ### Evaluation-Driven Development


### PR DESCRIPTION
- plugins/core/skills/agent-loop/SKILL.md: clarify Sub-team Leader does fan-out; tier labels are dispatch-prompt strings, not bees-issue labels
- plugins/core/skills/bees/SKILL.md: drop team:* from label vocab; rename "Tier labels" → "Complexity labels"; delete "FIVE chained bees issues per slice" sentence
- plugins/core/skills/bees/agents/bees-worker.md: rename "Tier-Aware Dispatch" → "Complexity-Aware Dispatch"; case-branch is 2-way on complexity:*; pipeline runs as 5 in-process Task spawns inside one bees issue
- plugins/tools/claude-code/skills/claude-skills/SKILL.md: clarify pipeline runs inside ONE bees issue per slice
- plugins/core/.claude-plugin/plugin.json: 0.2.4 → 0.2.5
- plugins/tools/claude-code/.claude-plugin/plugin.json: 0.2.2 → 0.2.3
- .claude-plugin/marketplace.json: core 0.2.4 → 0.2.5, claude-code 0.2.2 → 0.2.3

Follow-up to #72. Refs: VIN-303