### PR TITLE
chore(core): update container skill to apple container 0.12.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.19",
+      "version": "0.4.20",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -62,7 +62,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "category": "development",
       "keywords": ["git", "documentation", "code-review", "tools", "beads", "bees", "container", "tdd", "agent-loop"]
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/container/SKILL.md
+++ b/plugins/core/skills/container/SKILL.md
@@ -17,7 +17,7 @@ Activate when:
 - Managing container images (pull, push, tag, save, load)
 - Configuring container networks and volumes
 - Managing the container system service
-- Migrating between Apple Container versions (0.5.x to 0.10.x)
+- Migrating between Apple Container versions (0.5.x to 0.12.x)
 
 ## What is Apple Container?
 
@@ -26,7 +26,7 @@ Apple Container is a macOS-native tool for running Linux containers as lightweig
 - **Swift-based**: Built on Apple's Virtualization.framework
 - **OCI-compatible**: Produces and runs standard OCI container images
 - **Apple silicon only**: Requires Apple silicon Mac (M1 or later)
-- **Pre-1.0**: Currently at version 0.10.0, breaking changes expected between minor versions
+- **Pre-1.0**: Currently at version 0.12.3, breaking changes expected between minor versions
 - **Lightweight VMs**: Each container runs as a lightweight Linux VM
 
 ## Prerequisites
@@ -79,6 +79,15 @@ container system property set <key> <value>
 # Clear a property
 container system property clear <key>
 ```
+
+Configurable default CPU/memory properties (0.11.0+):
+
+| Property | Description |
+|----------|-------------|
+| `container.cpus` | Default CPU count for new containers |
+| `container.memory` | Default memory for new containers |
+| `build.cpus` | Default CPU count for image builds |
+| `build.memory` | Default memory for image builds |
 
 ### System DNS
 
@@ -155,11 +164,15 @@ container run -e API_URL=http://host.docker.internal:3000 myapp:latest
 # Run with custom init image (0.10.0+)
 container run --init-image custom-init:latest -d --name app myapp:latest
 
-# Run with init process (0.10.0+)
-container run --init -d --name app myapp:latest
-
 # Run with runtime selection (0.10.0+)
 container run --runtime myruntime -d --name app myapp:latest
+
+# Run with init process (0.11.0+)
+container run --init -d --name app myapp:latest
+
+# Run with reduced/custom capabilities (0.12.0+)
+container run --cap-add NET_ADMIN myimage:latest
+container run --cap-drop ALL --cap-add NET_BIND_SERVICE myimage:latest
 ```
 
 ### Manage Running Containers
@@ -208,7 +221,7 @@ container prune
 ### Export Container (0.10.0+)
 
 ```bash
-# Create an image from a running container
+# Create an image from a running container (0.10.0+: running; 0.11.0+: stopped containers also supported)
 container export <name-or-id> -o exported.tar
 
 # Export with a tag
@@ -279,6 +292,12 @@ When pulling or building images, specify the target platform:
 ```
 
 Architecture aliases (0.8.0+): `amd64`=`x86_64`, `arm64`=`aarch64`
+
+**Default platform (0.11.0+)**: Set `CONTAINER_DEFAULT_PLATFORM` to avoid specifying `--platform` on every pull/build:
+
+```bash
+export CONTAINER_DEFAULT_PLATFORM=linux/arm64
+```
 
 ## Build
 
