### PR TITLE
docs(agent-loop): add autonomous-loop carve-out to Phase 1.5a

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,7 +62,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "category": "development",
       "keywords": ["git", "documentation", "code-review", "tools", "beads", "bees", "container", "tdd", "agent-loop"]
     },

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/agent-loop/SKILL.md
+++ b/plugins/core/skills/agent-loop/SKILL.md
@@ -38,7 +38,7 @@ Between Phase 1 (pre-flight) and Phase 2 (spawn), the Team Leader checks two det
 | State | bees | `DECOMPOSITION_PATH` | Action |
 |-------|------|----------------------|--------|
 | A | Has issues | Unset, OR set+missing | Skip Phase 1.5a. Spot-check each issue (AC, skill labels, dep edges). Flag gaps, proceed. |
-| B | Empty | Unset, OR set+missing | Run Phase 1.5a (clarifying questions), then decompose into bees. |
+| B | Empty | Unset, OR set+missing | Run Phase 1.5a — produce the decomposition from the epic objective + AC, record assumptions, decompose into bees. Ask only on a genuine fork or hard blocker. |
 | C | Empty | Set + file exists | Consume the proposal verbatim — `bees create` one issue per proposed item with AC, skill labels, and dep edges as written. Topological order (deps before dependents); map `depends_on` titles to bee IDs returned by prior `bees create` calls as you go. If any cycle is detected in the dep graph (2-cycle X↔Y, 3-cycle A→B→C→A, or longer), halt and report all cycle members — create zero issues. No clarifying questions. Spot-check after, proceed. |
 | D | Has issues | Set + file exists | Resume gap — diff proposal titles vs existing bees titles. Materialize each missing proposed item with the same rules as State C (topological order, cycle detection). Spot-check the complete set, proceed. Never re-ask, never re-decompose. |
 
@@ -49,21 +49,15 @@ Between Phase 1 (pre-flight) and Phase 2 (spawn), the Team Leader checks two det
 
 **Proposal file format:** this skill mandates only the consumption rules above; the file's on-disk schema is defined by whatever upstream process produces it. A minimum interoperable shape is a JSON array of issues each carrying `title`, `acceptance_criteria` (list), `labels` (list), and `depends_on` (list of titles or stable local keys that resolve to other entries in the same file).
 
-### Phase 1.5a: Clarifying Questions (State B only)
+### Phase 1.5a: Default to proceeding (State B only)
 
-State B behavior depends on whether a human is attached to the session:
+The operative question is plan presence, not who is at the keyboard. A decomposition plan is PRESENT when any of these hold: `DECOMPOSITION_PATH` is set and the file exists, OR bees already has issues, OR an upstream proposal exists. States A / C / D are plan-present — consume, spot-check, or resume and proceed; never ask clarifying questions there.
 
-**Interactive session (human present):** Call AskUserQuestion before any bees writes. Single call, max 4 questions, 2–4 options each.
+State B is plan-absent. The lead PRODUCES the decomposition itself from the epic objective and acceptance criteria, records its assumptions as a bees comment (auditable trail), and proceeds. Default to proceeding on the most reasonable interpretation.
 
-Skip Phase 1.5a only when the scope is fully implied by the request and the agent does not have to assume any architectural choice. Qualifies: "rename foo to bar in file X", "tail the deploy log". Does NOT qualify: "add caching", "make it faster", "improve error handling", or anything that forks on a strategy decision the user owns.
+Reserve AskUserQuestion ONLY for a genuine architectural fork the user owns that cannot be responsibly defaulted, or a hard blocker: missing repository, missing credential, or contradictory acceptance criteria with no clear winner. A preference question — "approach A or B?" — is NOT a blocker; pick the reasonable default, record the choice, proceed.
 
