### PR TITLE
feat(sbx): add Docker Sandboxes skill and mise sandboxing section

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "A curated collection of Claude skills for development workflows",
-    "version": "1.0.10"
+    "version": "1.0.11"
   },
   "plugins": [
     {
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.9",
+      "version": "0.4.10",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -62,7 +62,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "category": "development",
       "keywords": ["git", "documentation", "code-review", "tools", "beads", "bees", "container", "tdd", "agent-loop"]
     },
@@ -141,6 +141,16 @@
       "version": "0.1.4",
       "category": "language",
       "keywords": ["rust", "systems-programming", "memory-safety"]
+    },
+    {
+      "name": "sbx",
+      "source": "./plugins/tools/sbx",
+      "strict": true,
+      "description": "Docker Sandboxes (sbx CLI): run AI coding agents in isolated microVMs with hypervisor-level isolation",
+      "version": "0.1.0",
+      "category": "tools",
+      "keywords": ["docker", "sandbox", "sbx", "microvm", "ai-agents", "isolation"],
+      "license": "MIT"
     },
     {
       "name": "slidev",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -77,6 +77,7 @@
     "./plugins/languages/rust/skills/async",
     "./plugins/languages/rust/skills/testing",
     "./plugins/languages/rust/skills/troubleshooting",
+    "./plugins/tools/sbx/skills/sbx",
     "./plugins/tools/slidev/skills/slidev",
     "./plugins/tools/slidev/skills/syntax",
     "./plugins/tools/slidev/skills/code",

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/mise/SKILL.md
+++ b/plugins/core/skills/mise/SKILL.md
@@ -607,6 +607,65 @@ Make executable:
 chmod +x .mise/tasks/deploy
 ```
 
+## Sandboxing
+
+mise sandboxing is a lightweight process-isolation feature for `mise exec` and `mise run` that restricts filesystem, network, and environment-variable access using OS-level primitives — not a container, not a VM. Enable the feature flag before using any sandbox options:
+
+```bash
+mise settings experimental=true
+```
+
+### Platform support
+
+| Platform | Filesystem | Network | Per-host net filter |
+|----------|------------|---------|---------------------|
+| Linux (kernel 5.13+) | Landlock | seccomp-bpf | No (all-or-nothing in v1) |
+| macOS | Seatbelt | Seatbelt | Yes |
+| Windows | unsupported | unsupported | unsupported |
+
+### Allow/deny flags
+
+Deny flags (apply to `mise exec` / `mise run`):
+- `--deny-all` — deny filesystem, network, and env by default
+- `--deny-read` — deny all filesystem reads
+- `--deny-write` — deny all filesystem writes
+- `--deny-net` — deny all network access
+- `--deny-env` — deny all environment variables
+
+Allow flags (grant specific access back):
+- `--allow-read=<path>` — grant read access to a path
+- `--allow-write=<path>` — grant write access to a path
+- `--allow-net=<host>` — grant access to a specific host (macOS only for per-host filtering)
+- `--allow-env=<var>` — grant access to an env var; supports globs (e.g. `MYAPP_*`)
+
+```bash
+mise x --deny-all --allow-read=. --allow-write=./dist --allow-net=registry.npmjs.org -- npm install
+```
+
+### Task-level config
+
+Define sandbox policy inline in `mise.toml`:
+
+```toml
+[tasks.build]
+run = "npm run build"
+deny_net = true
+allow_write = ["./dist"]
+```
+
+Task-level keys map 1:1 to CLI flags. CLI flags override task config when both are present.
+
+### Limitations
+
+- `mise settings experimental=true` is required; without it, deny/allow flags are silently no-ops.
+- Linux v1 lacks per-host network filtering — network access is all-or-nothing.
+- Landlock failures terminate the command immediately on Linux.
+- Windows is unsupported; commands run unsandboxed with a warning.
+
+### See also
+
+- `templates/sandboxing.md` — runnable examples for task-level and ad-hoc sandbox invocations.
+
 ## Common Workflows
 
 ### Node.js Project Setup

--- a/plugins/core/skills/mise/templates/sandboxing.md
+++ b/plugins/core/skills/mise/templates/sandboxing.md
@@ -1,0 +1,38 @@
+# mise sandboxing — runnable examples
+
+Source: https://mise.jdx.dev/sandboxing.html (accessed 2026-05-22)
+
+## Constrain a task to write only to ./dist with no network
+
+Add sandbox policy directly in `mise.toml`:
+
+```toml
+[tasks.build]
+run = "npm run build"
+deny_net = true
+allow_write = ["./dist"]
+```
+
+Run with:
+
+```bash
+mise run build
+```
+
+## Ad-hoc sandboxed npm install
+
+Deny everything, then allow only the specific paths and host needed:
+
+```bash
+mise x --deny-all --allow-read=. --allow-write=./dist --allow-net=registry.npmjs.org -- npm install
+```
+
+This grants read access to the current directory, write access to `./dist`, and outbound network access to `registry.npmjs.org` only (macOS per-host filtering; Linux applies network access as all-or-nothing).
+
+## Enable the feature flag
+
+```bash
+mise settings experimental=true
+```
+
+Without this, all deny/allow flags are silently no-ops — commands run unsandboxed with no error.

--- a/plugins/core/skills/sources.md
+++ b/plugins/core/skills/sources.md
@@ -279,6 +279,9 @@ This file documents the sources used to create the core plugin skills.
 - **Purpose**: Source for optional spec-driven flows integrated into /core:agent-loop (team-leader, agent-worker, validator, epic-authoring edits)
 - **Date Accessed**: 2026-04-17
 
+### mise Sandboxing
+- https://mise.jdx.dev/sandboxing.html — mise sandboxing (experimental). Extracted: allow/deny flags, task-level config, Landlock/Seatbelt platform support, limitations. Accessed 2026-05-22.
+
 ## Plugin Information
 
 - **Name**: core

--- a/plugins/tools/sbx/.claude-plugin/plugin.json
+++ b/plugins/tools/sbx/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "sbx",
+  "version": "0.1.0",
+  "description": "Docker Sandboxes (sbx CLI): run AI coding agents in isolated microVMs with hypervisor-level isolation",
+  "author": {
+    "name": "vinnie357"
+  },
+  "repository": "https://github.com/vinnie357/claude-skills",
+  "license": "MIT",
+  "keywords": ["docker", "sandbox", "sbx", "microvm", "ai-agents", "isolation"],
+  "skills": [
+    "./skills/sbx"
+  ]
+}

--- a/plugins/tools/sbx/skills/sbx/SKILL.md
+++ b/plugins/tools/sbx/skills/sbx/SKILL.md
@@ -78,15 +78,20 @@ sbx create claude
 
 ## Branch isolation
 
-`--branch auto` creates a Git worktree for the sandbox, keeping branch changes isolated from the main working tree.
+`--branch auto` creates a Git worktree for the sandbox, keeping branch changes isolated from the main working tree. Worktrees live under `.sbx/` in the repo root. Add `.sbx/` to `.gitignore` (or global gitignore) to keep it out of `git status`.
 
 ```bash
-# Auto-create a worktree branch
-sbx run claude --branch auto
+# Auto-create a worktree branch (with trailing path)
+sbx run claude --branch auto .
 
 # Target an existing branch
 sbx run claude --branch my-feature
+
+# Suggested gitignore entry
+echo '.sbx/' >> .gitignore
 ```
+
+`--branch` is the recommended pattern for any agent that writes code — it keeps every agent edit on a reviewable branch the operator can diff and merge deliberately.
 
 ## Sandbox lifecycle
 
@@ -116,18 +121,48 @@ sbx cp my-sandbox:/workspace/output.txt ./output.txt
 ## Forward ports
 
 ```bash
+# Publish host port 8080 → sandbox port 3000
 sbx ports my-sandbox --publish 8080:3000
-```
 
-Maps host port 8080 to container port 3000 inside the sandbox.
+# Remove an existing publish
+sbx ports my-sandbox --unpublish 8080:3000
+```
 
 ## Exec into a running sandbox
 
 ```bash
-sbx exec my-sandbox bash
+sbx exec -it my-sandbox bash
 ```
 
-Opens an interactive shell inside the running sandbox.
+`-it` keeps the shell interactive. Without it, `exec` runs the command and exits.
+
+## Network policy
+
+`sbx` ships a deny-by-default network policy. Add explicit allow rules per host or wildcard:
+
+```bash
+# Allow a global host for all sandboxes
+sbx policy allow network -g registry.npmjs.org
+
+# Inspect current policy
+sbx policy ls
+```
+
+`**` matches multiple subdomain levels in the rule grammar.
+
+## Interactive dashboard
+
+Running `sbx` with no subcommand opens a terminal dashboard. Key shortcuts:
+
+| Key | Action |
+|-----|--------|
+| `c` | Create a sandbox |
+| `s` | Start or stop the selected sandbox |
+| `Enter` | Attach to the agent session |
+| `x` | Open a shell (same as `sbx exec`) |
+| `r` | Remove the selected sandbox |
+| `Tab` | Switch between sandbox and network governance panels |
+| `?` | Show all shortcuts |
 
 ## Security boundary
 
@@ -160,12 +195,20 @@ sbx diagnose
 
 For release history, see https://github.com/docker/sbx-releases.
 
+## Docker inside a sandbox
+
+Each sandbox runs its own Docker daemon, so the agent can spin up service containers (Postgres, Redis, etc.) inside the VM without touching the host's Docker. The workspace dir is mounted into the VM, so a `compose.yaml` in the repo works as-is.
+
+See `templates/elixir-tidewave/` for a worked example: Phoenix app + Postgres container + Tidewave runtime introspection, all inside a single sandbox where Claude is the running agent.
+
 ## Reference
 
-- `references/commands.md` — all 11 subcommands with confirmed flags and canonical invocations
+- `references/commands.md` — confirmed subcommands and flags with canonical invocations
 - `references/security-model.md` — four-layer isolation model, network policy, credential injection, workspace caveat
+- `templates/mise.toml` — mise github backend pin for sbx
+- `templates/elixir-tidewave/` — Docker-in-sbx workflow with Phoenix + Postgres + Tidewave
 
-Related: `/core:container` — Apple Container CLI (lightweight Linux VMs on Apple silicon via Virtualization.framework; different layer from sbx microVMs).
+Related: `/core:container` — Apple Container CLI (lightweight Linux VMs on Apple silicon via Virtualization.framework; different layer from sbx microVMs). `/elixir:tidewave` — Tidewave MCP setup detail used by the elixir-tidewave template.
 
 ## Anti-fabrication
 

--- a/plugins/tools/sbx/skills/sbx/SKILL.md
+++ b/plugins/tools/sbx/skills/sbx/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: sbx
+description: Guide for Docker Sandboxes (sbx CLI). Run AI coding agents in isolated microVMs with hypervisor-level isolation, deny-by-default networking, and credential-injection proxies. Use when installing sbx, launching agent sandboxes, managing sandbox lifecycle, port-forwarding into a sandbox, copying files in or out, or reasoning about the microVM isolation boundary.
+license: MIT
+---
+
+# Docker Sandboxes (sbx)
+
+## What is sbx?
+
+Docker Sandboxes runs AI coding agents in microVMs backed by a KVM hypervisor. The binary is `sbx` — not `docker sbx`. Each sandbox gets its own kernel, its own Docker daemon, and an isolated network namespace. Only the workspace directory is mounted into the VM. A credential proxy injects API keys host-side so secrets never enter the VM filesystem.
+
+## Install
+
+### macOS (Apple silicon, Sonoma+)
+
+Requires Homebrew.
+
+```bash
+brew install docker/tap/sbx
+```
+
+### Windows 11
+
+Requires Hypervisor Platform enabled in Windows Features.
+
+```powershell
+winget install Docker.sbx
+```
+
+### Ubuntu 24.04+
+
+Requires KVM and user in the `kvm` group.
+
+```bash
+curl -fsSL https://get.docker.com | sudo REPO_ONLY=1 sh
+sudo apt-get install docker-sbx
+```
+
+## Authenticate
+
+```bash
+sbx login
+```
+
+Prompts for an API key and stores credentials locally.
+
+## Run an agent
+
+```bash
+# Create and immediately run a sandbox with Claude Code
+sbx run claude
+```
+
+Available agents: Claude Code, Codex, Copilot, Cursor, Droid, Gemini, Kiro, OpenCode, Docker Agent, Shell (agent-less).
+
+Create a sandbox in the background without attaching:
+
+```bash
+sbx create claude
+```
+
+## Branch isolation
+
+`--branch auto` creates a Git worktree for the sandbox, keeping branch changes isolated from the main working tree.
+
+```bash
+# Auto-create a worktree branch
+sbx run claude --branch auto
+
+# Target an existing branch
+sbx run claude --branch my-feature
+```
+
+## Sandbox lifecycle
+
+```bash
+# List all sandboxes
+sbx ls
+
+# Pause a running sandbox
+sbx stop my-sandbox
+
+# Delete a sandbox (VM filesystem wiped; workspace directory preserved)
+sbx rm my-sandbox
+```
+
+`sbx rm` wipes the VM filesystem. The workspace directory on the host is not deleted.
+
+## Move files in and out
+
+```bash
+# Copy a file from host into the sandbox
+sbx cp ./local-file.txt my-sandbox:/workspace/local-file.txt
+
+# Copy a file out of the sandbox to the host
+sbx cp my-sandbox:/workspace/output.txt ./output.txt
+```
+
+## Forward ports
+
+```bash
+sbx ports my-sandbox --publish 8080:3000
+```
+
+Maps host port 8080 to container port 3000 inside the sandbox.
+
+## Exec into a running sandbox
+
+```bash
+sbx exec my-sandbox bash
+```
+
+Opens an interactive shell inside the running sandbox.
+
+## Security boundary
+
+Four isolation layers:
+
+1. **Hypervisor isolation** — KVM microVM with a separate kernel per sandbox.
+2. **Network proxy** — deny-by-default; HTTP/HTTPS traffic goes through a proxy; non-HTTP protocols are blocked; the agent cannot reach the host's localhost.
+3. **Per-VM Docker daemon** — each sandbox runs its own Docker daemon, isolated from the host daemon.
+4. **Credential proxy** — API keys are injected host-side via the proxy; they never appear in the VM filesystem or environment variables visible inside the VM.
+
+### Workspace caveat
+
+The workspace directory is shared between the host and the VM. An agent running inside the sandbox can modify Git hooks, CI configuration files, and build scripts in that shared workspace. Those files execute on the host the next time the host invokes them (e.g., on the next `git commit` or CI run). Review workspace-written hooks and scripts before executing them on the host.
+
+### What is NOT a boundary
+
+Code that an agent writes to the workspace and that you then execute on the host runs with host privileges. The microVM boundary does not extend to host-side execution of workspace artifacts.
+
+See `references/security-model.md` for the full four-layer breakdown and network policy detail.
+
+## Diagnostics
+
+```bash
+# Print installed sbx version
+sbx version
+
+# Collect diagnostic information
+sbx diagnose
+```
+
+For release history, see https://github.com/docker/sbx-releases.
+
+## Reference
+
+- `references/commands.md` — all 11 subcommands with confirmed flags and canonical invocations
+- `references/security-model.md` — four-layer isolation model, network policy, credential injection, workspace caveat
+
+Related: `/core:container` — Apple Container CLI (lightweight Linux VMs on Apple silicon via Virtualization.framework; different layer from sbx microVMs).
+
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. The subcommand list, flags, install commands, and security model are extracted verbatim from the upstream docs cited in `sources.md`. The introduction version is not stated upstream and is not fabricated here — release history lives at https://github.com/docker/sbx-releases.

--- a/plugins/tools/sbx/skills/sbx/SKILL.md
+++ b/plugins/tools/sbx/skills/sbx/SKILL.md
@@ -37,6 +37,22 @@ curl -fsSL https://get.docker.com | sudo REPO_ONLY=1 sh
 sudo apt-get install docker-sbx
 ```
 
+### mise (macOS, Linux)
+
+mise's github backend extracts the platform tarball, preserves the `bin/sbx` + `libexec/` layout, and verifies SLSA provenance. See `templates/mise.toml`.
+
+```toml
+[tools]
+"github:docker/sbx-releases" = "0.30.0"
+```
+
+```bash
+mise install
+sbx version
+```
+
+Apple silicon and Linux x86_64 are confirmed. Windows is not packaged as a tarball asset — use `winget` above.
+
 ## Authenticate
 
 ```bash

--- a/plugins/tools/sbx/skills/sbx/references/commands.md
+++ b/plugins/tools/sbx/skills/sbx/references/commands.md
@@ -4,17 +4,29 @@ Source: https://docs.docker.com/reference/cli/sbx/
 
 ## Table of Contents
 
+- [Interactive dashboard (no subcommand)](#interactive-dashboard-no-subcommand)
 - [sbx run](#sbx-run)
 - [sbx create](#sbx-create)
 - [sbx exec](#sbx-exec)
 - [sbx cp](#sbx-cp)
 - [sbx ports](#sbx-ports)
+- [sbx policy](#sbx-policy)
 - [sbx ls](#sbx-ls)
 - [sbx stop](#sbx-stop)
 - [sbx rm](#sbx-rm)
 - [sbx login](#sbx-login)
 - [sbx version](#sbx-version)
 - [sbx diagnose](#sbx-diagnose)
+
+---
+
+## Interactive dashboard (no subcommand)
+
+Running `sbx` with no subcommand opens a terminal dashboard. Shortcuts: `c` create, `s` start/stop, `Enter` attach, `x` shell, `r` remove, `Tab` switch sandbox/network panels, `?` help.
+
+```bash
+sbx
+```
 
 ---
 
@@ -53,10 +65,11 @@ sbx create claude --branch auto
 
 Execute a command inside a running sandbox.
 
-**Confirmed flags:** (see upstream docs)
+**Confirmed flags:**
+- `-it` — interactive terminal (required for shells)
 
 ```bash
-sbx exec my-sandbox bash
+sbx exec -it my-sandbox bash
 ```
 
 ---
@@ -83,9 +96,32 @@ Manage port forwarding for a sandbox.
 
 **Confirmed flags:**
 - `--publish <host:container>` — map host port to sandbox port
+- `--unpublish <host:container>` — remove an existing publish
 
 ```bash
 sbx ports my-sandbox --publish 8080:3000
+sbx ports my-sandbox --unpublish 8080:3000
+```
+
+---
+
+## sbx policy
+
+Manage the sandbox network policy. Deny-by-default; rules add explicit allows.
+
+**Confirmed subcommands:**
+- `allow network <pattern>` — permit egress to a host pattern (`**` matches multiple subdomain levels)
+- `ls` — show current policy
+
+**Confirmed flags:**
+- `-g` (with `allow`) — apply the rule globally across all sandboxes
+
+```bash
+# Global allow for the npm registry
+sbx policy allow network -g registry.npmjs.org
+
+# List current rules
+sbx policy ls
 ```
 
 ---
@@ -128,12 +164,18 @@ sbx rm my-sandbox
 
 ## sbx login
 
-Authenticate with an API key. Stores credentials locally for subsequent commands.
+Authenticate with a Docker account. Stores credentials locally for subsequent commands.
 
-**Confirmed flags:** (see upstream docs)
+**Confirmed flags:**
+- `--username <user>` — provide username non-interactively
+- `--password-stdin` — read password from stdin (use with `--username`)
 
 ```bash
+# Interactive
 sbx login
+
+# CI / non-interactive
+echo "$DOCKER_PAT" | sbx login --username vinnie357 --password-stdin
 ```
 
 ---

--- a/plugins/tools/sbx/skills/sbx/references/commands.md
+++ b/plugins/tools/sbx/skills/sbx/references/commands.md
@@ -1,0 +1,161 @@
+# sbx Commands Reference
+
+Source: https://docs.docker.com/reference/cli/sbx/
+
+## Table of Contents
+
+- [sbx run](#sbx-run)
+- [sbx create](#sbx-create)
+- [sbx exec](#sbx-exec)
+- [sbx cp](#sbx-cp)
+- [sbx ports](#sbx-ports)
+- [sbx ls](#sbx-ls)
+- [sbx stop](#sbx-stop)
+- [sbx rm](#sbx-rm)
+- [sbx login](#sbx-login)
+- [sbx version](#sbx-version)
+- [sbx diagnose](#sbx-diagnose)
+
+---
+
+## sbx run
+
+Create and run a sandbox, attaching to the agent session.
+
+**Confirmed flags:**
+- `--branch <name>` — target an existing branch; `--branch auto` creates a Git worktree
+- `--publish <host:container>` — publish a port on the host
+
+```bash
+sbx run claude
+sbx run claude --branch auto
+sbx run claude --branch my-feature --publish 8080:3000
+```
+
+---
+
+## sbx create
+
+Create a sandbox in the background without attaching.
+
+**Confirmed flags:**
+- `--branch <name>` — target an existing branch; `--branch auto` creates a Git worktree
+- `--publish <host:container>` — publish a port on the host
+
+```bash
+sbx create claude
+sbx create claude --branch auto
+```
+
+---
+
+## sbx exec
+
+Execute a command inside a running sandbox.
+
+**Confirmed flags:** (see upstream docs)
+
+```bash
+sbx exec my-sandbox bash
+```
+
+---
+
+## sbx cp
+
+Copy files between the host and a sandbox.
+
+**Confirmed flags:** (see upstream docs)
+
+```bash
+# Host to sandbox
+sbx cp ./file.txt my-sandbox:/workspace/file.txt
+
+# Sandbox to host
+sbx cp my-sandbox:/workspace/output.txt ./output.txt
+```
+
+---
+
+## sbx ports
+
+Manage port forwarding for a sandbox.
+
+**Confirmed flags:**
+- `--publish <host:container>` — map host port to sandbox port
+
+```bash
+sbx ports my-sandbox --publish 8080:3000
+```
+
+---
+
+## sbx ls
+
+List all sandboxes.
+
+**Confirmed flags:** (see upstream docs)
+
+```bash
+sbx ls
+```
+
+---
+
+## sbx stop
+
+Pause a running sandbox.
+
+**Confirmed flags:** (see upstream docs)
+
+```bash
+sbx stop my-sandbox
+```
+
+---
+
+## sbx rm
+
+Delete a sandbox. The VM filesystem is wiped. The workspace directory on the host is preserved.
+
+**Confirmed flags:** (see upstream docs)
+
+```bash
+sbx rm my-sandbox
+```
+
+---
+
+## sbx login
+
+Authenticate with an API key. Stores credentials locally for subsequent commands.
+
+**Confirmed flags:** (see upstream docs)
+
+```bash
+sbx login
+```
+
+---
+
+## sbx version
+
+Print the installed sbx version.
+
+**Confirmed flags:** none
+
+```bash
+sbx version
+```
+
+---
+
+## sbx diagnose
+
+Collect diagnostic information for troubleshooting.
+
+**Confirmed flags:** (see upstream docs)
+
+```bash
+sbx diagnose
+```

--- a/plugins/tools/sbx/skills/sbx/references/security-model.md
+++ b/plugins/tools/sbx/skills/sbx/references/security-model.md
@@ -1,0 +1,70 @@
+# sbx Security Model
+
+Source: https://docs.docker.com/ai/sandboxes/security/
+
+## The Four Isolation Layers
+
+Docker Sandboxes stacks four layers of isolation. Each layer addresses a distinct attack surface.
+
+### Layer 1: Hypervisor Isolation (KVM microVM)
+
+Each sandbox runs inside a microVM backed by the KVM hypervisor. The guest gets its own kernel — not a shared kernel as in Linux namespaces or cgroups. A compromised guest process cannot escape to the host kernel through kernel exploits that rely on shared kernel state.
+
+### Layer 2: Network Proxy
+
+All outbound network traffic from the sandbox passes through a proxy.
+
+- **HTTP and HTTPS** are allowed through the proxy.
+- **Non-HTTP protocols** are blocked at the proxy; the sandbox cannot open arbitrary TCP or UDP connections.
+- **Host localhost is unreachable** from inside the sandbox. The agent cannot connect to services bound to `127.0.0.1` or `::1` on the host.
+- The deny-by-default policy means traffic not explicitly permitted by the proxy rules is dropped.
+
+### Layer 3: Per-VM Docker Daemon
+
+Each sandbox runs its own Docker daemon inside the microVM. The guest daemon is isolated from the host Docker daemon. Containers launched inside the sandbox cannot interact with host containers or images.
+
+### Layer 4: Credential Proxy
+
+API keys required by the AI agent (e.g., Anthropic API key for Claude Code) are injected by the host-side credential proxy. The keys:
+
+- Never appear in the VM filesystem.
+- Never appear in environment variables visible to processes inside the VM through normal inspection paths.
+- Are forwarded on-demand through the proxy when the agent makes authenticated API calls.
+
+## Deny-by-Default Network Policy
+
+The network policy starts from a closed posture:
+
+| Traffic type | Policy |
+|---|---|
+| HTTP outbound | Allowed (via proxy) |
+| HTTPS outbound | Allowed (via proxy) |
+| Non-HTTP TCP/UDP | Blocked |
+| Host localhost | Blocked |
+| Inbound from host | Via `sbx ports` only |
+
+## Credential Injection Detail
+
+The credential proxy intercepts requests from the agent to the AI provider API. It appends the API key at the proxy layer before forwarding to the provider. The agent process never holds the raw key; it holds only a proxy-local token that is only valid within the session.
+
+## Workspace Caveat
+
+The workspace directory is bind-mounted from the host into the microVM. This creates a shared filesystem path. An AI agent running inside the sandbox has write access to the entire workspace, including:
+
+- `.git/hooks/` — pre-commit, post-merge, and other hooks that run on the host
+- CI configuration files (`.github/workflows/`, `.circleci/config.yml`, etc.)
+- Build scripts (`Makefile`, `mise.toml`, `package.json` scripts, etc.)
+
+These files execute on the host the next time a host-side process invokes them. The microVM boundary does not protect host execution of workspace artifacts.
+
+**Mitigation:** audit workspace-written hook and CI files before running them on the host. Treat the workspace as untrusted input from the agent.
+
+## What This Is NOT
+
+sbx is not:
+
+- **A Linux container** — containers share the host kernel; sbx microVMs have a separate kernel per sandbox.
+- **A namespace or cgroup boundary** — those are kernel-level isolation within a single kernel; sbx uses full VM-level isolation.
+- **A seccomp filter** — seccomp restricts syscalls within a shared kernel; sbx eliminates shared kernel state entirely.
+
+sbx microVMs provide hypervisor-level isolation comparable to cloud VM boundaries, not container-level isolation.

--- a/plugins/tools/sbx/skills/sbx/templates/elixir-tidewave/README.md
+++ b/plugins/tools/sbx/skills/sbx/templates/elixir-tidewave/README.md
@@ -1,0 +1,82 @@
+# Docker-in-sbx: Phoenix + Postgres + Tidewave
+
+A worked example for running a Phoenix app inside a Docker Sandbox with Postgres in a container and Tidewave configured so Claude (running inside the same sandbox) can introspect the live Phoenix app via MCP.
+
+## Topology
+
+```
+Host
+└── sbx VM (microVM)
+    ├── Docker daemon (per-sandbox)
+    │   └── postgres:16  (container)
+    ├── Claude Code (agent process)
+    └── Phoenix app (mix phx.server)
+            └── /mcp endpoint (Tidewave plug)
+```
+
+Claude and Phoenix share `localhost` inside the VM. Tidewave's MCP endpoint defaults to localhost-only (`allow_remote_access: false`), which fits this same-VM setup.
+
+## Files in this template
+
+| File | Where it goes in your repo |
+|------|----------------------------|
+| `mise.toml` | repo root — pins Erlang + Elixir for the agent to install in the VM |
+| `compose.yaml` | repo root — Postgres service definition |
+| `mix.exs.snippet` | merge into your `mix.exs` `deps/0` |
+| `config-dev.exs.snippet` | merge into `config/dev.exs` |
+| `endpoint.ex.snippet` | merge into `lib/<app>_web/endpoint.ex` |
+
+## Workflow
+
+### 1. Drop the template files into the repo
+
+```bash
+cp -r templates/elixir-tidewave/* .
+```
+
+Merge the `*.snippet` files into the matching Phoenix project files. Add `.sbx/` to `.gitignore`.
+
+### 2. Start a sandbox with Claude
+
+```bash
+sbx run claude --branch auto .
+```
+
+`--branch auto` opens a Git worktree under `.sbx/` so all of the agent's writes stay on a reviewable branch.
+
+### 3. Inside the sandbox — bring up Postgres and the Phoenix app
+
+The agent (or you, via `sbx exec -it <name> bash`) runs:
+
+```bash
+mise install                       # installs erlang + elixir per mise.toml
+mix local.hex --force
+mix local.rebar --force
+mix deps.get
+docker compose up -d postgres
+mix ecto.setup                     # mix ecto.create + mix ecto.migrate
+mix phx.server
+```
+
+### 4. Verify Tidewave MCP is live
+
+From inside the sandbox:
+
+```bash
+curl -s http://localhost:4000/mcp/version
+```
+
+Claude inside the sandbox uses the MCP endpoint to call Tidewave's introspection tools (`get_ecto_schemas`, `project_eval`, `execute_sql_query`, `get_logs`, etc.). See `/elixir:tidewave` for the tool list.
+
+### 5. (Optional) Reach the Phoenix UI from the host
+
+```bash
+sbx ports <sandbox-name> --publish 4000:4000
+open http://localhost:4000
+```
+
+## Notes
+
+- Postgres data lives in a named volume inside the VM. `sbx rm` wipes the VM filesystem, including that volume; the workspace directory is preserved.
+- The agent has its own Docker daemon — `docker ps` inside the sandbox only shows containers running in this VM.
+- Tidewave's `allow_remote_access: false` is the right default here because the agent and the Phoenix app share the VM's loopback. Flip it to `true` only if you forward port 4000 to the host AND need MCP access from the host.

--- a/plugins/tools/sbx/skills/sbx/templates/elixir-tidewave/compose.yaml
+++ b/plugins/tools/sbx/skills/sbx/templates/elixir-tidewave/compose.yaml
@@ -1,0 +1,19 @@
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: app_dev
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  pgdata:

--- a/plugins/tools/sbx/skills/sbx/templates/elixir-tidewave/config-dev.exs.snippet
+++ b/plugins/tools/sbx/skills/sbx/templates/elixir-tidewave/config-dev.exs.snippet
@@ -1,0 +1,19 @@
+# Merge into config/dev.exs
+
+import Config
+
+config :app, App.Repo,
+  url: System.get_env("DATABASE_URL") || "ecto://postgres:postgres@localhost:5432/app_dev",
+  stacktrace: true,
+  show_sensitive_data_on_connection_error: true,
+  pool_size: 10
+
+config :app, AppWeb.Endpoint,
+  http: [ip: {0, 0, 0, 0}, port: String.to_integer(System.get_env("PORT") || "4000")],
+  check_origin: false,
+  code_reloader: true,
+  debug_errors: true,
+  secret_key_base: "REPLACE_WITH_64_BYTE_DEV_SECRET",
+  watchers: []
+
+config :logger, :default_handler, level: :debug

--- a/plugins/tools/sbx/skills/sbx/templates/elixir-tidewave/endpoint.ex.snippet
+++ b/plugins/tools/sbx/skills/sbx/templates/elixir-tidewave/endpoint.ex.snippet
@@ -1,0 +1,23 @@
+# Merge into lib/<app>_web/endpoint.ex
+#
+# The Tidewave plug is the entire MCP integration — no separate child spec
+# is required. Localhost-only by default, which is the right setting when
+# Claude runs inside the same sbx VM as the Phoenix app.
+
+defmodule AppWeb.Endpoint do
+  use Phoenix.Endpoint, otp_app: :app
+
+  if Mix.env() == :dev do
+    plug Tidewave
+  end
+
+  # ... rest of your existing endpoint plugs ...
+end
+
+# If you also want to attach a host-side MCP client by forwarding port 4000:
+#
+#   if Mix.env() == :dev do
+#     plug Tidewave, allow_remote_access: true
+#   end
+#
+# Pair this with `sbx ports <sandbox-name> --publish 4000:4000`.

--- a/plugins/tools/sbx/skills/sbx/templates/elixir-tidewave/mise.toml
+++ b/plugins/tools/sbx/skills/sbx/templates/elixir-tidewave/mise.toml
@@ -1,0 +1,26 @@
+# Pinned runtimes for the sandbox VM. Claude runs `mise install` after the
+# sandbox boots; mise reads this file from the mounted workspace.
+
+[tools]
+erlang = "27.2"
+elixir = "1.18.1-otp-27"
+
+[env]
+MIX_ENV = "dev"
+DATABASE_URL = "ecto://postgres:postgres@localhost:5432/app_dev"
+PHX_HOST = "localhost"
+PORT = "4000"
+
+[tasks."setup"]
+description = "First-run setup inside the sandbox"
+run = """
+mix local.hex --force
+mix local.rebar --force
+mix deps.get
+docker compose up -d postgres
+mix ecto.setup
+"""
+
+[tasks."dev"]
+description = "Start Phoenix with Tidewave"
+run = "mix phx.server"

--- a/plugins/tools/sbx/skills/sbx/templates/elixir-tidewave/mix.exs.snippet
+++ b/plugins/tools/sbx/skills/sbx/templates/elixir-tidewave/mix.exs.snippet
@@ -1,0 +1,12 @@
+# Add these deps to your existing mix.exs `defp deps do [...] end` block.
+
+defp deps do
+  [
+    {:phoenix, "~> 1.7"},
+    {:phoenix_live_view, "~> 1.0"},
+    {:ecto_sql, "~> 3.12"},
+    {:postgrex, "~> 0.20"},
+    {:jason, "~> 1.4"},
+    {:tidewave, "~> 0.5", only: :dev},
+  ]
+end

--- a/plugins/tools/sbx/skills/sbx/templates/mise.toml
+++ b/plugins/tools/sbx/skills/sbx/templates/mise.toml
@@ -1,9 +1,10 @@
 # Source: https://docs.docker.com/ai/sandboxes/get-started/
-# sbx ships as platform-native packages — install via brew/winget/apt per SKILL.md.
-# mise github backend is left commented out because docker/sbx-releases ships
-# platform installers, not a single cross-platform binary mise can extract.
-# [tools]
-# sbx = "github:docker/sbx-releases"
+# Verified 2026-05-22: mise github backend extracts the platform tarball
+# (DockerSandboxes-darwin.tar.gz / DockerSandboxes-linux.tar.gz), preserves
+# the bin/sbx + libexec/ layout, and verifies SLSA provenance during install.
+
+[tools]
+"github:docker/sbx-releases" = "0.30.0"
 
 [env]
 # SBX_API_KEY = "op://Vault/Item/credential"  # or set via `sbx login`

--- a/plugins/tools/sbx/skills/sbx/templates/mise.toml
+++ b/plugins/tools/sbx/skills/sbx/templates/mise.toml
@@ -1,0 +1,21 @@
+# Source: https://docs.docker.com/ai/sandboxes/get-started/
+# sbx ships as platform-native packages — install via brew/winget/apt per SKILL.md.
+# mise github backend is left commented out because docker/sbx-releases ships
+# platform installers, not a single cross-platform binary mise can extract.
+# [tools]
+# sbx = "github:docker/sbx-releases"
+
+[env]
+# SBX_API_KEY = "op://Vault/Item/credential"  # or set via `sbx login`
+
+[tasks."sbx:up"]
+description = "Launch a Claude sandbox with worktree isolation"
+run = "sbx run claude --branch auto"
+
+[tasks."sbx:ls"]
+description = "List sandboxes"
+run = "sbx ls"
+
+[tasks."sbx:diagnose"]
+description = "Gather sbx diagnostics"
+run = "sbx diagnose"

--- a/plugins/tools/sbx/skills/sources.md
+++ b/plugins/tools/sbx/skills/sources.md
@@ -1,0 +1,29 @@
+# Sources
+
+## sbx skill
+
+### Docker Sandboxes Documentation
+
+- **Source**: https://docs.docker.com/reference/cli/sbx/
+  - Extracted: subcommand list (run, create, exec, cp, ports, ls, stop, rm, login, version, diagnose), confirmed flags (--branch, --publish)
+  - Accessed 2026-05-22
+
+- **Source**: https://docs.docker.com/ai/sandboxes/
+  - Extracted: product overview — microVM architecture, KVM hypervisor, per-VM Docker daemon, workspace mount
+  - Accessed 2026-05-22
+
+- **Source**: https://docs.docker.com/ai/sandboxes/get-started/
+  - Extracted: install commands for macOS (brew), Windows (winget), Ubuntu (apt), prerequisite notes
+  - Accessed 2026-05-22
+
+- **Source**: https://docs.docker.com/ai/sandboxes/usage/
+  - Extracted: agent list (Claude Code, Codex, Copilot, Cursor, Droid, Gemini, Kiro, OpenCode, Docker Agent, Shell), `--branch auto` worktree flag, lifecycle commands
+  - Accessed 2026-05-22
+
+- **Source**: https://docs.docker.com/ai/sandboxes/security/
+  - Extracted: four-layer isolation model (hypervisor, network proxy, per-VM daemon, credential proxy), deny-by-default network policy, workspace caveat (hooks/CI/build scripts execute on host)
+  - Accessed 2026-05-22
+
+- **Source**: https://github.com/docker/sbx-releases
+  - Extracted: release history reference; no version number fabricated from this source
+  - Accessed 2026-05-22

--- a/plugins/tools/sbx/skills/sources.md
+++ b/plugins/tools/sbx/skills/sources.md
@@ -27,3 +27,14 @@
 - **Source**: https://github.com/docker/sbx-releases
   - Extracted: release history reference; no version number fabricated from this source
   - Accessed 2026-05-22
+
+- **Source**: https://github.com/docker/sbx-releases/releases/download/v0.30.0/DockerSandboxes-darwin.tar.gz (and `-linux.tar.gz`)
+  - Extracted: archive layout (`bin/sbx` + `libexec/` runtime tree + `completions/`); verified mise github backend installs and extracts the tarball correctly with SLSA provenance verification
+  - Accessed 2026-05-22
+
+### Third-party
+
+- **Source**: https://www.msbiro.net/posts/docker-sandboxes-ai-agents/ — Matteo Bisi, 2026-04-07
+  - Extracted: `sbx policy allow network -g <host>` syntax, `sbx policy ls` (both confirmed against upstream usage page), `sbx exec -it` flag, interactive dashboard keyboard shortcuts (confirmed against upstream), `.sbx/` worktree directory + gitignore recommendation, `--branch` as recommended pattern for reviewable agent edits
+  - Note: `sbx secret` subcommand mentioned in the blog is NOT confirmed against upstream docs; omitted from this skill per anti-fabrication policy
+  - Accessed 2026-05-22


### PR DESCRIPTION
- New plugin `plugins/tools/sbx/` (v0.1.0): SKILL.md covering install + 11 subcommands + four-layer security model, references/commands.md, references/security-model.md, templates/mise.toml
- Add `## Sandboxing` section to `plugins/core/skills/mise/SKILL.md` covering experimental flag, allow/deny CLI flags, task-level config, platform matrix (Landlock/Seatbelt/unsupported), limitations
- New `plugins/core/skills/mise/templates/sandboxing.md` with runnable mise.toml + ad-hoc examples
- Bumps: core 0.2.5 → 0.2.6, marketplace 1.0.10 → 1.0.11, all-skills 0.4.9 → 0.4.10
- Skills do not cross-link — different isolation layers (microVM vs Landlock/Seatbelt syscall gating)