@@ -369,7 +388,7 @@ container network delete mynetwork
 container network prune
 ```
 
-**Network capabilities (0.8.0+)**: Full IPv6 support. Host-only and isolated network modes available in 0.9.0+ (verify flag syntax with `container network create --help`).
+**Network capabilities (0.8.0+)**: Full IPv6 support. Host-only and isolated network modes available in 0.9.0+ (verify flag syntax with `container network create --help`). `mtu` network attachment option available in 0.11.0+.
 
 ### Multi-Container Networking
 
@@ -401,6 +420,9 @@ container volume create --label env=prod mydata
 
 # Create with driver options
 container volume create --opt type=tmpfs mydata
+
+# Create with journaling (0.12.0+)
+container volume create --journal mydata
 
 # List volumes
 container volume list
@@ -445,7 +467,7 @@ container registry list
 
 **Note**: In 0.5.0, the keychain ID changed from `com.apple.container` to `com.apple.container.registry`. Re-login is required after upgrading from 0.4.x.
 
-## Version Differences (0.5.0 to 0.10.0)
+## Version Differences (0.5.0 to 0.12.x)
 
 ### Breaking Changes
 
@@ -458,6 +480,8 @@ container registry list
 | 0.10.0 | ClientContainer reworked as generic client | Update API consumers for generic client interface |
 | 0.10.0 | Bundle creation moved to SandboxService | Move bundle creation code from main container ops |
 | 0.10.0 | Multiple network plugins support | Review network configuration for multi-plugin model |
+| **0.12.0** | **Default Linux capability set REDUCED** | **Delete & recreate all existing containers; use `--cap-add` to restore needed capabilities** |
+| 0.12.0 | Builder-shim gRPC protocol changed | Incompatible with pre-0.12.0 clients — update all builder clients |
 
 ### New Features by Release
 
@@ -469,9 +493,19 @@ container registry list
 
 **0.9.0**: Resource limits (`--cpus`/`--memory`), `host.docker.internal`, host-only/isolated networks, `--dns` on build, `--force` on image delete, zstd compression, container prune improvements, enhanced image inspection, Kata 3.26.0 kernel
 
-**0.10.0**: `--init-image` selection, `container export`, `--runtime` flag, `container registry list`, `--format` on `system status`, `--init` flag, minimum memory validation, multiple network plugins, SELinux kernel panic fix, env var duplication fix
+**0.10.0**: `--init-image` selection, `container export`, `--runtime` flag, `container registry list`, `--format` on `system status`, minimum memory validation, multiple network plugins, SELinux kernel panic fix, env var duplication fix
 
-### Migration Checklist (0.5.x to 0.10.0)
+**0.11.0**: `container export` for stopped containers, build secrets, `--init` flag for run/create, `CONTAINER_DEFAULT_PLATFORM` env var, `mtu` network attachment option, system properties `container.cpus`/`container.memory`/`build.cpus`/`build.memory`, Dockerfile-specific ignore files, ARG-parsing and docker-ignore bug fixes
+
+> **⚠ BREAKING — 0.12.0 capability change:** The default Linux capability set was **reduced**. Users MUST delete and recreate existing containers to apply the new defaults. Use `--cap-add` to restore capabilities; use `--cap-drop` to further restrict them. See [0.12.0 template](templates/0.12.0/commands.md) for details.
+
+**0.12.0**: `--cap-add`/`--cap-drop` on run/create, plain/color progress modes (auto-plain when stderr non-TTY), YAML output format, TOML plugin config files, `SSH_AUTH_SOCK` passthrough, kernel kata-3.28.0, `journal` option for `volume create`, single-file-mount fix, improved `image save` error messaging
+
+**0.12.1**: macOS 15 (Sequoia) compat — `network list` and `network delete` now work on macOS 15
+
+**0.12.3** (security): HTTP downgrade prevention in registry commands, path/rule injection prevention in `system dns`, `image push` prints image reference to stdout on success
+
+### Migration Checklist (0.5.x to 0.12.x)
 
 1. Replace `--disable-progress-updates` with `--progress none` in scripts
 2. Update any paths referencing `.build` directory to `builder`
@@ -481,6 +515,9 @@ container registry list
 6. Update API consumers for generic ClientContainer interface (0.10.0)
 7. Move bundle creation code from main container operations to SandboxService (0.10.0)
 8. Review network configurations for multiple network plugins model (0.10.0)
+9. **0.12.0 REQUIRED**: Delete and recreate all existing containers (reduced default capability set)
+10. **0.12.0 REQUIRED**: Update builder clients (gRPC protocol changed, incompatible with older clients)
+11. Add `--cap-add` flags to any containers that require elevated capabilities (0.12.0+)
 
 ### Dependencies
 
@@ -493,7 +530,7 @@ container registry list
 | 0.9.0 | 0.24.0 | Kata 3.26.0 |
 | 0.10.0 | 0.26.2 | |
 
-See `templates/<version>/commands.md` for version-specific details (0.4.1, 0.5.0, 0.6.0, 0.7.0, 0.8.0, 0.9.0, 0.10.0).
+See `templates/<version>/commands.md` for version-specific details (0.4.1, 0.5.0, 0.6.0, 0.7.0, 0.8.0, 0.9.0, 0.10.0, 0.11.0, 0.12.0, 0.12.3).
 
 ## Scripts
 

--- a/plugins/core/skills/container/references/command-reference.md
+++ b/plugins/core/skills/container/references/command-reference.md
@@ -43,11 +43,13 @@ container run [FLAGS] IMAGE [COMMAND] [ARGS...]
 | `--tmpfs` | | Mount a tmpfs filesystem |
 | `--cidfile` | | Write container ID to file |
 | `--publish-socket` | | Publish a socket |
-| `--init` | | Run an init process in the container (0.10.0+) |
+| `--init` | | Run an init process in the container (0.11.0+) |
 | `--init-image` | | Init image for VM (0.10.0+ selection support) |
 | `--kernel` | | Custom kernel for VM |
 | `--virtualization` | | Virtualization backend |
 | `--runtime` | | Container runtime (0.10.0+) |
+| `--cap-add` | | Add a Linux capability (0.12.0+) |
+| `--cap-drop` | | Drop a Linux capability (0.12.0+) |
 | `--scheme` | | Image scheme |
 | `--progress` | | Progress output (`none`, `ansi`) (0.7.0+) |
 | `--gid` | | Group ID |
@@ -66,7 +68,7 @@ Create a container without starting it.
 container create [FLAGS] IMAGE [COMMAND] [ARGS...]
 ```
 