-When in doubt, ask. Asking costs one prompt cycle; guessing wrong costs an entire epic loop.
-
-**Autonomous loop (no human attached):** Default to proceeding — select the most reasonable decomposition from the epic objective and acceptance criteria, record the assumption as a bees comment (auditable), and decompose without pausing for input.
-
-Reserve AskUserQuestion in autonomous mode ONLY for a genuine architectural fork the user owns that cannot be responsibly defaulted (e.g., contradictory acceptance criteria with no clear winner, missing repository or credential that blocks all forward paths). A preference question — "should I use approach A or B?" — is NOT a hard blocker; pick A, record the choice, proceed.
-
-The signal for "human attached" is the runtime context: an interactive terminal session has a human present; an autonomous dispatch (no TTY, triggered by a workflow or scheduler) does not.
+This rule applies in every context. A host that runs without a human supplies the plan (State C fires); when no plan exists the default is still proceed-on-reasonable-default.
 
 ## 6-Tier Prompt Hierarchy
 
@@ -301,7 +295,7 @@ Epics WITHOUT a `spec:` field behave exactly as today — all spec-driven steps 
 
 Claude Code dynamic workflows are an optional runtime for the five-tier pipeline. When available and opted-in, the Sub-team Leader encodes one issue's pipeline as a workflow script instead of dispatching five Task spawns — the adversarial separation and stage gates (`test files unmodified before P5`, `mise run ci` green before review) become deterministic script assertions, model escalation becomes a retry ladder, and the validator↔fix iteration becomes a bounded loop. `isolation: 'worktree'` gives each parallel implementer its own tree, replacing the shallow-clone workaround for working-tree contention.
 
-The boundary: decomposition, Phase 1.5a clarifying questions, and merge approval stay in the interactive loop — a workflow has no mid-run user input. The workflow executes already-decomposed issues (gate States A/C/D); it never decomposes them.
+The boundary: decomposition, any Phase 1.5a escalation (the rare fork-or-blocker AskUserQuestion), and merge approval stay in the interactive loop — a workflow has no mid-run user input. The workflow executes already-decomposed issues (gate States A/C/D); it never decomposes them.
 
 Workflows are a research preview on paid plans. When disabled, the default Task-spawn path applies unchanged. See `references/workflows-execution.md` and the `/claude-code:claude-workflows` skill.
 

--- a/plugins/core/skills/agent-loop/SKILL.md
+++ b/plugins/core/skills/agent-loop/SKILL.md
@@ -51,9 +51,19 @@ Between Phase 1 (pre-flight) and Phase 2 (spawn), the Team Leader checks two det
 
 ### Phase 1.5a: Clarifying Questions (State B only)
 
-When the lead is the decomposer with no upstream proposal, call AskUserQuestion before any bees writes. Single call, max 4 questions, 2–4 options each.
+State B behavior depends on whether a human is attached to the session:
+
+**Interactive session (human present):** Call AskUserQuestion before any bees writes. Single call, max 4 questions, 2–4 options each.
 
 Skip Phase 1.5a only when the scope is fully implied by the request and the agent does not have to assume any architectural choice. Qualifies: "rename foo to bar in file X", "tail the deploy log". Does NOT qualify: "add caching", "make it faster", "improve error handling", or anything that forks on a strategy decision the user owns.
+
+When in doubt, ask. Asking costs one prompt cycle; guessing wrong costs an entire epic loop.
+
+**Autonomous loop (no human attached):** Default to proceeding — select the most reasonable decomposition from the epic objective and acceptance criteria, record the assumption as a bees comment (auditable), and decompose without pausing for input.
+
+Reserve AskUserQuestion in autonomous mode ONLY for a genuine architectural fork the user owns that cannot be responsibly defaulted (e.g., contradictory acceptance criteria with no clear winner, missing repository or credential that blocks all forward paths). A preference question — "should I use approach A or B?" — is NOT a hard blocker; pick A, record the choice, proceed.
+
+The signal for "human attached" is the runtime context: an interactive terminal session has a human present; an autonomous dispatch (no TTY, triggered by a workflow or scheduler) does not.
 
 ## 6-Tier Prompt Hierarchy
 

--- a/plugins/core/skills/agent-loop/SKILL.md
+++ b/plugins/core/skills/agent-loop/SKILL.md
@@ -57,6 +57,8 @@ State B is plan-absent. The lead PRODUCES the decomposition itself from the epic
 
 Reserve AskUserQuestion ONLY for a genuine architectural fork the user owns that cannot be responsibly defaulted, or a hard blocker: missing repository, missing credential, or contradictory acceptance criteria with no clear winner. A preference question — "approach A or B?" — is NOT a blocker; pick the reasonable default, record the choice, proceed.
 
