### PR TITLE
feat(qa): support persona-aware docs/user-stories/<persona>/<slug>.md layout

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -128,7 +128,7 @@
       "source": "./plugins/tools/qa",
       "strict": true,
       "description": "QA team that validates a running application against Gherkin user stories using Playwright and Tidewave",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "tools",
       "keywords": ["qa", "gherkin", "playwright", "tidewave", "tdd", "user-stories", "bdd"],
       "license": "MIT"

--- a/plugins/tools/qa/.claude-plugin/plugin.json
+++ b/plugins/tools/qa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "QA team that validates a running application against Gherkin user stories using Playwright and Tidewave",
   "author": { "name": "vinnie357" },
   "repository": "https://github.com/vinnie357/claude-skills",

--- a/plugins/tools/qa/agents/qa-author.md
+++ b/plugins/tools/qa/agents/qa-author.md
@@ -1,13 +1,13 @@
 ---
 name: qa-author
-description: Questionnaire agent that interviews a user about a feature, writes a Gherkin user story to docs/user-stories/<slug>.md, and self-validates the output against the qa parser. Spawned by /qa:new-story.
+description: Questionnaire agent that interviews a user about a feature, writes a persona-aware Gherkin user story to docs/user-stories/<persona>/<slug>.md, and self-validates the output against the qa parser. Spawned by /qa:new-story.
 tools: Read, Write, Glob, Grep, Bash
 model: haiku
 ---
 
 # QA Author
 
-You interview the user about a feature, then write a Gherkin user story to `docs/user-stories/<slug>.md`. You self-validate against the parser rules in `/qa:qa` `references/gherkin-format.md` before reporting success.
+You interview the user about a feature, then write a Gherkin user story to `docs/user-stories/<persona>/<slug>.md`. You self-validate against the parser rules in `/qa:qa` `references/gherkin-format.md` before reporting success.
 
 ## Skills (load and quote one sentence each as proof)
 
@@ -21,15 +21,23 @@ Quote one sentence from each in your first response.
 
 The `/qa:new-story` command passes:
 
-- `SLUG` — kebab-case slug. The output file will be `docs/user-stories/<slug>.md`.
+- `RAW_SLUG` — one of two forms:
+  - `<persona>/<slug>` shorthand, e.g. `editor/cell-regenerate`.
+  - bare `<slug>` (kebab-case), paired with an explicit `PERSONA` arg.
+- `PERSONA` — optional kebab-case persona name when `RAW_SLUG` is bare. If both forms are supplied and conflict, reject.
 - `FEATURE_HINT` — optional short title from the `--feature=` flag.
 - `REPO_ROOT` — absolute path.
 
+The output file is `<REPO_ROOT>/docs/user-stories/<persona>/<slug>.md`. Slug uniqueness is scoped per-persona: `owner/cell-create.md` and `editor/cell-create.md` are distinct stories and both succeed.
+
 ## Phase 1: Re-check the gate
 
-1. Verify the slug matches `^[a-z0-9]+(-[a-z0-9]+)*$`. Reject and stop if not.
-2. Verify `<REPO_ROOT>/docs/user-stories/<slug>.md` does not exist. Reject and stop if it does — the command-level pre-check should have caught this, but never overwrite.
-3. Ensure `<REPO_ROOT>/docs/user-stories/` exists, creating it if missing via the Bash tool (`mkdir -p`).
+1. **Split `RAW_SLUG`**. If `RAW_SLUG` contains exactly one `/`, split into `PERSONA` and `SLUG`; if it contains zero `/`, treat `RAW_SLUG` as `SLUG` and use the `PERSONA` arg. If `RAW_SLUG` contains more than one `/`, reject (`docs/user-stories/` admits at most one persona sub-directory).
+2. **Load the persona allowlist** from `<REPO_ROOT>/.qa/personas.toml`. If the file is missing, fall back to the default set `{owner, editor, viewer, cross-persona, administrator}`. Allowlist keys live under the top-level `[personas]` table (subkeys are persona names).
+3. Verify `PERSONA` is in the allowlist. Reject with the allowed list if not.
+4. Verify `SLUG` matches `^[a-z0-9]+(-[a-z0-9]+)*$`. Reject and stop if not.
+5. Verify `<REPO_ROOT>/docs/user-stories/<PERSONA>/<SLUG>.md` does not exist. Reject and stop if it does — the command-level pre-check should have caught this, but never overwrite.
+6. Ensure `<REPO_ROOT>/docs/user-stories/<PERSONA>/` exists, creating it if missing via the Bash tool (`mkdir -p`).
 
 ## Phase 2: Read the spec
 
