### PR TITLE
feat(agent-loop): add optional Claude Code workflow execution substrate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "A curated collection of Claude skills for development workflows",
-    "version": "1.0.19"
+    "version": "1.0.20"
   },
   "plugins": [
     {
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.18",
+      "version": "0.4.19",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -62,7 +62,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "category": "development",
       "keywords": ["git", "documentation", "code-review", "tools", "beads", "bees", "container", "tdd", "agent-loop"]
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/agent-loop/SKILL.md
+++ b/plugins/core/skills/agent-loop/SKILL.md
@@ -123,6 +123,7 @@ Fan-out happens at the Sub-team Leader, not at the epic decomposer or the bees-w
 - P4 reports verbatim CI output; on red the leader dispatches a fresh P3 (no chat continuity).
 - P5 reads `git diff main...HEAD`, tests, and the acceptance criteria; approves with one line or rejects with a structured findings list.
 - bees issues carry a single `complexity:complex` or `complexity:trivial` label, not tier labels. The Sub-team Leader picks up the issue, reads complexity, and (for complex) dispatches the five stages internally — each Task spawn prompt names its tier (`team:opus-planner` ... `team:opus-review`) as dispatch-time metadata. Tier labels never land on bees rows. See `/core:bees`.
+- The five stages run as Task spawns by default. When Claude Code workflows are available and the operator opts in, encode them as one workflow script instead — the stage gates become deterministic assertions. See "Optional: workflow execution substrate" below and `references/workflows-execution.md`.
 
 ### Avoiding pipeline collapse
 
@@ -286,6 +287,14 @@ Epics may include a `spec:` field pointing to a `.allium` behavioral spec file (
 
 Epics WITHOUT a `spec:` field behave exactly as today — all spec-driven steps are no-ops. Requires the upstream allium plugin: `/plugin install allium@juxt`. See `/allium:allium` for full integration details.
 
+## Optional: workflow execution substrate
+
+Claude Code dynamic workflows are an optional runtime for the five-tier pipeline. When available and opted-in, the Sub-team Leader encodes one issue's pipeline as a workflow script instead of dispatching five Task spawns — the adversarial separation and stage gates (`test files unmodified before P5`, `mise run ci` green before review) become deterministic script assertions, model escalation becomes a retry ladder, and the validator↔fix iteration becomes a bounded loop. `isolation: 'worktree'` gives each parallel implementer its own tree, replacing the shallow-clone workaround for working-tree contention.
+
+The boundary: decomposition, Phase 1.5a clarifying questions, and merge approval stay in the interactive loop — a workflow has no mid-run user input. The workflow executes already-decomposed issues (gate States A/C/D); it never decomposes them.
+
+Workflows are a research preview on paid plans. When disabled, the default Task-spawn path applies unchanged. See `references/workflows-execution.md` and the `/claude-code:claude-workflows` skill.
+
 ## References
 
 - `references/team-leader.md` -- Epic decomposition, team formation, orchestration
@@ -299,3 +308,4 @@ Epics WITHOUT a `spec:` field behave exactly as today — all spec-driven steps 
 - `references/no-todos.md` — Implementer worker prompts forbid TODO/FIXME/XXX/HACK/KLUDGE/DEFERRED markers; pre-commit grep + escalate-to-lead-or-implement-now rule
 - `references/dispatch-discipline.md` — Spawn-prompt rules: explicit model, specialized subagent types, lead delegates all execution, fresh-main branch creation, no polling loops, host-inspection for tool-state claims, search ADRs before proposing architecture
 - `references/secret-provisioning.md` — Tier 1 plans for new-env-var features include symmetric provisioning (generation cmd, secret-store creation, prod deploy diff, dev environment diff); Tier 5 BLOCKER check
+- `references/workflows-execution.md` — optional Claude Code workflow substrate for the five-tier pipeline: pipeline-as-script, stage-gate assertions, escalation ladder, loop-until-green, nested `workflow()` for teams-of-teams, `isolation: 'worktree'`; the decomposition/merge boundary that stays interactive

--- a/plugins/core/skills/agent-loop/references/workflows-execution.md
+++ b/plugins/core/skills/agent-loop/references/workflows-execution.md
@@ -1,0 +1,111 @@
+# Workflow Execution Substrate (optional)
+
+Claude Code dynamic workflows are a JavaScript runtime that orchestrates subagents at scale. They are an optional execution substrate for the five-tier decomposition pipeline: when available and opted-in, encode the pipeline as a workflow script so the adversarial separation and stage gates become structural instead of discipline the lead must remember. When unavailable, spawn Task agents exactly as the default path describes. See the `/claude-code:claude-workflows` skill for the full script API.
+
+## When this applies
+
+- The work is already decomposed — issues exist in bees (gate States A, C, or D). The workflow executes issues; it never decomposes them.
+- The session is on a paid plan with workflows enabled, and the operator opts in (the word "workflow" in the request, `/effort ultracode`, or a saved workflow command).
+
+Skip the substrate and use Task spawns when workflows are disabled, when the run needs mid-flight user input, or for a single trivial issue.
+
+## The hard boundary — what stays in the interactive loop
+
+A workflow has no mid-run user input; only an agent's own permission prompt pauses a run. Three responsibilities therefore never move into a workflow:
+
+- **Decomposition and Phase 1.5a clarifying questions** (`AskUserQuestion`). The Team Leader decomposes and clarifies in the main loop, then hands the issue list to the workflow. This matches the existing rule: fan-out happens at the Sub-team Leader, not the epic decomposer.
+- **Merge approval** (Phase 4). A workflow drives commit, push, and PR creation up to the squash-merge gate, which stays operator-owned.
+- **Escalation to the user** on opus-failure, dependency conflict, or ambiguity. The script surfaces the condition in its return value; the lead escalates.
+
+## Five-tier pipeline as a script
+
+The pipeline's "separate Agent invocation per tier, no SendMessage continuation, each tier adversarial against the next" is automatic — every `agent()` call is a fresh context. The stage gates the lead must verify by hand (`test commit present before P3`, `test files unmodified before P5`) become deterministic assertions between stages.
+
+```javascript
+export const meta = {
+  name: 'five-tier-issue',
+  description: 'Run one complex issue through plan/test/impl/ci/review',
+  phases: [
+    { title: 'Plan' }, { title: 'Test' }, { title: 'Impl' },
+    { title: 'CI' }, { title: 'Review' },
+  ],
+}
+
+// args = { issueId, acceptanceCriteria, testFiles, skills }
+const plan = await agent(planPrompt(args), { phase: 'Plan', schema: TEST_LIST })
+const testSha = await agent(testAuthorPrompt(args, plan), { phase: 'Test', schema: COMMIT })
+const impl = await agent(implPrompt(args, plan, testSha), { phase: 'Impl', schema: COMMIT })
+
+// Stage gate: the adversarial-TDD diff boundary, enforced not narrated
+const touched = await agent(`Return git diff ${testSha.sha}..HEAD -- ${args.testFiles.join(' ')}`, { schema: DIFF })
+if (touched.nonEmpty) return { status: 'escalate', reason: 'implementer modified test files', testSha }
+
+const ci = await agent('Run mise run ci, return verbatim output and green/red.', { phase: 'CI', schema: CI_RESULT })
+if (!ci.green) return { status: 'ci-red', ci }
+
+const review = await agent(reviewPrompt(args), { phase: 'Review', schema: VERDICT })
+return { status: review.approved ? 'done' : 'rework', review }
+```
+
+Each stage prompt still names its tier (`You are P2 — test author for issue <id>`) and forbids out-of-stage activity, per the pipeline-collapse rule.
+
+## Model escalation as a retry ladder
+
+The `haiku → sonnet → opus`, max-two-promotions rule and the overridable `AGENT_LOOP_ESCALATION_CHAIN` map to a loop. The chain is read by the process that launches the workflow and passed in via `args` — the model name never appears as a literal in the prompt body.
+
+```javascript
+async function withEscalation(prompt, opts) {
+  for (const model of args.escalationChain) {        // e.g. ['haiku','sonnet','opus']
+    try { return await agent(prompt, { ...opts, model }) }
+    catch (e) { log(`escalating from ${model}`) }
+  }
+  return { status: 'escalate', reason: 'opus failed' } // hand back to the lead
+}
+```
+
+## Validator ↔ Fix Agent loop-until-green
+
+Phase 3's "Validator and Fix Agent iterate until clean, escalate after 3 stalled cycles" is a bounded loop.
+
+```javascript
+let cycles = 0
+let ci = await agent('Run mise run ci.', { phase: 'CI', schema: CI_RESULT })
+while (!ci.green && cycles < 3) {
+  await agent(`Fix these failures without touching tests: ${ci.output}`, { phase: 'Fix' })
+  ci = await agent('Run mise run ci.', { phase: 'CI', schema: CI_RESULT })
+  cycles++
+}
+if (!ci.green) return { status: 'escalate', reason: 'validation stalled', ci }
+```
+
+## Teams of teams via nested workflow()
+
+The two-tier authority boundary (Team Leader manages the epic, Sub-team Leader runs the pipeline per issue) maps onto `workflow()` nesting, which is allowed exactly one level deep — the same depth as the authority model. The epic workflow fans over ready issues; each issue runs the five-tier pipeline as a sub-step.
+
+```javascript
+const ready = args.issues.filter(i => i.depsSatisfied)
+const results = await parallel(ready.map(issue => () =>
+  workflow('five-tier-issue', issue)))   // one level only; the sub-step does not nest further
+return results.filter(Boolean)
+```
+
+Respect dependency ordering in the lead's selection of `ready` — do not pass an issue whose dependencies have not completed.
+
+## Worktree isolation solves working-tree contention
+
+The default path forbids git worktrees and uses shallow clones because parallel workers in one tree pollute each other's checkouts. A workflow spawns each parallel implementer with its own auto-cleaned worktree, removing the footgun directly:
+
+```javascript
+agent(implPrompt(issue), { isolation: 'worktree' })   // ~200-500ms + disk per agent
+```
+
+Use it only for agents that mutate files in parallel; it is expensive and pointless for read-only or single-writer stages.
+
+## Budget-scaled thoroughness and resume
+
+- `budget` scales fan-out to the operator's token directive. Guard on `budget.total` (null when no target is set, which makes `remaining()` Infinity).
+- Long epic runs are resumable in-session via `{ scriptPath, resumeFromRunId }`: completed stages replay from cache, the rest run live. This complements bees — bees is the durable cross-session tracker; resume is the in-session fast-replay.
+
+## Permissions and limits
+
+Workflow agents run in `acceptEdits` mode and inherit the session's tool allowlist regardless of session mode. Concurrent `agent()` calls cap at `min(16, cpu_cores - 2)`; lifetime cap is 1000 agents per run. Scripts are plain JavaScript — no TypeScript annotations, and `Date.now()` / `Math.random()` / argless `new Date()` throw. Pass timestamps and the escalation chain through `args`.

--- a/plugins/core/skills/sources.md
+++ b/plugins/core/skills/sources.md
@@ -279,6 +279,18 @@ This file documents the sources used to create the core plugin skills.
 - **Purpose**: Source for optional spec-driven flows integrated into /core:agent-loop (team-leader, agent-worker, validator, epic-authoring edits)
 - **Date Accessed**: 2026-04-17
 
+## Agent Loop — Workflow Execution Substrate
+
+- **URL**: https://code.claude.com/docs/en/workflows and https://claude.com/blog/introducing-dynamic-workflows-in-claude-code
+- **Purpose**: Source for the optional Claude Code dynamic-workflows substrate documented in references/workflows-execution.md — five-tier pipeline as a script, stage-gate assertions, escalation ladder, loop-until-green, nested workflow() for teams-of-teams, worktree isolation, and the decomposition/merge boundary that stays interactive
+- **Date Accessed**: 2026-05-30
+- **Key Topics**:
+  - `pipeline()` no-barrier staging vs `parallel()` barrier; `agent()` opts (`phase`, `schema`, `model`, `isolation`)
+  - `workflow()` one-level nesting matching the two-tier authority model
+  - No mid-run user input — decomposition, clarifying questions, and merge approval stay in the interactive loop
+  - `acceptEdits` + inherited tool allowlist; concurrency `min(16, cores-2)`; 1000-agent lifetime cap; JS not TS
+  - Cross-references the `/claude-code:claude-workflows` skill for the full script API
+
 ### mise Sandboxing
 - https://mise.jdx.dev/sandboxing.html — mise sandboxing (experimental). Extracted: allow/deny flags, task-level config, Landlock/Seatbelt platform support, limitations. Accessed 2026-05-22.
 


### PR DESCRIPTION
- Add `references/workflows-execution.md` documenting Claude Code dynamic workflows as an optional runtime for the five-tier pipeline
- Five-tier pipeline encoded as a `pipeline()` script with stage-gate assertions (diff boundary, CI-green) made deterministic
- Model escalation as a retry ladder; validator↔fix as loop-until-green; teams-of-teams via one-level `workflow()` nesting
- `isolation: 'worktree'` replaces the shallow-clone workaround for working-tree contention
- Documents the hard boundary: decomposition, clarifying questions, and merge approval stay in the interactive loop (no mid-run user input)
- Add SKILL.md "Optional: workflow execution substrate" section, Five-Tier Pipeline cross-link, and References entry
- Add core sources.md entry; bump core 0.2.8 → 0.2.9, all-skills 0.4.18 → 0.4.19, marketplace 1.0.19 → 1.0.20