-Accepts all the same flags as `container run` except `--detach`. Includes `--read-only` (0.8.0+), `--cpus`/`--memory` (0.9.0+), `--init`/`--init-image`/`--runtime` (0.10.0+), and all DNS flags.
+Accepts all the same flags as `container run` except `--detach`. Includes `--read-only` (0.8.0+), `--cpus`/`--memory` (0.9.0+), `--init`/`--init-image`/`--runtime` (0.10.0+), `--cap-add`/`--cap-drop` (0.12.0+), and all DNS flags.
 
 ### `container start`
 
@@ -170,7 +172,7 @@ container prune
 
 ### `container export`
 
-Create an image from a container's changes. (0.10.0+)
+Create an OCI layout tar from a container. (0.10.0+; 0.11.0+ supports stopped containers)
 
 ```
 container export [FLAGS] CONTAINER
@@ -220,6 +222,8 @@ Push an image to a registry.
 ```
 container image push IMAGE
 ```
+
+**Note (0.12.3+)**: Prints the image reference to stdout on success, enabling scripting/automation to capture the pushed reference.
 
 ### `container image save`
 
@@ -374,8 +378,9 @@ container network create [FLAGS] NAME
 |------|-------------|
 | `--subnet` | Subnet in CIDR format (e.g., `10.0.0.0/24`) (0.6.0+) |
 | `--labels` | Labels for the network (0.5.0+) |
+| `--mtu` | MTU for the network attachment (0.11.0+) |
 
-**Note**: Full IPv6 support in 0.8.0+. Host-only and isolated network capabilities in 0.9.0+ (verify flag syntax with `container network create --help`).
+**Note**: Full IPv6 support in 0.8.0+. Host-only and isolated network capabilities in 0.9.0+ (verify flag syntax with `container network create --help`). MTU network attachment option added in 0.11.0+.
 
 ### `container network delete`
 
@@ -424,6 +429,7 @@ container volume create [FLAGS] [NAME]
 | `--size` | `-s` | Size limit (e.g., `10G`) |
 | `--label` | | Label for the volume |
 | `--opt` | | Driver-specific options (e.g., `type=tmpfs`) |
+| `--journal` | | Enable journaling for the volume (0.12.0+) |
 
 ### `container volume delete`
 
@@ -585,6 +591,8 @@ Create a DNS entry.
 container system dns create NAME IP
 ```
 
+**Security (0.12.3+)**: Path/rule injection is prevented — inputs are sanitized.
+
 ### `container system dns delete`
 
 Delete a DNS entry.
@@ -612,3 +620,40 @@ container system kernel set [FLAGS] PATH
 | Flag | Description |
 |------|-------------|
 | `--force` | Force set (0.5.0+ only) |