@@ -40,12 +48,13 @@ Read `/qa:qa` `references/gherkin-format.md` and `templates/user-story.md` from 
 Use the AskUserQuestion tool when available, otherwise ask conversationally. Wait for each answer before proceeding. Ask in order:
 
 1. **Feature title** — "One-line title for this feature?" Use `FEATURE_HINT` as the default offer if provided. Required.
-2. **Actor** — "Who is the primary user role?" Options: guest, authenticated user, admin, API client, other. Required.
-3. **App URL** — "What URL does the app run at during validation?" Default to `http://localhost:4000` (Phoenix) or `http://localhost:3000` (Node) if you can sniff `mix.exs` or `package.json` from `REPO_ROOT`; otherwise ask. This populates `Background:`.
-4. **Seed data** — "Any seed data or auth state that should hold before every scenario?" Optional. Multi-line answer accepted; each line becomes one `And` step in `Background:`.
-5. **Golden-path scenario name** — "One-line name for the primary happy path?" Required.
-6. **Golden-path steps** — For each of Given / When / Then, ask "What <Given/When/Then> step(s) for this scenario?" Multi-line; each line becomes its own step (`Given` for the first, `And` for subsequent). At least one `When` and one `Then` required.
-7. **Edge scenarios** — "Add another scenario? (yes/no)" Loop on yes. For each new scenario, repeat steps 5–6.
+2. **Persona confirmation** — Only ask if `PERSONA` came from the bare-slug form AND the allowlist has more than one entry. Otherwise skip (the persona is already pinned). When asking: AskUserQuestion with one option per allowlist entry, header "Persona". Default to the `PERSONA` arg if supplied.
+3. **Actor** — "Who is the primary user role for the steps?" This populates the Gherkin step text (e.g., "Given an authenticated editor on the workspace…"); it is not the persona directory. Default offer: the `PERSONA` value resolved above. Required.
+4. **App URL** — "What URL does the app run at during validation?" Default to `http://localhost:4000` (Phoenix) or `http://localhost:3000` (Node) if you can sniff `mix.exs` or `package.json` from `REPO_ROOT`; otherwise ask. This populates `Background:`.
+5. **Seed data** — "Any seed data or auth state that should hold before every scenario?" Optional. Multi-line answer accepted; each line becomes one `And` step in `Background:`.
+6. **Golden-path scenario name** — "One-line name for the primary happy path?" Required.
+7. **Golden-path steps** — For each of Given / When / Then, ask "What <Given/When/Then> step(s) for this scenario?" Multi-line; each line becomes its own step (`Given` for the first, `And` for subsequent). At least one `When` and one `Then` required.
+8. **Edge scenarios** — "Add another scenario? (yes/no)" Loop on yes. For each new scenario, repeat steps 6–7.
 
 ## Phase 4: Compose
 
@@ -54,7 +63,10 @@ Build the file content in this exact shape:
 ````markdown
 # <Feature title>
 
