### PR TITLE
feat(claude-code): add claude-workflows skill for dynamic workflows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "A curated collection of Claude skills for development workflows",
-    "version": "1.0.18"
+    "version": "1.0.19"
   },
   "plugins": [
     {
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.17",
+      "version": "0.4.18",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -53,9 +53,9 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills: plugin marketplace management and validation",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "category": "tools",
-      "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark", "skill-update", "output-styles", "statusline"]
+      "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark", "skill-update", "output-styles", "statusline", "workflows"]
     },
     {
       "name": "core",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -36,6 +36,7 @@
     "./plugins/tools/claude-code/skills/claude-skills-benchmark",
     "./plugins/tools/claude-code/skills/skill-update",
     "./plugins/tools/claude-code/skills/claude-statusline",
+    "./plugins/tools/claude-code/skills/claude-workflows",
     "./plugins/core/skills/git",
     "./plugins/core/skills/mise",
     "./plugins/core/skills/nushell",
@@ -112,6 +113,9 @@
     "./plugins/tools/agent-sandboxing/commands/exec.md",
     "./plugins/tools/agent-sandboxing/commands/reap.md",
     "./plugins/tools/agent-sandboxing/commands/status.md",
-    "./plugins/tools/agent-sandboxing/commands/build-image.md"
+    "./plugins/tools/agent-sandboxing/commands/build-image.md",
+    "./plugins/tools/linear/commands/plan-epic.md",
+    "./plugins/tools/linear/commands/audit-epics.md",
+    "./plugins/tools/linear/commands/groom-epics.md"
   ]
 }

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "claude-code",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["claude-code", "marketplace", "validation", "plugin-management", "commands", "agents", "skills", "hooks", "teams", "output-styles", "statusline"],
+  "keywords": ["claude-code", "marketplace", "validation", "plugin-management", "commands", "agents", "skills", "hooks", "teams", "output-styles", "statusline", "workflows"],
   "skills": [
     "./skills/plugin-marketplace",
     "./skills/claude-plugins",
@@ -19,6 +19,7 @@
     "./skills/claude-output-styles",
     "./skills/claude-skills-benchmark",
     "./skills/skill-update",
-    "./skills/claude-statusline"
+    "./skills/claude-statusline",
+    "./skills/claude-workflows"
   ]
 }

