### PR TITLE
docs(linear): require self-contained epic bodies, ban local-filesystem refs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -108,7 +108,7 @@
       "source": "./plugins/tools/linear",
       "strict": true,
       "description": "Linear project management: MCP/GraphQL API, VantageEx epic authoring, auditing, and grooming",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "category": "tools",
       "keywords": ["linear", "project-management", "epics", "graphql", "vantageex", "mcp"],
       "license": "MIT"

--- a/plugins/tools/linear/.claude-plugin/plugin.json
+++ b/plugins/tools/linear/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "linear",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Linear project management: MCP/GraphQL API, VantageEx epic authoring, auditing, and grooming",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/linear/commands/plan-epic.md
+++ b/plugins/tools/linear/commands/plan-epic.md
@@ -32,6 +32,7 @@ Before creating:
 - Confirm objective is 2-3 sentences
 - Confirm slug is kebab-case and under 30 chars
 - Confirm at least one repo is specified
+- Confirm the body is self-contained: no local-filesystem paths (`~/.claude/...`, `/Users/<name>/...`) used as the source of truth. Embed design plans inline under a `## Design context` section, or link to other epics by Linear URL.
 
 ## Body Format Rules
 
@@ -40,6 +41,7 @@ Apply the format rules from the `/linear` skill's "Epic Body Format Rules" secti
 - Plain markdown only — no YAML fences in any section.
 - Skill labels must exist in the marketplace; core skills (anti-fabrication, git, tdd, twelve-factor, security, mise, nushell) are implicit and not listed.
 - Initial state is `Backlog`.
+- Bodies are self-contained: embed design context inline, cross-link other epics by Linear URL, never reference local-filesystem paths.
 
 See `plugins/tools/linear/skills/linear/SKILL.md` "Epic Body Format Rules" for the canonical wording.
 

--- a/plugins/tools/linear/skills/linear/SKILL.md
+++ b/plugins/tools/linear/skills/linear/SKILL.md
@@ -229,6 +229,32 @@ Skill labels listed in the epic body must exist in the claude-skills marketplace
 
 Core skills are implicit and MUST NOT be listed in epic bodies: `anti-fabrication`, `git`, `tdd`, `twelve-factor`, `security`, `mise`, `nushell`. Listing them adds noise without value — every epic loads them by default.
 
+### Self-contained content
+
+Epic bodies are self-contained. Workers pick up epics on any machine; local-filesystem paths (`~/.claude/plans/...`, `/Users/<name>/...`) resolve only on the author's system and fail everywhere else.
+
+WRONG — points at a local file:
+
+```markdown
+See `~/.claude/plans/foo.md` for the design context.
+```
+
+CORRECT — embed the content inline under a `## Design context` (or similarly named) section, or link to another epic by URL:
+
+```markdown
+## Design context
+
+[full design content pasted here]
+```
+
+```markdown
+## Instructions
+
+Design rationale lives in the paired docs epic [VIN-316](https://linear.app/...).
+```
+
+When a design plan is too large for a single body, split into paired epics (docs + implementation) linked by URL. Each epic carries its own self-contained context; cross-references between epics use URLs, never filesystem paths.
+
 ### Initial state
 
 New epics start in `Backlog`. Labels are team-scoped; missing skill labels auto-create on first use via `issueLabelCreate`.

--- a/plugins/tools/linear/skills/linear/references/epic-format.md
+++ b/plugins/tools/linear/skills/linear/references/epic-format.md
@@ -204,12 +204,21 @@ When an epic lands in `needs_help`:
 
 Previous instructions are visible in the comment thread for history.
 
+## Self-Contained Bodies
+
+Epic bodies are read by workers on any machine. Local-filesystem paths (e.g. `~/.claude/plans/foo.md`, `/Users/<name>/...`) resolve only on the author's system and fail elsewhere.
+
+- **Embed**, do not reference. When the epic depends on a design plan, ADR draft, or research note authored locally, paste the content into the epic body under a `## Design context` (or similarly named) section.
+- **Cross-link by URL**, not path. When two epics relate, link by Linear issue URL (`https://linear.app/<workspace>/issue/<KEY>`), never by filesystem path.
+- **Split when too large**. When design context exceeds a comfortable body length, split into paired epics — one docs epic, one implementation epic — each self-contained and linked to its partner by URL.
+
 ## Anti-Patterns
 
 Do NOT include in epics:
 
 - **Implementation details** — let agents decide HOW
-- **File paths** — let agents discover the codebase
+- **Local filesystem paths as the source of truth** — `~/.claude/plans/...`, `/Users/<name>/...`, and similar host-specific paths break on every machine except the author's. Embed the content or link by URL instead.
+- **File paths to codebase locations** — let agents discover the codebase
 - **Step-by-step instructions** — that is what skills are for
 - **Acceptance criteria per issue** — the team leader writes those during decomposition
 - **Model assignments per task** — the system optimizes this


### PR DESCRIPTION
## Summary

- Epic bodies are read by workers on any machine; local paths like `~/.claude/plans/...` resolve only on the author's system
- Document the rule in `skills/linear/SKILL.md` (new `### Self-contained content` subsection under "Epic Body Format Rules")
- Document the rule in `skills/linear/references/epic-format.md` (new `## Self-Contained Bodies` section + "Local filesystem paths as the source of truth" anti-pattern bullet)
- Add Validate-step check + Body-Format-Rules item to `commands/plan-epic.md`
- Bump linear plugin 0.1.5 → 0.1.6 (plugin.json + marketplace.json)

## Root cause

While filing VIN-316/VIN-317 on 2026-05-31, the operator caught me referencing `~/.claude/plans/effervescent-swimming-adleman.md` in both epic bodies. That path is local to one machine; any worker picking up the epic on Mini or a fresh host would see a broken pointer. The fix at the time was to embed the full plan inline under a `## Design context` section. This change writes the rule into the skill so future epics don't repeat the mistake.

## Test plan

- [x] Local `mise run test` passes (claude validation, marketplace, plugins, version bumps, skills quality)
- [x] No `.claude/` artifacts committed
- [x] No attribution in commit message
- [ ] GitHub Actions "Validate marketplace and plugins" passes
- [ ] GitHub Actions "Check version bumps" passes