+**Persona**: `<persona>`
+
 ```gherkin
+@persona:<persona>
 Feature: <Feature title>
 
   Background:
@@ -94,26 +106,27 @@ If any check fails, fix the composition and re-check. If after one fix it still 
 
 ## Phase 6: Write
 
-Use the Write tool to create `<REPO_ROOT>/docs/user-stories/<slug>.md` with the composed content. Re-check the file does not exist immediately before writing (race-free; Write fails if it already exists when used for a new file, which is the desired behavior).
+Use the Write tool to create `<REPO_ROOT>/docs/user-stories/<PERSONA>/<SLUG>.md` with the composed content. Re-check the file does not exist immediately before writing (race-free; Write fails if it already exists when used for a new file, which is the desired behavior).
 
 ## Phase 7: Report
 
 Output:
 
 ```
-STORY WRITTEN — docs/user-stories/<slug>.md
+STORY WRITTEN — docs/user-stories/<persona>/<slug>.md
 
 Skill quotes:
 - /qa:qa: <sentence>
 - /core:anti-fabrication: <sentence>
 - /core:nushell: <sentence>
 
+Persona: <persona>
 Feature: <title>
 Scenarios:
 - <name 1> — <count> Given / <count> When / <count> Then
 - <name 2> — …
 
-Next: run /qa docs/user-stories/<slug>.md to validate the app against this story.
+Next: run /qa docs/user-stories/<persona>/<slug>.md to validate the app against this story.
 ```
 
 ## Hard rules

--- a/plugins/tools/qa/commands/new-story.md
+++ b/plugins/tools/qa/commands/new-story.md
@@ -1,28 +1,38 @@
 ---
-description: "Author a Gherkin user story compatible with /qa, saved to docs/user-stories/<name>.md"
-argument-hint: "<slug> [--feature=<short-title>]"
+description: "Author a persona-aware Gherkin user story compatible with /qa, saved to docs/user-stories/<persona>/<slug>.md"
+argument-hint: "<persona>/<slug> [--feature=<short-title>]   OR   <slug> --persona=<persona> [--feature=...]"
 ---
 
-Author a new Gherkin user story compatible with the `/qa` validator. Runs the `qa-author` agent (haiku) which asks a short questionnaire and writes a parser-valid file to `docs/user-stories/<slug>.md`. The resulting story can be validated end-to-end against the running application by running `/qa docs/user-stories/<slug>.md`.
+Author a new Gherkin user story compatible with the `/qa` validator. Runs the `qa-author` agent (haiku) which asks a short questionnaire and writes a parser-valid file to `docs/user-stories/<persona>/<slug>.md`. The resulting story can be validated end-to-end against the running application by running `/qa docs/user-stories/<persona>/<slug>.md`.
 
 **What it does:**
 
-1. **Validate the slug** — kebab-case, no spaces or slashes; the file must not already exist.
-2. **Spawn `qa-author`** — Reads the parser spec at `/qa:qa` `references/gherkin-format.md` and the skeleton at `templates/user-story.md`, then runs the questionnaire.
-3. **Questionnaire** — Asks for the feature title, primary actor, app URL, optional shared seed data, golden-path scenario name + steps, and optional edge scenarios + steps. Uses `AskUserQuestion` when available.
-4. **Compose + self-validate** — Builds the Gherkin, re-checks it against the parser rules, and only writes the file when the output is valid.
-5. **Write** — Writes `docs/user-stories/<slug>.md`. Refuses to overwrite if the file already exists.
+1. **Resolve persona + slug** — accept either `<persona>/<slug>` shorthand or a bare `<slug>` paired with `--persona=<name>`. Validate persona against the repo's allowlist at `.qa/personas.toml` (fall back to a default set if absent). Validate slug against `^[a-z0-9]+(-[a-z0-9]+)*$`.
+2. **Confirm the file does not exist** at `docs/user-stories/<persona>/<slug>.md`. Slug uniqueness is scoped per-persona — the same slug under two different personas is allowed and produces two distinct files.
+3. **Spawn `qa-author`** — Reads the parser spec at `/qa:qa` `references/gherkin-format.md` and the skeleton at `templates/user-story.md`, then runs the questionnaire.
+4. **Questionnaire** — Asks for the feature title, primary actor, app URL, optional shared seed data, golden-path scenario name + steps, and optional edge scenarios + steps. Uses `AskUserQuestion` when available. Persona is pre-filled; confirms only when ambiguous.
+5. **Compose + self-validate** — Builds the Gherkin (including the `@persona:<name>` tag and a `**Persona**: <name>` prose line above the fence), re-checks it against the parser rules, and only writes the file when the output is valid.
+6. **Write** — Writes `docs/user-stories/<persona>/<slug>.md`. Refuses to overwrite if the file already exists.
 
 **Arguments:**
 
-- `<slug>` — kebab-case identifier; becomes the file name. Required.
+- `<persona>/<slug>` (shorthand) or `<slug> --persona=<name>` — the persona segment selects the destination directory; the slug becomes the file name.
 - `--feature=<short-title>` — optional default offer for the feature-title question.
 
 **Examples:**
 
 ```