+When you do escalate, group related questions into a single AskUserQuestion call (max 4 questions, 2–4 options each) — never one question at a time. Once you have judged a decision to be a genuine fork the user owns, do not guess — ask. This phase does not apply at all to single-file mechanical refactors, status checks, or log diagnosis.
+
 This rule applies in every context. A host that runs without a human supplies the plan (State C fires); when no plan exists the default is still proceed-on-reasonable-default.
 
 ## 6-Tier Prompt Hierarchy

--- a/plugins/core/skills/agent-loop/references/team-leader.md
+++ b/plugins/core/skills/agent-loop/references/team-leader.md
@@ -53,6 +53,8 @@ When no plan is present, the lead PRODUCES the decomposition itself from the epi
 
 When a checklist item is underspecified, fill it with the most reasonable default and record that choice. Escalate via AskUserQuestion ONLY for a genuine architectural fork the user owns that cannot be responsibly defaulted, or a hard blocker: missing repository, missing credential, or contradictory acceptance criteria with no clear winner. A preference question ("approach A or B?") is NOT a blocker — pick the reasonable default, record the rationale, proceed.
 
+When you do escalate, group related questions into a single AskUserQuestion call (max 4 questions, 2–4 options each) — never one question at a time. Once you have judged a decision to be a genuine fork the user owns, do not guess — ask. This phase does not apply at all to single-file mechanical refactors, status checks, or log diagnosis.
+
 This rule applies in every context. A host that runs without a human supplies the plan (State C fires); when no plan exists the default is still proceed-on-reasonable-default.
 
 **State A / C / D analogues:** in State A, a plan already exists in bees; in State C/D, an upstream proposal supplies it. In all three, the lead's job is the spot-check in step 4 — verify each issue is well-formed, flag gaps, do not re-decompose and do not re-interrogate.

--- a/plugins/core/skills/agent-loop/references/team-leader.md
+++ b/plugins/core/skills/agent-loop/references/team-leader.md
@@ -39,13 +39,11 @@ You are the Team Leader for an epic. You receive the epic assignment and are res
    - Respect dependency ordering: do not start issue B if it depends on A
 8. Report plan before spawning any agents
 
-## Phase 1.5a: Clarifying Questions (State B only)
+## Phase 1.5a: Default to proceeding (State B only)
 
-When the lead is the decomposer AND no upstream proposal exists (State B from step 4), apply the rule that matches the session context:
+State B is the plan-absent state — bees is empty AND no upstream proposal exists (from step 4). The decision axis is plan presence, not who is at the keyboard.
 
-### Interactive session (human present)
-
-Call AskUserQuestion before creating any bees issues. Required checklist:
+When no plan is present, the lead PRODUCES the decomposition itself from the epic objective and acceptance criteria, records its assumptions as a bees comment on the epic (auditable trail), and proceeds. Default to proceeding on the most reasonable interpretation. Before decomposing, confirm:
 
 - [ ] Epic objective is concrete (no "improve X" without measurable outcome)
 - [ ] Acceptance criteria are testable
@@ -53,19 +51,11 @@ Call AskUserQuestion before creating any bees issues. Required checklist:
 - [ ] Repos/paths are explicit
 - [ ] Model assignments are appropriate (opus for the lead via `AGENT_LOOP_LEAD_MODEL`, haiku/sonnet for workers per task complexity)
 
-Group related questions into a single AskUserQuestion call (max 4 questions, 2–4 options each). Skip this phase ONLY for: single-file mechanical refactors, status checks, log diagnosis. When in doubt, ask.
+When a checklist item is underspecified, fill it with the most reasonable default and record that choice. Escalate via AskUserQuestion ONLY for a genuine architectural fork the user owns that cannot be responsibly defaulted, or a hard blocker: missing repository, missing credential, or contradictory acceptance criteria with no clear winner. A preference question ("approach A or B?") is NOT a blocker — pick the reasonable default, record the rationale, proceed.
 