+
+## Environment Variables (0.11.0+)
+
+| Variable | Description |
+|----------|-------------|
+| `CONTAINER_DEFAULT_PLATFORM` | Sets the default image platform (e.g., `linux/arm64`). Applies to `image pull`, `container run`, and `container build` when `--platform` is not specified. |
+
+## Output Formats (0.12.0+)
+
+Commands that accept `--format` support these values:
+
+| Format | Description |
+|--------|-------------|
+| `json` | JSON output (0.10.0+) |
+| `yaml` | YAML output (0.12.0+) |
+
+Progress output modes (0.12.0+):
+
+| Mode | Description |
+|------|-------------|
+| `plain` | Plain text progress output |
+| `color` | Colored progress output |
+| (auto) | Automatically falls back to `plain` when stderr is not a TTY |
+
+## Build Secrets (0.11.0+)
+
+Build secrets can be passed to build steps without baking them into image layers. Use the `--secret` flag with `container build`:
+
+```bash
+container build --secret id=mysecret,src=/path/to/secret -t myimage:latest .
+```
+
+Reference the secret in a Dockerfile using `RUN --mount=type=secret`.
+
+## Plugin Configuration (0.12.0+)
+
+TOML-based plugin configuration files are supported. Plugin config files allow per-plugin settings without modifying the main container configuration.

--- a/plugins/core/skills/container/templates/0.11.0/commands.md
+++ b/plugins/core/skills/container/templates/0.11.0/commands.md
@@ -1,0 +1,71 @@
+# Apple Container CLI - Version 0.11.0 Commands
+
+Changes from 0.10.0.
+
+## Breaking Changes from 0.10.0
+
+None. 0.11.0 is a non-breaking release.
+
+## New Features in 0.11.0
+
+- `container export` (OCI layout tar) for **stopped** containers
+- Build secrets support in `container build`
+- `--init` flag on `container run`/`container create`
+- `CONTAINER_DEFAULT_PLATFORM` environment variable (sets default image platform)
+- `mtu` option for network attachments
+- Configurable default CPU/memory via system properties: `container.cpus`, `container.memory`, `build.cpus`, `build.memory`
+- Dockerfile-specific ignore files support
+- ARG-parsing and docker-ignore bug fixes
+
+## Container Lifecycle
+
+| Command | Description |
+|---------|-------------|
+| `container run` | **`--init` flag: run an init process in the container** |
+| `container create` | **`--init` flag: run an init process in the container** |
+| `container export` | **Writes OCI layout tar for a STOPPED container** |
+
+## Build
+
+| Feature | Description |
+|---------|-------------|
+| Build secrets | **Pass secrets to build steps without baking into image layers** |
+| Dockerfile ignore files | **Dockerfile-specific `.dockerignore` files now respected** |
+
+## System Properties (0.11.0+)
+
+| Property | Description |
+|----------|-------------|
+| `container.cpus` | Default CPU count for new containers |
+| `container.memory` | Default memory for new containers |
+| `build.cpus` | Default CPU count for image builds |
+| `build.memory` | Default memory for image builds |
+
+```bash
+# Set default resources
+container system property set container.cpus 2
+container system property set container.memory 2g
+container system property set build.cpus 4
+container system property set build.memory 4g
+```
+
+## Network
+
+| Option | Description |
+|--------|-------------|
+| `mtu` | **Network attachment MTU option (0.11.0+)** |
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `CONTAINER_DEFAULT_PLATFORM` | Sets default image platform (e.g., `linux/arm64`) |
+
+## Bug Fixes
+
+- ARG-parsing fix in Dockerfile handling
+- Docker-ignore bug fixes
+
+## Dependencies
+
+- No dependency version changes listed for this release