-/qa:new-story checkout
-/qa:new-story user-registration --feature="Email-based signup"
+/qa:new-story editor/cell-regenerate
+/qa:new-story cell-regenerate --persona=editor --feature="Editor regenerates a presentation cell"
+/qa:new-story owner/share-workbook
+/qa:new-story administrator/audit-log --feature="Admin exports the audit log"
+```
+
+The same slug under two personas is valid:
+
+```
+/qa:new-story owner/cell-create        # writes docs/user-stories/owner/cell-create.md
+/qa:new-story editor/cell-create       # writes docs/user-stories/editor/cell-create.md
 ```
 
 **Skills the author loads (no globs — explicit names):**
@@ -33,4 +43,11 @@ Author a new Gherkin user story compatible with the `/qa` validator. Runs the `q
 
 **Task instructions:**
 
-Use the `qa-author` subagent. Pass it the resolved slug (rejecting if it does not match `^[a-z0-9]+(-[a-z0-9]+)*$`), the `--feature` value if provided, and the repo root (current working directory unless the path is in a subrepo). Verify `docs/user-stories/<slug>.md` does not exist before spawning the agent — refuse to overwrite.
+Use the `qa-author` subagent. Parse the argument:
+
+- If the first positional contains exactly one `/`, split into `PERSONA` / `SLUG`. If it contains zero `/`, the first positional is `SLUG`; require `--persona=<name>`. Multiple `/` is an error.
+- Validate `PERSONA` against `<REPO_ROOT>/.qa/personas.toml` (or the default set `{owner, editor, viewer, cross-persona, administrator}` if the file is absent).
+- Validate `SLUG` against `^[a-z0-9]+(-[a-z0-9]+)*$`.
+- Compute the resolved target path: `<REPO_ROOT>/docs/user-stories/<PERSONA>/<SLUG>.md`.
+
+Verify the resolved target does not exist before spawning the agent — refuse to overwrite. Pass `RAW_SLUG`, `PERSONA`, the `--feature` value if provided, and the repo root (current working directory unless the path is in a subrepo) to the agent.

--- a/plugins/tools/qa/skills/qa/references/gherkin-format.md
+++ b/plugins/tools/qa/skills/qa/references/gherkin-format.md
@@ -4,7 +4,27 @@ The dialect `/qa` accepts, the parsing rules, and the rejection criteria.
 
 ## File Layout
 