--- a/plugins/tools/claude-code/skills/claude-workflows/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-workflows/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: claude-workflows
+description: Guide for Claude Code dynamic workflows — JavaScript scripts that orchestrate many subagents in one background run. Use when a task needs more agents than one conversation can coordinate, codifying repeatable orchestration, running codebase-wide sweeps or large migrations, authoring or reading a workflow script, or deciding between a workflow, a subagent, and a skill.
+license: MIT
+---
+
+# Claude Code Workflows
+
+A dynamic workflow is a JavaScript script that orchestrates subagents at scale. Claude writes the script for a task you describe, a runtime executes it in the background, and only the final answer returns to your conversation. The script — not Claude's context — holds the loop, the branching, and the intermediate results, so one run coordinates tens to hundreds of agents instead of the few a single turn manages.
+
+Status: research preview, Claude Code v2.1.154+. Available on paid plans (Pro toggle in `/config`; Max, Team, Enterprise) and via the Anthropic API, Amazon Bedrock, Google Cloud Vertex AI, and Microsoft Foundry.
+
+## When to use a workflow
+
+Reach for a workflow when fan-out exceeds one turn, when the orchestration itself must be repeatable, or when work needs independent verification passes before results reach you. Examples: a codebase-wide bug sweep, a 500-file migration, research that cross-checks sources, or a hard plan drafted from several angles before commitment.
+
+Use a single subagent (the `Agent` tool) for one-off delegated work whose result lands directly in your context. Use a skill for instructions Claude follows inline. Use a workflow when neither scales.
+
+| Aspect | Subagents | Skills | Workflows |
+|--------|-----------|--------|-----------|
+| Scale | A few tasks per turn | Same as subagents | Dozens to hundreds of agents per run |
+| Intermediate results live in | Claude's context | Claude's context | Script variables |
+| What's repeatable | Worker definition | Instructions | The orchestration itself |
+| Interruption | Restarts the turn | Restarts the turn | Resumable in the same session |
+
+## How to trigger a workflow
+
+Workflows require explicit opt-in. Three paths:
+
+1. **Include the word "workflow" in the prompt.** Claude writes and runs a workflow script for the task — e.g. `Run a workflow to audit every endpoint under src/routes/ for missing auth checks`.
+2. **`/effort ultracode`.** Combines `xhigh` reasoning with automatic orchestration; Claude decides per task when a workflow is warranted. One request can spawn several workflows (understand → change → verify).
+3. **Run a saved or bundled workflow** as `/<name>`. `/deep-research` is the built-in workflow; scripts saved to `.claude/workflows/` become their own commands.
+
+## Script anatomy
+
+Every script begins with a pure-literal `export const meta = {...}` block, then a body that uses the orchestration hooks. The body runs in an async context — `await` directly.
+
+```javascript
+export const meta = {
+  name: 'audit-endpoints',
+  description: 'Find endpoints missing auth checks and propose fixes',
+  phases: [
+    { title: 'Scan', detail: 'list route files' },
+    { title: 'Review', detail: 'one agent per route file' },
+  ],
+}
+
+phase('Scan')
+const files = await agent('List every route file under src/routes/.', { schema: FILES_SCHEMA })
+
+phase('Review')
+const findings = await parallel(files.paths.map(p => () =>
+  agent(`Check ${p} for endpoints missing auth middleware.`, { schema: FINDING_SCHEMA })))
+
+return findings.filter(Boolean)
+```
+
+`meta` must be a pure literal — no variables, function calls, spreads, or template interpolation. Required fields: `name`, `description`. Reuse the same `phase()` titles in `meta.phases` so progress groups match.
+
+## Core hooks at a glance
+
+- `agent(prompt, opts?)` — spawn one subagent; returns its final text, or a validated object when `opts.schema` is set. Options: `label`, `phase`, `schema`, `model`, `isolation`, `agentType`.
+- `pipeline(items, ...stages)` — run each item through all stages independently, no barrier between stages. The default for multi-stage work.
+- `parallel(thunks)` — run thunks concurrently and await all (a barrier). A thunk that throws resolves to `null`; `.filter(Boolean)` before use.
+- `phase(title)` — start a progress group; later `agent()` calls fall under it.
+- `log(message)` — emit a narrator line to the user.
+- `workflow(nameOrRef, args?)` — run another saved workflow inline as a sub-step (one level of nesting only).
+- `args` — the value passed as the workflow's input. `budget` — the turn's token target (`budget.total`, `budget.spent()`, `budget.remaining()`).
+
+Full signatures, return values, schema usage, worktree isolation, model overrides, and resume in `references/script-api.md`.
+
+## pipeline() vs parallel()
+
+Default to `pipeline()`. It streams each item through every stage with no synchronization point, so item A reaches stage 3 while item B is still in stage 1 — wall-clock equals the slowest single chain, not the sum of slowest-per-stage.
+
+Use `parallel()` only when stage N genuinely needs every result of stage N-1 at once: dedup or merge across the full set, early-exit on a zero count, or a prompt that compares against "the other findings." Needing to flatten, map, or filter is not a barrier reason — do that inside a pipeline stage.
+
+```javascript
+// pipeline — review and verify stream per-item, no wasted wall-clock
+const results = await pipeline(
+  dimensions,
+  d => agent(d.prompt, { phase: 'Review', schema: FINDINGS }),
+  review => parallel(review.findings.map(f => () =>
+    agent(`Adversarially verify: ${f.title}`, { phase: 'Verify', schema: VERDICT })
+      .then(v => ({ ...f, verdict: v })))),
+)
+```
+
+Orchestration patterns (adversarial verify, judge panel, loop-until-dry, multi-modal sweep, completeness critic) are in `references/patterns.md`.
+
+## Constraints
+
+- JavaScript only — no TypeScript type annotations, interfaces, or generics.
+- `Date.now()`, `Math.random()`, and argless `new Date()` throw (they break resume). Pass timestamps via `args`; vary randomness by index.
+- The script has no filesystem or shell access — agents do that work; the script coordinates them.
+- Concurrent `agent()` calls cap at `min(16, cpu_cores - 2)` per workflow; excess queues. Lifetime cap is 1000 agents per run.
+- Spawned agents run in `acceptEdits` mode and inherit the session's tool allowlist regardless of session mode.
+- No mid-run user input — only an agent's own permission prompt can pause a run.
+
+## Managing runs
+
+Run `/workflows` to list and monitor runs — each phase shows agent count, token total, and elapsed time. Press `Ctrl+G` to view or edit the raw script before approval. A run pauses and resumes within the same session (completed agents replay from cache); exiting Claude Code restarts it fresh on relaunch.
+
+Keybindings, the approval flow, save locations, and disabling workflows are in `references/managing-runs.md`.
+
+## Anti-fabrication
+
+A workflow's final return value is only as trustworthy as the agent results it synthesizes. Return what agents actually reported — never invent findings, counts, or verdicts to fill a schema. When a workflow bounds coverage (top-N, sampling, no-retry), `log()` what was dropped so partial coverage never reads as complete. Apply `/core:anti-fabrication` to every claim the workflow surfaces.
+
+## References
+
+- `references/script-api.md` — full hook signatures, schema, isolation, model overrides, budget, resume/runId
+- `references/patterns.md` — orchestration patterns and scale guidance
+- `references/managing-runs.md` — `/workflows` TUI, triggering, save locations, config toggles, availability