--- a/plugins/core/skills/container/templates/0.12.0/commands.md
+++ b/plugins/core/skills/container/templates/0.12.0/commands.md
@@ -1,0 +1,74 @@
+# Apple Container CLI - Version 0.12.0 Commands
+
+Changes from 0.11.0.
+
+## Breaking Changes from 0.11.0
+
+> **CRITICAL — Capability model change.** The default Linux capability set has been **REDUCED** in 0.12.0. Existing containers created with prior versions run with a broader capability set than new containers will receive.
+>
+> **Migration required:** Delete and recreate all existing containers to apply the reduced default capability set. Containers that need elevated capabilities must use `--cap-add` to restore them. Containers that do not need existing defaults should use `--cap-drop` to reduce their surface.
+
+| Change | Migration |
+|--------|-----------|
+| Default Linux capability set REDUCED | Delete & recreate all existing containers |
+| `--cap-add` / `--cap-drop` flags added to `run`/`create` | Use `--cap-add` to restore needed capabilities |
+| Builder-shim gRPC protocol changed | Incompatible with pre-0.12.0 clients — update all builder clients |
+
+## New Features in 0.12.0
+
+- `--cap-add` / `--cap-drop` flags on `container run` / `container create`
+- Plain and color progress output modes; auto-falls back to plain when stderr is not a TTY
+- YAML output format support
+- TOML-based plugin configuration files
+- `SSH_AUTH_SOCK` passthrough after user login
+- Kernel updated to kata-3.28.0
+- `journal` option for `container volume create`
+- Single-file-mount fix
+- Improved `image save` platform error messaging
+
+## Container Lifecycle
+
+| Command | Description |
+|---------|-------------|
+| `container run` | **`--cap-add`/`--cap-drop` flags added; reduced default capability set** |
+| `container create` | **`--cap-add`/`--cap-drop` flags added; reduced default capability set** |
+
+### Capability Flags
+
+```bash
+# Add a capability
+container run --cap-add NET_ADMIN myimage:latest
+
+# Drop a capability
+container run --cap-drop ALL --cap-add NET_BIND_SERVICE myimage:latest
+```
+
+## Volume Management
+
+| Option | Description |
+|--------|-------------|
+| `--journal` | **Enable journaling for a volume (0.12.0+)** |
+
+```bash
+# Create a volume with journaling
+container volume create --journal mydata
+```
+
+## Output Formats
+
+| Feature | Description |
+|---------|-------------|
+| YAML output | **`--format yaml` now supported where format flags are accepted** |
+| Progress output | **Plain/color modes; auto-plain when stderr is not a TTY** |
+
+## Plugin Configuration
+
+TOML-based plugin configuration files supported in 0.12.0+.
+
+## SSH Auth
+
+`SSH_AUTH_SOCK` is now passed through to containers after user login.
+
+## Dependencies
+
+- Kernel: kata-3.28.0

--- a/plugins/core/skills/container/templates/0.12.3/commands.md
+++ b/plugins/core/skills/container/templates/0.12.3/commands.md
@@ -1,0 +1,56 @@
+# Apple Container CLI - Version 0.12.3 Commands
+
+Changes from 0.12.0. Includes 0.12.1 compat fix.
+
+NOTE: There is no 0.12.2 release.
+
+## Breaking Changes
+
+None. 0.12.1 and 0.12.3 are non-breaking releases.
+
+## Changes in 0.12.1 (2026-04-29)
+
+- macOS 15 (Sequoia) compatibility: allow listing and deleting networks on macOS 15
+
+## Changes in 0.12.3 (2026-04-30, Security)
+
+- Prevent HTTP downgrade in registry commands
+- Prevent path/rule injection in `container system dns`
+- `ImagePush` now prints the image reference to stdout on success
+
+## Security Fixes Summary
+
+| Fix | Impact |
+|-----|--------|
+| Prevent HTTP downgrade in registry commands | Registry operations now enforce HTTPS |
+| Prevent path/rule injection in `container system dns` | DNS operations sanitize inputs |
+| `ImagePush` prints image reference to stdout on success | Scripting / automation can capture the pushed reference |
+
+## Registry
+
+| Command | Change |
+|---------|--------|
+| `container image push IMAGE` | **Now prints the image reference to stdout on success (0.12.3+)** |
+
+## System
+
+| Command | Change |
+|---------|--------|
+| `container system dns create/delete/list` | **Path/rule injection prevented (0.12.3+)** |
+
+## Network (from 0.12.1)
+
+| Platform | Change |
+|----------|--------|
+| macOS 15 (Sequoia) | **`container network list` and `container network delete` now work correctly** |
+
+## Install / Upgrade
+
+```bash
+# Install 0.12.3
+curl -LO https://github.com/apple/container/releases/download/0.12.3/container-0.12.3-installer-signed.pkg
+sudo installer -pkg container-0.12.3-installer-signed.pkg -target /
+
+# Upgrade existing installation
+/usr/local/bin/update-container.sh
+```

