### PR TITLE
docs(linear): add ## Agents optional section to epic-format

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -108,7 +108,7 @@
       "source": "./plugins/tools/linear",
       "strict": true,
       "description": "Linear project management: MCP/GraphQL API, VantageEx epic authoring, auditing, and grooming",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "category": "tools",
       "keywords": ["linear", "project-management", "epics", "graphql", "vantageex", "mcp"],
       "license": "MIT"

--- a/plugins/tools/linear/.claude-plugin/plugin.json
+++ b/plugins/tools/linear/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "linear",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Linear project management: MCP/GraphQL API, VantageEx epic authoring, auditing, and grooming",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/linear/skills/linear/references/epic-format.md
+++ b/plugins/tools/linear/skills/linear/references/epic-format.md
@@ -131,9 +131,9 @@ Written by the agent when a PR is submitted. Contains the pull request URL.
 Per-epic agent priority list — ordered, comma-separated agent types the picker walks when dispatching.
 
 - Allowed values (v1): `claude`, `codex`, `antigravity`, `local`
-- Missing section defaults to `[claude]` (matches pre-VIN-311 behavior)
+- Missing section defaults to `[claude]`
 - Picker walks the list in order; for each type it checks (a) driver registered, (b) usage under cap. First match wins.
-- Types without a registered Runex driver are logged and skipped (e.g. `codex pending VIN-281`)
+- Types without a registered driver are logged and skipped
 - Per-account scoping is opaque in v1 (single account per type); per-issue `account_id` is a follow-up
 
 Example:
@@ -144,7 +144,6 @@ Example:
 claude, local
 ```
 
-See ADR-069 (agent-usage-quotas-and-priority-list) for the picker gate and adapter contract.
 
 ## Title and Slug
 

--- a/plugins/tools/linear/skills/linear/references/epic-format.md
+++ b/plugins/tools/linear/skills/linear/references/epic-format.md
@@ -7,7 +7,7 @@
 - [Required Sections](#required-sections)
 - [Optional Sections](#optional-sections)
 - [Title and Slug](#title-and-slug)
-- [Description Sections (ADR-027)](#description-sections-adr-027)
+- [Description Sections](#description-sections)
 - [Instructions Flow](#instructions-flow)
 - [Anti-Patterns](#anti-patterns)
 - [Example Epic](#example-epic)
@@ -16,7 +16,7 @@
 
 VantageEx parses Linear issue descriptions programmatically. The epic body uses markdown `## Section` headers that VantageEx reads at pick time and on every poll. Sections must use exact header names — the parser matches on these strings.
 
-Source: ADR-027 (Epic Messaging), ADR-016 (Layered Tasking), ADR-025 (Epic Lifecycle).
+The epic format follows the VantageEx epic messaging convention, the VantageEx layered tasking model, and the VantageEx epic lifecycle.
 
 ## Three-Level Hierarchy
 
@@ -64,11 +64,11 @@ Target repositories this epic touches:
 - vinnie357/runex
 ```
 
-May be a single repo or multiple. ADR-023 supports multi-repo epics with parallel execution.
+May be a single repo or multiple. The VantageEx multi-repo epic support enables parallel execution across repos.
 
 ## Optional Sections
 
-### `## Instructions` (ADR-027)
+### `## Instructions`
 
 User guidance added when re-queuing an epic from `needs_help` state. Takes priority over general conventions.
 
@@ -167,7 +167,7 @@ The slug determines the feature branch name: `feature/<epic-slug>`
 
 Max 80 characters when combined with role prefix: `<epic-slug>/_team/leader-<model>`
 
-## Description Sections (ADR-027)
+## Description Sections
 
 Two communication channels:
 

--- a/plugins/tools/linear/skills/linear/references/epic-format.md
+++ b/plugins/tools/linear/skills/linear/references/epic-format.md
@@ -126,6 +126,26 @@ Written by the agent when a PR is submitted. Contains the pull request URL.
 - VantageEx reads this section to track PR state
 - Written once at submission time
 
+### `## Agents` (Optional)
+
+Per-epic agent priority list — ordered, comma-separated agent types the picker walks when dispatching.
+
+- Allowed values (v1): `claude`, `codex`, `antigravity`, `local`
+- Missing section defaults to `[claude]` (matches pre-VIN-311 behavior)
+- Picker walks the list in order; for each type it checks (a) driver registered, (b) usage under cap. First match wins.
+- Types without a registered Runex driver are logged and skipped (e.g. `codex pending VIN-281`)
+- Per-account scoping is opaque in v1 (single account per type); per-issue `account_id` is a follow-up
+
+Example:
+
+```markdown
+## Agents
+
+claude, local
+```
+
+See ADR-069 (agent-usage-quotas-and-priority-list) for the picker gate and adapter contract.
+
 ## Title and Slug
 
 ### Title


### PR DESCRIPTION
## Summary
- Adds optional `## Agents` section to the VantageEx epic format spec — per-epic agent priority list (ordered, comma-separated; defaults to `[claude]`).
- Documents semantics: walks the list in order, falls through types without a registered driver, single-account scoping in v1.
- Bumps `linear` plugin patch version + matching marketplace entry per the Version Synchronization rule.