### PR TITLE
feat(linear): normalize epic template for multi-agent + harden groom-epics for scale

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -108,7 +108,7 @@
       "source": "./plugins/tools/linear",
       "strict": true,
       "description": "Linear project management: MCP/GraphQL API, VantageEx epic authoring, auditing, and grooming",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "category": "tools",
       "keywords": ["linear", "project-management", "epics", "graphql", "vantageex", "mcp"],
       "license": "MIT"

--- a/plugins/tools/linear/.claude-plugin/plugin.json
+++ b/plugins/tools/linear/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "linear",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Linear project management: MCP/GraphQL API, VantageEx epic authoring, auditing, and grooming",
   "author": {
     "name": "vinnie357"
@@ -10,5 +10,10 @@
   "keywords": ["linear", "project-management", "epics", "graphql", "vantageex", "mcp"],
   "skills": [
     "./skills/linear"
+  ],
+  "commands": [
+    "./commands/plan-epic.md",
+    "./commands/audit-epics.md",
+    "./commands/groom-epics.md"
   ]
 }

--- a/plugins/tools/linear/commands/groom-epics.md
+++ b/plugins/tools/linear/commands/groom-epics.md
@@ -1,73 +1,162 @@
 ---
 description: "Fix VantageEx compatibility issues found by audit-epics"
-argument-hint: "[--project=<slug>] [--issue=<key>] [--auto]"
+argument-hint: "[--project=<slug>] [--issue=<key>] [--auto] [--max-issues=<N>] [--confirm-bulk]"
 ---
 
-Fix VantageEx compatibility issues found by the audit.
+Fix VantageEx compatibility issues across one epic or a whole project. Scoped, pre-flight-gated, and offloads the audit pass to a haiku mapper so the parent session never holds full descriptions for an entire project.
 
 ## Steps
 
 1. Load the `/linear` skill
 2. Read the epic format spec at `references/epic-format.md`
-3. Read the team definition template at `templates/0.1.0/team-definition.md`
+3. Read the audit checklist at `references/audit-checklist.md`
+4. Read the team definition template at `templates/0.1.0/team-definition.md`
 
-## Get Audit Results
+## Phase A — Pre-flight
 
-Either:
-- Accept prior audit output if available in the conversation
-- Run a fresh audit (same as `/linear:audit-epics`) for the specified scope
+Run on every invocation. Halt with a clear message if any check fails — never partial-progress.
 
-Only process findings with severity `error` or `warning`. Info-level findings are reported but not auto-fixed.
+1. **Verify Linear access**. Pass if either:
+   - The Linear MCP server is registered (`claude mcp list` shows a `linear-server` entry), OR
+   - `LINEAR_API_KEY` environment variable is set.
 