-User stories live at `docs/user-stories/<slug>.md` in the target repo. One story per file. The slug is kebab-case and becomes the file name.
+User stories live at `docs/user-stories/<persona>/<slug>.md` in the target repo. One story per file. The slug is kebab-case and becomes the file name. The persona segment selects which role the story belongs to; allowed values come from the repo's `.qa/personas.toml` allowlist (default set: `{owner, editor, viewer, cross-persona, administrator}`).
+
+The legacy flat layout `docs/user-stories/<slug>.md` (no persona segment) is accepted for backward compatibility — existing flat stories continue to lint clean — but new stories should use the persona-aware path so worker dispatch and visibility-conditioned validation can reason about role.
+
+Slug uniqueness is scoped per-persona: `owner/cell-create.md` and `editor/cell-create.md` are distinct stories that both exist simultaneously.
+
+## Persona taxonomy
+
+Allowed personas come from `<REPO_ROOT>/.qa/personas.toml`:
+
+```toml
+[personas.owner]
+description = "Creates and owns the resource; controls sharing."
+
+[personas.editor]
+description = "Edits content; cannot share."
+
+# … one table per allowed persona name.
+```
+
+If the file is missing, the parser falls back to the default set above so first-run UX still works. When the file exists, persona names not listed in it are rejected at path-resolution time (rule #2 below).
 
 The file is a markdown document with **at least one** fenced Gherkin block:
 
@@ -69,7 +89,7 @@ Tags (lines starting with `@`) are tolerated but currently ignored — they have
 The `qa-lead` aborts (no workers spawned) if any of the following hold. Each rejection includes the rule number in the error report so the user can fix the file.
 
 1. File does not exist at the resolved path.
-2. Path is outside `docs/user-stories/` in the target repo.
+2. Path is outside `docs/user-stories/` in the target repo. Within `docs/user-stories/`, two depths are accepted: `docs/user-stories/<slug>.md` (legacy flat) and `docs/user-stories/<persona>/<slug>.md` (persona-aware, recommended). Deeper nesting is rejected. The `<persona>` segment must be in the repo's allowlist (`.qa/personas.toml` or the default set).
 3. No ```gherkin fenced block present.
 4. Zero `Feature:` lines, or more than one.
 5. Zero `Scenario:` / `Scenario Outline:` blocks.

--- a/plugins/tools/qa/skills/qa/templates/user-story.md
+++ b/plugins/tools/qa/skills/qa/templates/user-story.md
@@ -1,8 +1,11 @@
 # <Feature title — human readable>
 
+**Persona**: `<persona>`
+
 <Optional prose explaining the feature, the user, and why this scenario matters. Not parsed by `/qa`.>
 
 ```gherkin
+@persona:<persona>
 Feature: <one-line feature title>
 
   Background:


### PR DESCRIPTION
## Summary

- Persona-aware story layout: `docs/user-stories/<persona>/<slug>.md` is now first-class in `/qa`.
- New `.qa/personas.toml` allowlist per repo (with a sane default set when the file is absent).
- Template adds `Persona:` prose line + `@persona:<name>` tag.
- Backward-compatible with existing flat-layout stories.

## Files changed

- `plugins/tools/qa/agents/qa-author.md`
- `plugins/tools/qa/commands/new-story.md`
- `plugins/tools/qa/skills/qa/references/gherkin-format.md`
- `plugins/tools/qa/skills/qa/templates/user-story.md`

## Local CI

```
[test:plugin] $ if [ -z "$1" ]; then qa
🔍 Validating plugin: qa...

[1;32mValidating plugin:[0m qa

[36mChecking required fields...[0m

[36mChecking for invalid fields...[0m

[36mValidating skills...[0m

[36mValidating agents...[0m

[1;36mValidation Results:[0m
  Errors: 0
  Warnings: 0

[1;32m✓ Plugin 'qa' is valid![0m
```

## Out of scope

- Persona-conditioned worker fixtures (auth-as-role).
- `BEES REQUESTS:` `persona=` field.
- Validation-loop contradiction-checks (e.g., a viewer scenario whose `Then` says "they click Edit").

These land in a follow-up once a runnable app under test exists.

## Test plan

- [x] Local: `mise run test:plugin qa` green (output above).
- [ ] Remote: validate.yml green.
- [ ] Smoke (separate session): `/qa:new-story owner/test-flow` writes to `docs/user-stories/owner/test-flow.md` with `Persona: owner` + `@persona:owner` tag.