--- a/plugins/core/skills/sources.md
+++ b/plugins/core/skills/sources.md
@@ -212,7 +212,7 @@ This file documents the sources used to create the core plugin skills.
 - **URL**: https://github.com/apple/container/releases
 - **Purpose**: Version tracking, breaking changes between releases, installation packages
 - **Date Accessed**: 2026-02-21
-- **Key Topics**: Version migration (0.4.1 through 0.9.0), breaking changes, new features, CVE fixes
+- **Key Topics**: Version migration (0.4.1 through 0.12.3), breaking changes, new features, CVE fixes
 
 ### Apple Container Release 0.6.0
 - **URL**: https://github.com/apple/container/releases/tag/0.6.0
@@ -239,6 +239,34 @@ This file documents the sources used to create the core plugin skills.
 - **Purpose**: Version 0.10.0 release notes
 - **Date Accessed**: 2026-03-24
 - **Key Topics**: VM init image selection, container export, runtime flag, registry list, --format on system status, --init flag, generic ClientContainer, SandboxService bundle creation, multiple network plugins, minimum memory validation, SELinux kernel panic fix, env var duplication fix, Containerization 0.26.2
+
+### Apple Container Release 0.11.0
+- **URL**: https://github.com/apple/container/releases/tag/0.11.0
+- **Purpose**: Version 0.11.0 release notes (non-breaking)
+- **Date Accessed**: 2026-05-31
+- **Key Topics**: container export for stopped containers, build secrets, --init flag, CONTAINER_DEFAULT_PLATFORM env var, mtu network attachment option, system properties container.cpus/container.memory/build.cpus/build.memory, Dockerfile-specific ignore files, ARG-parsing and docker-ignore bug fixes
+
+### Apple Container Release 0.12.0
+- **URL**: https://github.com/apple/container/releases/tag/0.12.0
+- **Purpose**: Version 0.12.0 release notes (BREAKING: reduced default capability set)
+- **Date Accessed**: 2026-05-31
+- **Key Topics**: BREAKING reduced default Linux capability set, --cap-add/--cap-drop flags, builder-shim gRPC protocol change, plain/color progress modes, YAML output format, TOML plugin config files, SSH_AUTH_SOCK passthrough, kernel kata-3.28.0, journal option for volume create, single-file-mount fix
+
+### Apple Container Release 0.12.1
+- **URL**: https://github.com/apple/container/releases/tag/0.12.1
+- **Purpose**: Version 0.12.1 release notes (non-breaking, compat fix)
+- **Date Accessed**: 2026-05-31
+- **Key Topics**: macOS 15 (Sequoia) compatibility for network list and network delete
+
+### Apple Container Release 0.12.3
+- **URL**: https://github.com/apple/container/releases/tag/0.12.3
+- **Purpose**: Version 0.12.3 release notes (security release; no 0.12.2 was published)
+- **Date Accessed**: 2026-05-31
+- **Key Topics**: HTTP downgrade prevention in registry commands, path/rule injection prevention in system dns, ImagePush prints image reference to stdout on success
+
+## Update history
+
+- 2026-05-31: updated container skill from 0.10.0 to Apple Container 0.12.3 (added 0.11.0/0.12.0/0.12.3 templates, capability-model breaking change, security fixes)
 
 ## TDD Skill
 


### PR DESCRIPTION
- Add command snapshots for 0.11.0, 0.12.0, 0.12.3 under templates/
- Document 0.12.0 BREAKING change: reduced default Linux capabilities, --cap-add/--cap-drop, delete & recreate containers
- Add 0.11.0 features: container export (stopped→OCI tar), build secrets, --init flag, CONTAINER_DEFAULT_PLATFORM, mtu network option, configurable default cpu/memory props
- Add 0.12.0 features: YAML output, TOML plugin config, journal option for volume create, kata-3.28.0 kernel
- Note 0.12.1 macOS 15 network compat and 0.12.3 security fixes (HTTP downgrade, system dns injection) + ImagePush stdout
- Update SKILL.md version refs (0.10.0 → 0.12.3) and command-reference.md flag markers
- Add sources.md release entries (0.11.0–0.12.3) and Update history section
- Bump core 0.2.9 → 0.2.10 and all-skills 0.4.19 → 0.4.20