--- a/plugins/tools/claude-code/skills/claude-workflows/references/managing-runs.md
+++ b/plugins/tools/claude-code/skills/claude-workflows/references/managing-runs.md
@@ -1,0 +1,71 @@
+# Managing Workflow Runs
+
+Triggering, monitoring, saving, and disabling dynamic workflows in Claude Code. Source: https://code.claude.com/docs/en/workflows and the Claude Code Workflow tool contract.
+
+## Table of contents
+
+- [Triggering a workflow](#triggering-a-workflow)
+- [Approval flow](#approval-flow)
+- [The /workflows TUI](#the-workflows-tui)
+- [Resume behavior](#resume-behavior)
+- [Saving workflows](#saving-workflows)
+- [Availability](#availability)
+- [Disabling workflows](#disabling-workflows)
+
+## Triggering a workflow
+
+Workflows require explicit opt-in. Three paths:
+
+1. **Include the word "workflow" in the prompt.** Claude Code highlights it and writes a workflow script for the task. Example: `Run a workflow to audit every API endpoint under src/routes/ for missing auth checks`.
+2. **`/effort ultracode`.** Combines `xhigh` reasoning effort with automatic workflow orchestration. Claude decides when each substantive task warrants a workflow; one request can turn into several workflows — one to understand code, one to make changes, one to verify.
+3. **Run a saved or bundled workflow.** `/deep-research` is the built-in workflow. Saved workflow scripts become their own slash commands, invoked as `/<workflow-name>`.
+
+## Approval flow
+
+Before each run, the CLI shows the planned phases and offers to view the raw script, approve once, or approve for future runs in that project. Press `Ctrl+G` to view or edit the raw script before approval. Spawned agents always run in `acceptEdits` mode and inherit the session's tool allowlist regardless of the session's own permission mode.
+
+## The /workflows TUI
+
+Run `/workflows` to list and monitor runs. Each entry shows its phases with agent count, token total, and elapsed time; drill into a phase to see individual agents. Live progress also appears in the task panel below the input box.
+
+Keybindings:
+
+| Key | Action |
+|-----|--------|
+| `↑` `↓` | Select |
+| `Enter` / `→` | Drill in |
+| `Esc` | Back |
+| `j` / `k` | Scroll |
+| `p` | Pause / resume |
+| `x` | Stop |
+| `r` | Restart |
+| `s` | Save |
+
+## Resume behavior
+
+Within the same session, a run pauses and resumes — agents that already completed replay their cached results, and the rest run live. Exiting Claude Code discards in-session run state; the workflow restarts fresh on next launch. For programmatic resume across an edit, relaunch the Workflow tool with `{ scriptPath, resumeFromRunId }` (see `script-api.md`).
+
+## Saving workflows
+
+Save a script from the `/workflows` TUI (`s`) or place it directly in a workflows directory:
+
+- `.claude/workflows/` — project-scoped, becomes a project command.
+- `~/.claude/workflows/` — home-scoped, available across projects.
+
+A saved workflow is invoked as `/<workflow-name>` and accepts an `args` value passed to its `args` global.
+
+## Availability
+
+- Research preview, Claude Code v2.1.154 or later.
+- Pro (enable via the `/config` toggle), Max, Team, and Enterprise plans. Enterprise requires admin enablement.
+- Also available with Anthropic API access and on Amazon Bedrock, Google Cloud Vertex AI, and Microsoft Foundry.
+
+## Disabling workflows
+
+Any one of:
+
+- Toggle off in `/config`.
+- Set `"disableWorkflows": true` in `settings.json`.
+- Set the environment variable `CLAUDE_CODE_DISABLE_WORKFLOWS=1`.
+
+To disable shell injection in skills (a separate control), use `"disableSkillShellExecution": true`.

--- a/plugins/tools/claude-code/skills/claude-workflows/references/patterns.md
+++ b/plugins/tools/claude-code/skills/claude-workflows/references/patterns.md
@@ -1,0 +1,133 @@
+# Workflow Orchestration Patterns
+
+Composable shapes for workflow scripts. Pick by task and combine freely. Source: the Claude Code Workflow tool contract.
+
+## Table of contents
+
+- [Pipeline by default](#pipeline-by-default)
+- [Barrier when stage N needs all of stage N-1](#barrier-when-stage-n-needs-all-of-stage-n-1)
+- [Adversarial verify](#adversarial-verify)
+- [Perspective-diverse verify](#perspective-diverse-verify)
+- [Judge panel](#judge-panel)
+- [Loop-until-count](#loop-until-count)
+- [Loop-until-budget](#loop-until-budget)
+- [Loop-until-dry](#loop-until-dry)
+- [Multi-modal sweep](#multi-modal-sweep)
+- [Completeness critic](#completeness-critic)
+- [No silent caps](#no-silent-caps)
+- [Scaling to the request](#scaling-to-the-request)
+
+## Pipeline by default
+
+Each dimension verifies as soon as its review completes — no wasted wall-clock.
+
+```javascript
+const DIMENSIONS = [{ key: 'bugs', prompt: '...' }, { key: 'perf', prompt: '...' }]
+const results = await pipeline(
+  DIMENSIONS,
+  d => agent(d.prompt, { label: `review:${d.key}`, phase: 'Review', schema: FINDINGS }),
+  review => parallel(review.findings.map(f => () =>
+    agent(`Adversarially verify: ${f.title}`, { label: `verify:${f.file}`, phase: 'Verify', schema: VERDICT })
+      .then(v => ({ ...f, verdict: v })))),
+)
+const confirmed = results.flat().filter(Boolean).filter(f => f.verdict?.isReal)
+```
+
+## Barrier when stage N needs all of stage N-1
+
+Dedup across all findings before expensive verification — a genuine barrier reason.
+
+```javascript
+const all = await parallel(DIMENSIONS.map(d => () => agent(d.prompt, { schema: FINDINGS })))
+const deduped = dedupeByFileAndLine(all.filter(Boolean).flatMap(r => r.findings))
+const verified = await parallel(deduped.map(f => () => agent(verifyPrompt(f), { schema: VERDICT })))
+```
+
+## Adversarial verify
+
+Spawn N independent skeptics per finding, each prompted to refute. Kill the finding if a majority refute. Stops plausible-but-wrong findings from surviving.
+
+```javascript
+const votes = await parallel(Array.from({ length: 3 }, () => () =>
+  agent(`Try to refute: ${claim}. Default to refuted=true if uncertain.`, { schema: VERDICT })))
+const survives = votes.filter(Boolean).filter(v => !v.refuted).length >= 2
+```
+
+## Perspective-diverse verify
+
+When a finding can fail in more than one way, give each verifier a distinct lens instead of N identical refuters. Diversity catches failure modes redundancy misses.
+
+```javascript
+const vs = await parallel(['correctness', 'security', 'repro'].map(lens => () =>
+  agent(`Judge "${finding.desc}" via the ${lens} lens — real?`, { schema: VERDICT })))
+const real = vs.filter(Boolean).filter(v => v.real).length >= 2
+```
+
+## Judge panel
+
+Generate N independent attempts from different angles (MVP-first, risk-first, user-first), score with parallel judges, synthesize from the winner while grafting the best ideas from runners-up. Beats one-attempt-iterated when the solution space is wide.
+
+## Loop-until-count
+
+Accumulate to a target.
+
+```javascript
+const bugs = []
+while (bugs.length < 10) {
+  const r = await agent('Find bugs in this codebase.', { schema: BUGS })
+  bugs.push(...r.bugs)
+  log(`${bugs.length}/10 found`)
+}
+```
+
+## Loop-until-budget
+
+Scale depth to the user's token directive. Guard on `budget.total` — with no target, `remaining()` is `Infinity` and the loop runs to the 1000-agent cap.
+
+```javascript
+const bugs = []
+while (budget.total && budget.remaining() > 50_000) {
+  const r = await agent('Find bugs in this codebase.', { schema: BUGS })
+  bugs.push(...r.bugs)
+  log(`${bugs.length} found, ${Math.round(budget.remaining() / 1000)}k remaining`)
+}
+```
+
+## Loop-until-dry
+
+For unknown-size discovery, keep spawning finders until K consecutive rounds return nothing new. Simple `while (count < N)` counters miss the tail. Dedup against everything seen, not just confirmed findings — else judge-rejected items reappear every round and the loop never converges.
+
+```javascript
+const seen = new Set(), confirmed = []
+let dry = 0
+while (dry < 2) {
+  const found = (await parallel(FINDERS.map(f => () =>
+    agent(f.prompt, { phase: 'Find', schema: BUGS })))).filter(Boolean).flatMap(r => r.bugs)
+  const fresh = found.filter(b => !seen.has(key(b)))
+  if (!fresh.length) { dry++; continue }
+  dry = 0; fresh.forEach(b => seen.add(key(b)))
+  const judged = await parallel(fresh.map(b => () =>
+    parallel(['correctness', 'security', 'repro'].map(lens => () =>
+      agent(`Judge "${b.desc}" via the ${lens} lens — real?`, { phase: 'Verify', schema: VERDICT })))
+      .then(vs => ({ b, real: vs.filter(Boolean).filter(v => v.real).length >= 2 }))))
+  confirmed.push(...judged.filter(v => v.real).map(v => v.b))
+}
+```
+
+## Multi-modal sweep
+
+Parallel agents each search a different way — by container, by content, by entity, by time. Each is blind to what the others surface; useful when one search angle alone won't find everything.
+
+## Completeness critic
+
+A final agent that asks "what's missing — a modality not run, a claim unverified, a source unread?" What it finds becomes the next round of work.
+
+## No silent caps
+
+When a workflow bounds coverage (top-N, no-retry, sampling), `log()` what was dropped. Silent truncation reads as "covered everything" when it did not.
+
+## Scaling to the request
+
+Match orchestration depth to what the user asked for. "Find any bugs" → a few finders, single-vote verify. "Thoroughly audit this" or "be comprehensive" → a larger finder pool, a 3–5 vote adversarial pass, and a synthesis stage. When unsure, lean toward thoroughness for research/review/audit requests and toward brevity for quick checks.
+
+These patterns are not exhaustive — compose novel harnesses when the task calls for it (tournament brackets, self-repair loops, staged escalation).

--- a/plugins/tools/claude-code/skills/claude-workflows/references/script-api.md
+++ b/plugins/tools/claude-code/skills/claude-workflows/references/script-api.md
@@ -1,0 +1,133 @@
+# Workflow Script API
+
+Full reference for the hooks and globals available inside a workflow script. The script is plain JavaScript running in an async context. Source: the Claude Code Workflow tool contract.
+
+## Table of contents
+
+- [meta block](#meta-block)
+- [agent()](#agent)
+- [pipeline()](#pipeline)
+- [parallel()](#parallel)
+- [phase() and log()](#phase-and-log)
+- [workflow()](#workflow)
+- [args global](#args-global)
+- [budget global](#budget-global)
+- [Structured output (schema)](#structured-output-schema)
+- [Worktree isolation](#worktree-isolation)
+- [Model overrides](#model-overrides)
+- [Resume and runId](#resume-and-runid)
+- [Concurrency and caps](#concurrency-and-caps)
+
+## meta block
+
+Every script begins with `export const meta = {...}` as a pure literal — no variables, function calls, spreads, or template interpolation.
+
+- `name` (required) — workflow identifier.
+- `description` (required) — one line, shown in the permission dialog.
+- `phases` (optional) — one entry per `phase()` call: `{ title, detail }`. Match titles exactly to `phase()` calls so progress groups align. Add `model` to a phase entry when that phase uses a model override.
+- `whenToUse` (optional) — shown in the saved-workflow list.
+
+A `phase()` call with no matching `meta.phases` entry still gets its own progress group.
+
+## agent()
+
+```
+agent(prompt: string, opts?: {
+  label?: string,
+  phase?: string,
+  schema?: object,
+  model?: string,
+  isolation?: 'worktree',
+  agentType?: string
+}): Promise<any>
+```
+
+Spawns one subagent. Without `schema`, returns the agent's final text as a string. With `schema`, the agent is forced to call a StructuredOutput tool and `agent()` returns the validated object. Returns `null` if the user skips the agent mid-run — filter with `.filter(Boolean)`.
+
+- `label` — overrides the display label.
+- `phase` — explicitly assigns this agent to a progress group. Use inside `pipeline()`/`parallel()` stages to avoid races on the global `phase()` state.
+- `model` — overrides the model for this call (see [Model overrides](#model-overrides)).
+- `isolation: 'worktree'` — runs in a fresh git worktree (see [Worktree isolation](#worktree-isolation)).
+- `agentType` — uses a custom subagent type (e.g. `'Explore'`) instead of the default workflow subagent. Resolved from the same registry as the Agent tool; composes with `schema`.
+
+Subagents are told their final text IS the return value, so they return raw data, not human-facing prose.
+
+## pipeline()
+
+```
+pipeline(items, stage1, stage2, ...): Promise<any[]>
+```
+
+Runs each item through all stages independently — NO barrier between stages. Item A can be in stage 3 while item B is still in stage 1. This is the default for multi-stage work; wall-clock equals the slowest single-item chain.
+
+Every stage callback receives `(prevResult, originalItem, index)` — use `originalItem`/`index` in later stages to label work without threading context through earlier returns. A stage that throws drops that item to `null` and skips its remaining stages.
+
+## parallel()
+
+```
+parallel(thunks: Array<() => Promise<any>>): Promise<any[]>
+```
+
+Runs tasks concurrently and awaits all of them — a BARRIER. A thunk that throws (or whose agent errors) resolves to `null` in the result array; the call itself never rejects, so `.filter(Boolean)` before using results.
+
+Use only when stage N needs all of stage N-1 together: dedup/merge across the full set, early-exit on a zero count, or a prompt that references the other findings. Flatten/map/filter alone do not justify a barrier — do them inside a pipeline stage.
+
+## phase() and log()
+
+```
+phase(title: string): void
+log(message: string): void
+```
+
+`phase()` starts a new progress group; subsequent `agent()` calls group under it. `log()` emits a narrator line above the progress tree. Inside `pipeline()`/`parallel()` stages, prefer `agent(..., { phase: 'X' })` over the global `phase()` to avoid races.
+
+## workflow()
+
+```
+workflow(nameOrRef: string | { scriptPath: string }, args?: any): Promise<any>
+```
+
+Runs another workflow inline as a sub-step and returns its result. Pass a name to invoke a saved workflow, or `{ scriptPath }` to run a script file. The child shares this run's concurrency cap, agent counter, abort signal, and token budget; its agents appear under a `▸ name` group in `/workflows` and its tokens count toward `budget.spent()`. The `args` param becomes the child's `args` global. Nesting is one level only — `workflow()` inside a child throws. Throws on unknown name, unreadable scriptPath, or child syntax error; catch to handle gracefully.
+
+## args global
+
+`args` is the value passed as the Workflow tool's `args` input, verbatim (`undefined` if not provided). Pass arrays/objects as actual JSON values, not a JSON-encoded string — a stringified list reaches the script as one string, so `args.filter`/`args.map` throw. Use it to parameterize saved workflows (a research question, a target path, a config object).
+
+## budget global
+
+```
+budget: { total: number|null, spent(): number, remaining(): number }
+```
+
+The turn's token target from a `+500k`-style directive. `budget.total` is `null` if no target was set. `budget.spent()` returns output tokens spent this turn across the main loop and all workflows — the pool is shared. `budget.remaining()` returns `max(0, total - spent())`, or `Infinity` if no target. The target is a hard ceiling: once `spent()` reaches `total`, further `agent()` calls throw.
+
+Guard budget loops on `budget.total` — with no target, `remaining()` is `Infinity` and the loop runs to the 1000-agent cap:
+
+```javascript
+while (budget.total && budget.remaining() > 50_000) {
+  const r = await agent('Find bugs in this codebase.', { schema: BUGS })
+  bugs.push(...r.bugs)
+}
+```
+
+## Structured output (schema)
+
+Pass a JSON Schema as `opts.schema` and the agent is forced to call a StructuredOutput tool; `agent()` returns the validated object. Validation happens at the tool-call layer, so the model retries on mismatch — no parsing in the script. This is the reliable way to get machine-readable data back from an agent.
+
+## Worktree isolation
+
+`isolation: 'worktree'` runs the agent in a fresh git worktree — expensive (~200-500ms setup plus disk per agent). Use only when agents mutate files in parallel and would otherwise conflict. The worktree is auto-removed if unchanged.
+
+## Model overrides
+
+`opts.model` overrides the model for one `agent()` call. Default to omitting it — the agent inherits the main-loop model (the resolved session model), which is almost always correct. Set it only when highly confident a different tier fits the task; when unsure, omit.
+
+## Resume and runId
+
+Every invocation persists its script under the session directory and returns a `scriptPath` and a `runId` in the tool result. To resume after a pause, kill, or script edit, relaunch with `{ scriptPath, resumeFromRunId }`. The longest unchanged prefix of `agent()` calls returns cached results instantly; the first edited or new call and everything after it runs live. Same script + same args → 100% cache hit. Resume is same-session only; stop the prior run before resuming.
+
+To iterate on a workflow, edit the persisted script file and re-invoke with `{ scriptPath }` instead of resending the full script inline.
+
+## Concurrency and caps
+
+Concurrent `agent()` calls cap at `min(16, cpu_cores - 2)` per workflow; excess calls queue and run as slots free. `parallel()`/`pipeline()` still accept 100+ items — they all complete, only ~10 run at any moment. Total agent count across a workflow's lifetime caps at 1000 (a runaway-loop backstop). Child workflows share the parent's cap and counter.

--- a/plugins/tools/claude-code/skills/sources.md
+++ b/plugins/tools/claude-code/skills/sources.md
@@ -257,6 +257,45 @@ This file documents the sources used to create the claude-code plugin skills.
   - Trust gate + `disableAllHooks` shared with hooks
 - **Used In**: skills/claude-statusline/SKILL.md, skills/claude-statusline/references/input-schema.md
 
+## Claude Workflows Skill
+
+### Claude Code Workflows Documentation
+- **URL**: https://code.claude.com/docs/en/workflows
+- **Purpose**: Usage and CLI framing for dynamic workflows — triggering, approval flow, the `/workflows` TUI, resume behavior, availability, and disabling
+- **Date Accessed**: 2026-05-30
+- **Key Topics**:
+  - Three trigger paths: "workflow" keyword, `/effort ultracode`, saved/bundled workflows (`/deep-research`)
+  - Subagents-vs-skills-vs-workflows comparison (scale, where intermediate results live, repeatability, interruption)
+  - `/workflows` TUI keybindings and per-phase agent/token/time monitoring
+  - In-session resume (cached agent replay) vs fresh-on-relaunch
+  - Concurrency cap (up to 16 agents), 1000-agent lifetime cap, no mid-run user input
+  - Spawned agents run `acceptEdits` and inherit the session tool allowlist
+  - Availability (v2.1.154+, paid plans, API/Bedrock/Vertex/Foundry) and disabling (`/config`, `disableWorkflows`, `CLAUDE_CODE_DISABLE_WORKFLOWS=1`)
+- **Used In**: skills/claude-workflows/SKILL.md, skills/claude-workflows/references/managing-runs.md
+
+### Introducing Dynamic Workflows in Claude Code (Blog)
+- **URL**: https://claude.com/blog/introducing-dynamic-workflows-in-claude-code
+- **Purpose**: Motivation and user-facing framing — what dynamic workflows are and the problems they target
+- **Date Accessed**: 2026-05-30
+- **Key Concepts**:
+  - JavaScript orchestration scripts running tens-to-hundreds of parallel subagents in one background run
+  - Targets legacy codebases, large migrations, and work needing multiple verification passes
+  - The script holds the loop/branching/intermediate results; Claude's context holds only the final answer
+- **Used In**: skills/claude-workflows/SKILL.md
+
+### Claude Code Workflow Tool Contract
+- **URL**: (internal tool definition surfaced in the Claude Code session)
+- **Purpose**: Authoritative script API — the `meta` block and the `agent()`/`pipeline()`/`parallel()`/`phase()`/`log()`/`workflow()` hooks, plus `args`/`budget` globals, schema, isolation, model overrides, and resume. The public docs pages are deliberately light on these internals.
+- **Date Accessed**: 2026-05-30
+- **Key Topics**:
+  - `meta` pure-literal requirement (`name`, `description`, `phases`)
+  - `pipeline()` (no barrier, default) vs `parallel()` (barrier) semantics
+  - Structured output via JSON-Schema `schema`; `isolation: 'worktree'`; `model` inherit-by-default
+  - Orchestration patterns: adversarial verify, perspective-diverse verify, judge panel, loop-until-dry/count/budget, multi-modal sweep, completeness critic
+  - Constraints: JS not TS; `Date.now()`/`Math.random()`/argless `new Date()` throw
+  - Resume via `{ scriptPath, resumeFromRunId }`
+- **Used In**: skills/claude-workflows/SKILL.md, skills/claude-workflows/references/script-api.md, skills/claude-workflows/references/patterns.md
+
 ## Project Context
 
 ### Overall Goals


### PR DESCRIPTION
- Add `claude-workflows` skill documenting Claude Code dynamic workflows (JS subagent orchestration)
- SKILL.md covers when to use vs subagents/skills, triggering, script anatomy, core hooks, pipeline-vs-parallel, constraints, run management
- references/script-api.md — full hook signatures, schema, isolation, model overrides, budget, resume
- references/patterns.md — adversarial verify, judge panel, loop-until-dry/count/budget, multi-modal sweep, completeness critic
- references/managing-runs.md — /workflows TUI, triggering, save locations, config toggles, availability
- Register skill in claude-code plugin.json and all-skills meta-plugin; add sources.md entries
- Bump claude-code 0.2.4 → 0.2.5, all-skills 0.4.17 → 0.4.18, marketplace 1.0.18 → 1.0.19