-Never guess at user intent. Asking costs one prompt cycle; guessing wrong costs an entire epic loop.
+This rule applies in every context. A host that runs without a human supplies the plan (State C fires); when no plan exists the default is still proceed-on-reasonable-default.
 
-### Autonomous loop (no human attached)
-
-Default to proceeding. Select the most reasonable decomposition from the epic objective and acceptance criteria. Record each significant assumption as a bees comment on the epic (auditable trail). Do not pause for input.
-
-Call AskUserQuestion ONLY when a genuine hard blocker exists — contradictory acceptance criteria with no clear winner, or a missing repository or credential that blocks ALL forward paths. A preference question ("should I use approach A or B?") is NOT a hard blocker: pick A, record the rationale, proceed.
-
-The "autonomous" signal: no TTY, session launched by a workflow or scheduler with no human at the terminal.
-
-**State A / C / D analogues:** in State A, clarifying questions happened in a prior session; in State C/D, they happened during the upstream decomposition pass. In all three, the lead's substitute is the spot-check in step 4 — verify each issue is well-formed, flag gaps, do not re-interrogate.
+**State A / C / D analogues:** in State A, a plan already exists in bees; in State C/D, an upstream proposal supplies it. In all three, the lead's job is the spot-check in step 4 — verify each issue is well-formed, flag gaps, do not re-decompose and do not re-interrogate.
 
 ## Before-spawn checklist
 

--- a/plugins/core/skills/agent-loop/references/team-leader.md
+++ b/plugins/core/skills/agent-loop/references/team-leader.md
@@ -41,7 +41,11 @@ You are the Team Leader for an epic. You receive the epic assignment and are res
 
 ## Phase 1.5a: Clarifying Questions (State B only)
 
-When the lead is the decomposer AND no upstream proposal exists (State B from step 4), call AskUserQuestion before creating any bees issues. Required checklist:
+When the lead is the decomposer AND no upstream proposal exists (State B from step 4), apply the rule that matches the session context:
+
+### Interactive session (human present)
+
+Call AskUserQuestion before creating any bees issues. Required checklist:
 
 - [ ] Epic objective is concrete (no "improve X" without measurable outcome)
 - [ ] Acceptance criteria are testable
@@ -52,6 +56,14 @@ When the lead is the decomposer AND no upstream proposal exists (State B from st
 Group related questions into a single AskUserQuestion call (max 4 questions, 2–4 options each). Skip this phase ONLY for: single-file mechanical refactors, status checks, log diagnosis. When in doubt, ask.
 
 Never guess at user intent. Asking costs one prompt cycle; guessing wrong costs an entire epic loop.
+
+### Autonomous loop (no human attached)
+
+Default to proceeding. Select the most reasonable decomposition from the epic objective and acceptance criteria. Record each significant assumption as a bees comment on the epic (auditable trail). Do not pause for input.
+
+Call AskUserQuestion ONLY when a genuine hard blocker exists — contradictory acceptance criteria with no clear winner, or a missing repository or credential that blocks ALL forward paths. A preference question ("should I use approach A or B?") is NOT a hard blocker: pick A, record the rationale, proceed.
+
+The "autonomous" signal: no TTY, session launched by a workflow or scheduler with no human at the terminal.
 
 **State A / C / D analogues:** in State A, clarifying questions happened in a prior session; in State C/D, they happened during the upstream decomposition pass. In all three, the lead's substitute is the spot-check in step 4 — verify each issue is well-formed, flag gaps, do not re-interrogate.
 


### PR DESCRIPTION
- Narrow Phase 1.5a State B behavior based on whether a human is attached
- Interactive session: preserve existing ask-first behavior and 'when in doubt, ask' maxim
- Autonomous loop: default to proceeding with the most reasonable decomposition, record assumptions as bees comments, reserve AskUserQuestion for genuine hard blockers only (contradictory AC, missing repo/credential)
- Update both SKILL.md and references/team-leader.md with the same two-mode split
- No new env vars or abstractions — uses existing DECOMPOSITION_PATH / human-attached signal