-## Fix Each Finding
+   If neither, halt with:
+   > Linear access is not configured. Set up one of:
+   > - `claude mcp add --transport http linear-server https://mcp.linear.app/mcp` then `/mcp` to authenticate
+   > - `export LINEAR_API_KEY=<key>` (see https://linear.app/settings/account/security)
 
-For each error/warning finding, apply the appropriate fix:
+2. **Resolve scope** from arguments:
+   - `--issue=<key>` (e.g., `--issue=VIN-42`) → single-issue path. Skip Phase B; audit + groom inline.
+   - `--project=<slug>` → project path. Continue to Phase B.
+   - Neither → ask the user which scope.
+
+3. **For project scope: identify open-state IDs.** Query the team's `workflowStates` and keep only states whose `type` is in `{triage, backlog, unstarted, started}`. **Exclude any state whose `type` is `completed` or `canceled`** — grooming closed epics is forbidden and would mutate finished work.
+
+4. **Count candidates.** Query the project for issues in the open-state IDs only. Print the count.
+
+5. **Overload gate.** If `count >= --max-issues` (default `50`), refuse to proceed without `--confirm-bulk`. Suggest narrowing with `--issue=<key>` or batching as a follow-up. This is a hard gate — `--auto` does not bypass it.
+
+## Phase B — Mapper (project scope only)
+
+Spawn a single read-only haiku agent to audit all candidates and return a compact digest. The parent session never holds the full descriptions.
+
+Use the Task tool with `subagent_type: Explore` and `model: haiku`. The mapper prompt:
+
+```
+## Load skills
+
+Load these by exact name (no globs):
+- /linear (provides MCP/GraphQL helpers and the epic format spec)
+- /core:anti-fabrication (no claim without tool verification)
+
+Quote one sentence from each loaded skill in your first response.
+
+## Task
+
+You are auditing Linear epics for VantageEx compatibility. READ-ONLY — do not write to Linear.
+
+For each issue in the candidate list, fetch via Linear MCP (preferred) or GraphQL:
+  - identifier, url, title, state.name, state.type, labels, attachments
+  - full description
+
+Run the structure + content checks from `references/audit-checklist.md`:
+  - Objective Present, Objective Quality
+  - Skills Present, Skills Valid, Skills Not Listing Core
+  - Repos Present
+  - Agents Valid, Agents Section Non-Empty
+  - Team Defined
+  - PR on Completed (only for state.type == "started" with a state.name suggesting review)
+  - Implementation Details
+
+Return JSON, sorted by error_count desc, truncated to top 25:
+
+[
+  {
+    "identifier": "VIN-42",
+    "url": "https://linear.app/...",
+    "state_type": "started",
+    "state_name": "In Progress",
+    "error_count": 2,
+    "warning_count": 1,
+    "info_count": 0,
+    "findings": [
+      {"check": "Objective Present", "severity": "error"},
+      {"check": "Agents Valid", "severity": "warning", "detail": "gemini -> antigravity"}
+    ]
+  }
+]
+
+Do not include description bodies in the response. The groom phase re-fetches them.
+```
+
+## Phase C — Groom
+
+For single-issue scope: audit the one issue inline, then proceed to fix.
+For project scope: iterate over the mapper digest.
+
+For each entry:
+
+1. **Re-fetch the full issue body** via MCP or GraphQL (only at fix time — Phase B kept tokens cheap).
+
+2. **Apply fixes** per check:
 
 ### Missing Objective
-- If the title is descriptive, generate a 2-3 sentence objective from the title and any existing description content
+- If the title is descriptive, generate a 2-3 sentence objective from the title and any existing content
 - Ask the user to confirm before applying
+- `--auto` skips this fix (content change requires human review)
 
 ### Missing Skills
-- Analyze the issue title and description to suggest relevant skills
-- Validate suggestions against marketplace.json
+- Suggest skills from the title and description
+- Validate against `marketplace.json`
 - Ask the user to confirm the skill list
 
 ### Missing Repos
-- Check if the issue mentions repository names in its description or comments
-- Ask the user to specify target repos if none can be inferred
+- Check the description and comments for repo names
+- Ask the user to specify if none can be inferred
 
 ### Missing Team
 - Insert the default team definition: `lead: sonnet, default_model: haiku, escalation: haiku -> sonnet -> opus`
-- Apply without asking (this is a safe default)
+- Apply without asking (safe default)
 
 ### Core Skills Listed
-- Remove core skills from the skills list automatically
+- Strip core skills (`anti-fabrication, git, tdd, twelve-factor, security, mise, nushell`) automatically
+
+### Invalid Agents
+- Confirm with the user before any rewrite
+- Rewrite `gemini` → `antigravity` (the Google CLI runs Gemini)
+- Flag any other unknown value (e.g., `gpt4`, `bard`) — do not auto-rewrite
+
+### Empty Agents Section
+- Ask the user: remove the empty header (default `[claude]` applies) or fill in agents
+- No auto-fix — intent is ambiguous
 
 ### Missing PR on Completed
-- Search for matching PRs using `gh pr list --search "<issue-identifier>"` and `gh pr list --search "<title>"`
-- If a matching PR is found, attach it via `attachmentLinkGitHubPR` and add `## PR` section
+- Search via `gh pr list --search "<issue-identifier>"` and `gh pr list --search "<title>"`
+- If found, attach via `attachmentLinkGitHubPR` and add `## PR` section
 - If no PR found, flag for manual resolution
+- (Phase A excludes `completed`/`canceled` epics; this rule fires only for `review`-state work)
 
 ### Implementation Details in Description
 - Flag the specific content for user review
-- Do not auto-remove (user may have intentional content)
+- Do not auto-remove — user may have intentional content
 
-## Apply Updates
+3. **Apply writes** via Linear MCP (preferred) or GraphQL.
 
-Use Linear MCP tools (preferred) or GraphQL to:
-1. Update issue descriptions with added/fixed sections
-2. Create/attach labels for skills
-3. Attach PR URLs where found
+`--auto` semantics: safe fixes (team default insertion, core-skill stripping) apply silently. Content fixes (objective, skills, repos, invalid agents) still confirm with the user.
 
-## Verify
+## Phase D — Verify + Report
 
-After applying fixes:
-1. Re-run the audit checks on modified issues
-2. Report what was changed and what remains unfixed
-3. Present a before/after summary
+1. Re-run the audit checks on touched epics (reuse the same check set from Phase B).
+2. Output a summary:
+   - Before/after error + warning counts per epic
+   - Epics flagged but skipped (user declined a content fix)
+   - Any writes that failed (auth, mutation errors) — these get listed individually with error text
+3. For project scope, also report the top-25 cap — if more epics had findings, name the next batch the user can target.
 
 ## Auto Mode
 
 If `--auto` is specified:
 - Apply all safe fixes without asking (team defaults, core skill removal)
-- Still ask for confirmation on content changes (objective, skills, repos)
+- Still ask for confirmation on content changes (objective, skills, repos, invalid agents)
+- Empty Agents Section still requires user input (no auto-fix)
+- Pre-flight overload gate still applies (`--auto` does not bypass `--confirm-bulk`)

--- a/plugins/tools/linear/skills/linear/SKILL.md
+++ b/plugins/tools/linear/skills/linear/SKILL.md
@@ -182,7 +182,8 @@ The user authors the epic description in Linear. The epic body uses markdown sec
 |---------|---------|--------|
 | `## Instructions` | User guidance added at re-queue (ADR-027) | User or dashboard |
 | `## Constraints` | Boundaries (defaults: `mise run ci`, no attribution, squash merge) | User |
-| `## Team` | Lead model, default model, escalation policy | User |
+| `## Agents` | Priority-ordered agent CLIs from `{claude, codex, antigravity, local}` (default `[claude]`) | User |
+| `## Team` | Claude model layer: lead, default, escalation (applies when Agents resolves to `claude`) | User |
 | `## Escalation` | Failure and ambiguity policies | User |
 | `## PR` | Pull request URL when submitted | Agent |
 

--- a/plugins/tools/linear/skills/linear/references/audit-checklist.md
+++ b/plugins/tools/linear/skills/linear/references/audit-checklist.md
@@ -42,6 +42,16 @@ Structured validation checks for VantageEx epic compatibility. Each check has a 
 - **Check**: Description contains `## Repos` section with at least one repository
 - **Remediation**: Add a `## Repos` section listing target repositories
 
+### Agents Valid
+- **Severity**: warning
+- **Check**: If `## Agents` section is present, every entry is in the canonical set `{claude, codex, antigravity, local}`
+- **Remediation**: Replace unknown values with canonical agents. `gemini` should be written as `antigravity` (the Google CLI runs Gemini).
+
+### Agents Section Non-Empty
+- **Severity**: info
+- **Check**: If a `## Agents` header is present, the body lists at least one agent identifier
+- **Remediation**: Either remove the empty `## Agents` header (the default `[claude]` will apply) or list at least one agent.
+
 ## Team Checks
 
 ### Team Defined

--- a/plugins/tools/linear/skills/linear/references/epic-format.md
+++ b/plugins/tools/linear/skills/linear/references/epic-format.md
@@ -131,6 +131,7 @@ Written by the agent when a PR is submitted. Contains the pull request URL.
 Per-epic agent priority list — ordered, comma-separated agent types the picker walks when dispatching.
 
 - Allowed values (v1): `claude`, `codex`, `antigravity`, `local`
+- `gemini` access goes through `antigravity` (the Google CLI runs Gemini under the hood) — write `antigravity`, not `gemini`
 - Missing section defaults to `[claude]`
 - Picker walks the list in order; for each type it checks (a) driver registered, (b) usage under cap. First match wins.
 - Types without a registered driver are logged and skipped

--- a/plugins/tools/linear/skills/linear/templates/0.1.0/epic.md
+++ b/plugins/tools/linear/skills/linear/templates/0.1.0/epic.md
@@ -33,6 +33,21 @@ skill-1, skill-2
 
 - org/repo-name
 
+## Agents (Optional)
+
+> Priority-ordered list of agent CLIs that may run this epic.
+> Defaults to `claude` if omitted.
+>
+> Canonical values: `claude`, `codex`, `antigravity`, `local`.
+> `gemini` access goes through `antigravity` (Google's CLI runs Gemini).
+>
+> Comma-separated. Lowercase. First entry is preferred; later entries are
+> fallbacks when the preferred agent's quota is exhausted.
+
+```
+agents: claude, codex
+```
+
 ## Constraints (Optional)
 
 > Real boundaries only. Defaults apply if omitted:

--- a/plugins/tools/linear/skills/linear/templates/0.1.0/team-definition.md
+++ b/plugins/tools/linear/skills/linear/templates/0.1.0/team-definition.md
@@ -2,6 +2,11 @@
 
 Add this as the `## Team` section in a VantageEx epic description.
 
+The `## Team` section configures the **Claude model layer** — which Claude
+model the lead and workers use. It applies when `## Agents` resolves to
+`claude` (the default). For non-Claude agents (`codex`, `antigravity`,
+`local`), the agent's own model selection applies; this section is ignored.
+
 ## Minimal (Recommended Default)
 
 ```yaml
@@ -51,3 +56,15 @@ escalation:
 - **escalation**: Standard is `haiku -> sonnet -> opus` with max 2 promotions per agent.
 - **workers**: Optional. The team leader assigns roles during decomposition if omitted.
 - **skills**: Per-worker skills are in addition to the epic's skill list.
+
+## Runtime Overrides
+
+Model values here are defaults, not hardcoded contracts. The `/core:agent-loop`
+bundle-parameter convention lets these be overridden at run time via env vars:
+
+- `AGENT_LOOP_LEAD_MODEL` — overrides `lead`
+- `AGENT_LOOP_WORKER_MODEL` — overrides `default_model`
+- `AGENT_LOOP_ESCALATION_CHAIN` — overrides `escalation`
+
+Use the template values for human-readable intent; switch models per-run by
+exporting env vars rather than editing the epic.


### PR DESCRIPTION
- Register `/linear:plan-epic`, `/linear:audit-epics`, `/linear:groom-epics` in plugin.json (`commands` array was missing)
- Bump linear plugin 0.1.4 → 0.1.5 in plugin.json + marketplace.json
- Add `## Agents` section to `templates/0.1.0/epic.md` (priority-ordered CLI list: claude, codex, antigravity, local; gemini-via-antigravity aliasing note)
- Clarify `team-definition.md` is the Claude model layer (applies when Agents resolves to `claude`); document AGENT_LOOP_LEAD_MODEL/WORKER_MODEL/ESCALATION_CHAIN env-var overrides
- Add gemini→antigravity alias note to `references/epic-format.md`
- Add `Agents Valid` (warning) and `Agents Section Non-Empty` (info) checks to `audit-checklist.md`
- Add `## Agents` row to SKILL.md optional-sections table
- Restructure `groom-epics.md` into 4 phases: pre-flight (access check + scope + closed-state exclusion + overload gate at `--max-issues`/`--confirm-bulk`), haiku Explore mapper (top-25 digest, never holds full descriptions in parent), groom (existing fix catalog + new Invalid Agents rule with gemini→antigravity rewrite + Empty Agents Section), verify+report