### PR TITLE
feat(graphify): add graphify knowledge-graph tool plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "A curated collection of Claude skills for development workflows",
-    "version": "1.0.21"
+    "version": "1.0.22"
   },
   "plugins": [
     {
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.21",
+      "version": "0.4.22",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -92,6 +92,16 @@
       "version": "0.1.3",
       "category": "tools",
       "keywords": ["github", "actions", "workflows", "ci-cd", "act", "testing", "community-health", "open-source"]
+    },
+    {
+      "name": "graphify",
+      "source": "./plugins/tools/graphify",
+      "strict": true,
+      "description": "Graphify knowledge-graph tool: build a queryable graph of a codebase and query it instead of reading raw files",
+      "version": "0.1.0",
+      "category": "tools",
+      "keywords": ["graphify", "knowledge-graph", "codebase", "code-search", "tree-sitter", "agents", "context"],
+      "license": "MIT"
     },
     {
       "name": "agent-sandboxing",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -68,6 +68,8 @@
     "./plugins/tools/github/skills/workflows",
     "./plugins/tools/github/skills/act",
     "./plugins/tools/github/skills/community-health",
+    "./plugins/tools/graphify/skills/graphify",
+    "./plugins/tools/graphify/skills/graphify-agents",
     "./plugins/tools/agent-sandboxing/skills/sandbox",
     "./plugins/tools/agent-sandboxing/skills/k8s-agent-sandbox",
     "./plugins/tools/agent-sandboxing/skills/kata-on-kind",

--- a/plugins/tools/graphify/.claude-plugin/plugin.json
+++ b/plugins/tools/graphify/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "graphify",
+  "version": "0.1.0",
+  "description": "Graphify knowledge-graph tool: build a queryable graph of a codebase and query it instead of reading raw files",
+  "author": {
+    "name": "vinnie357"
+  },
+  "repository": "https://github.com/vinnie357/claude-skills",
+  "license": "MIT",
+  "keywords": ["graphify", "knowledge-graph", "codebase", "code-search", "tree-sitter", "agents", "context"],
+  "skills": [
+    "./skills/graphify",
+    "./skills/graphify-agents"
+  ]
+}

--- a/plugins/tools/graphify/skills/graphify-agents/SKILL.md
+++ b/plugins/tools/graphify/skills/graphify-agents/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: graphify-agents
+description: Use a graphify knowledge graph to give agents low-token codebase context — query the graph instead of reading raw files during research, decomposition, and impact analysis. Use when wiring graphify into an agent-loop, an Explore/research subagent, or an MCP-enabled agent, or when deciding when a graph query beats grepping and reading files.
+license: MIT
+---
+
+# Graphify for Agents
+
+Reading raw files into context is the dominant token cost of codebase-understanding work. Graphify builds a knowledge graph once (`graphify-out/graph.json`) and answers structural questions by traversing it — returning the relevant nodes and edges instead of whole files. This skill covers using that graph to make agent workflows cheaper and more targeted.
+
+The project's published benchmark reports "**71.5x** fewer tokens per query vs reading raw files" on a mixed corpus, with smaller gains (≈5.4x on a 4-file corpus, ≈1x on a 6-file library) — the advantage scales with corpus size. Measure a specific repo with `graphify benchmark` before quoting a number; small repos see little benefit, so reserve the graph for large corpora.
+
+For installing graphify and the full CLI surface, load the `graphify` skill.
+
+## When to Use This Skill
+
+Activate when:
+- Giving a research or Explore subagent codebase context without reading every file
+- Adding a graph-build + graph-query step to a `/core:agent-loop` Phase 1 pre-flight
+- Doing impact analysis ("what breaks if I change X") before decomposing an epic
+- Exposing the graph to an agent through the graphify MCP server
+- Deciding between a graph query and grep+read for a given question
+
+## The Core Pattern: Query, Don't Read
+
+| Question shape | Without graphify | With graphify |
+|----------------|------------------|---------------|
+| "How does auth connect to the request pipeline?" | Grep, open 6–10 files, read each | `graphify query "how does auth connect to the request pipeline?"` → relevant nodes + edges |
+| "What is `SwinTransformer` and what touches it?" | Read the class + every caller | `graphify explain "SwinTransformer"` |
+| "What breaks if I change `add`?" | Trace callers by hand | `graphify affected "add"` |
+| "How do these two modules connect?" | Read both, infer | `graphify path "DigestAuth" "Response"` |
+
+`query` returns within a token budget (`--budget`, default 2000), so an agent gets a bounded, relevant slice rather than unbounded file contents.
+
+## Integration with /core:agent-loop
+
+Graphify slots into the loop's existing phases without replacing them. Load `/core:agent-loop` for the phase model.
+
+**Phase 1 (Pre-flight / research).** Before decomposition, build or refresh the graph, then have the research/Explore subagent query it instead of fanning out file reads:
+
+```bash
+mise run graphify:update      # AST-only refresh, no API key needed
+graphify query "where is <epic-area> implemented and what does it depend on?"
+```
+
+Feed the query result into the Team Leader's decomposition. The graph names the real files and symbols to reference in worker prompts — which the agent-loop prompt template already requires ("reference existing code and functions to reuse").
+
+**Phase 2 (Working).** Give each worker the `path`/`explain` output for its slice instead of pre-reading files into the prompt. Workers still read the specific files they edit.
+
+**Impact analysis before slicing.** `graphify affected "<symbol>"` (needs a full clustered build) surfaces the blast radius of a change, which informs dependency edges between bees issues.
+
+## Keeping the Graph Fresh
+
+A stale graph misleads agents the way stale docs do. Keep it current:
+
+```bash
+graphify hook install    # rebuild on post-commit / post-checkout
+graphify watch .         # rebuild live during a session
+```
+
+The agent that relies on the graph confirms freshness — `graphify check-update .` reports whether a semantic re-extraction is pending. Treat graph claims like any other: an agent verifies a graph answer against the actual file before acting on it (anti-fabrication).
+
+## Exposing the Graph via MCP
+
+`graphify . --mcp` starts an MCP stdio server (the `[mcp]` extra / `graphify-mcp` console script). An MCP-enabled agent then calls graphify tools directly rather than shelling out. See `/claude-code:claude-agents` (MCP-enabled agent pattern) for declaring the server in an agent's tool set.
+
+## Registering graphify with Claude Code
+
+`graphify claude install` writes a graphify section to `CLAUDE.md` and a PreToolUse hook so a Claude Code session reaches for the graph automatically. This is graphify's own integration; this marketplace's `graphify`/`graphify-agents` skills are the alternative, progressive-disclosure path that does not modify `CLAUDE.md`.
+
+## When NOT to Use the Graph
+
+- Small repos (the benchmark shows ≈1x on a 6-file library) — grep+read is simpler.
+- Questions about the exact current contents of one known file — read it.
+- Anything where the graph has not been rebuilt since the relevant code changed — refresh first or read directly.
+
+## Anti-Fabrication Requirements
+
+- Run `graphify benchmark` (or cite the project's published figures as such) before stating a token-savings number — never present a benchmark figure as independent measurement.
+- Verify a graph answer against the actual source file before an agent acts on it.
+- Confirm graph freshness (`graphify check-update`) before trusting a query in a long session.
+- State which commands require a full clustered build vs a raw AST extraction (`affected` and community labels need clustering).

--- a/plugins/tools/graphify/skills/graphify/SKILL.md
+++ b/plugins/tools/graphify/skills/graphify/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: graphify
+description: Build and query a knowledge graph of a codebase, docs, and mixed media with the graphify CLI. Use when installing graphify via mise, building or updating a code graph, exporting it (GraphML, SVG, Neo4j, Obsidian, call-flow HTML), or querying it with query/path/explain/affected instead of reading raw files.
+license: MIT
+---
+
+# Graphify
+
+Graphify converts a folder of code, docs, PDFs, images, and videos into a queryable knowledge graph. It extracts symbols and relationships locally with tree-sitter (no code leaves the machine for AST extraction), writes the graph to `graphify-out/graph.json` plus an interactive `graph.html`, and answers questions by traversing the graph instead of re-reading files.
+
+PyPI package: **`graphifyy`** (double-y). CLI command: **`graphify`**. License: MIT. Requires Python >= 3.10.
+
+## When to Use This Skill
+
+Activate when:
+- Installing graphify in a project via mise
+- Building or refreshing a knowledge graph of a repository or document corpus
+- Exporting a graph to GraphML, SVG, Neo4j/Cypher, an Obsidian vault, or call-flow HTML
+- Querying a codebase with `query`, `path`, `explain`, or `affected`
+- Setting up `graphify hook install` to rebuild the graph on git commits
+- Wiring graphify into an AI assistant via `graphify install` / `graphify claude install`
+
+For using graphify to reduce agent token usage during research and decomposition, load `graphify-agents`.
+
+## Installation
+
+### Using mise (recommended for this project)
+
+Copy `templates/mise.toml` from this skill into the project's `mise.toml`, then run `mise install`. graphify is a PyPI package, so mise installs it through its `pipx` backend; the template pins `uv` as the backend installer and enables uvx mode so one `mise install` resolves `uv` then `graphifyy`:
+
+```toml
+[settings.pipx]
+uvx = true
+
+[tools]
+python = "3.12"
+uv = "latest"
+"pipx:graphifyy" = "0.8.36"
+```
+
+```bash
+mise trust && mise install     # installs python, uv, then graphifyy
+graphify --version             # → graphify 0.8.36
+```
+
+Verify the backend sees the package before pinning a different version:
+
+```bash
+mise ls-remote pipx:graphifyy | tail -5
+```
+
+### Alternative installation (upstream)
+
+The project's own documented install (outside mise):
+
+```bash
+pip install graphifyy && graphify install
+```
+
+`pip install graphifyy` also accepts extras, e.g. `pip install "graphifyy[all]"`. Available extras: `pdf, office, google, video, mcp, neo4j, svg, leiden, ollama, openai, gemini, anthropic, bedrock, azure, sql, postgres, dm, terraform, chinese, all`.
+
+## How Graphify Works
+
+1. **Scan + extract** — walks the target path, classifies files (code, docs, papers, images), and runs tree-sitter AST extraction locally. AST extraction needs no LLM and no network.
+2. **Infer relationships** — semantic edge inference uses a configured LLM backend (`gemini|kimi|claude|openai|deepseek|ollama`, auto-detected from available API keys). Skippable with `--no-cluster` / `update`.
+3. **Cluster + label** — community detection groups related nodes; an LLM names the communities (skippable with `--no-label`).
+4. **Write outputs** — `graphify-out/graph.json` (NetworkX node-link JSON), `graph.html` (interactive viz), and a markdown report.
+5. **Query** — `query`/`path`/`explain`/`affected` traverse `graph.json` with no LLM call for the traversal itself.
+
+Default output directory: `graphify-out/`. Default graph path: `graphify-out/graph.json`.
+
+## Building a Graph
+
+```bash
+graphify .                       # build the graph for the current directory
+graphify ./raw                   # build for a specific path
+graphify ./raw --mode deep       # aggressive INFERRED-edge semantic extraction
+graphify update .                # re-extract code via AST only — no LLM, no API key
+graphify cluster-only .          # rerun clustering/report on an existing graph.json
+graphify add https://arxiv.org/abs/1706.03762   # fetch a URL into ./raw, then update
+```
+
+`update` is the offline path: it rebuilds the graph from code with no LLM backend, which is what runs without any API key configured.
+
+## Exporting
+
+Export flags run on a build invocation:
+
+```bash
+graphify . --graphml             # GraphML (Gephi, yEd)
+graphify . --svg                 # SVG vector graph
+graphify . --neo4j               # Neo4j/Cypher MERGE statements
+graphify . --wiki                # Wikipedia-style markdown
+graphify . --mcp                 # start the MCP stdio server
+graphify export callflow-html    # Mermaid-based architecture / call-flow HTML
+graphify tree                    # D3 collapsible-tree HTML of the module hierarchy
+```
+
+## Querying
+
+```bash
+graphify query "what connects attention to the optimizer?"   # BFS traversal, default 2000-token budget
+graphify query "..." --budget 1500     # cap output at N tokens
+graphify query "..." --dfs             # depth-first instead of breadth-first
+graphify path "DigestAuth" "Response"  # shortest path between two nodes
+graphify explain "SwinTransformer"     # plain-language explanation of a node + neighbors
+graphify affected "add"                # reverse traversal: nodes impacted by a change to "add"
+```
+
+`query`, `path`, and `explain` work on a raw AST-extracted `graph.json`. `affected` and community labels need a full clustered build (it errors with `could not load graph: 'links'` on an unclustered raw extraction).
+
+## Continuous Updates
+
+```bash
+graphify watch .                 # watch a folder, rebuild on code changes
+graphify hook install            # install post-commit/post-checkout git hooks
+graphify hook status             # check whether hooks are installed
+graphify check-update .          # cron-safe check of the needs_update flag
+```
+
+## Excluding Files
+
+graphify honors a `.graphifyignore` file (gitignore syntax) in the target directory to skip dependencies, build output, caches, and secrets. Keep generated graphs and secrets out of the corpus.
+
+## CLI Reference
+
+For the full command and flag surface (extraction backends, `global` cross-repo graphs, `merge-graphs`, per-platform `install` targets, and every flag captured from `graphify --help`), see `references/cli.md`.
+
+## Anti-Fabrication Requirements
+
+- Run `graphify --version` before stating the installed version.
+- Run `graphify --help` (or read `references/cli.md`) before documenting a command or flag — do not infer flags from blog posts.
+- Run `mise ls-remote pipx:graphifyy` before pinning a version.
+- Build a real graph and run an actual `query` before claiming a graph answers a given question.
+- Report token-reduction numbers only from `graphify benchmark` output or the project's own published figures, attributed as such — never as independent measurement.

--- a/plugins/tools/graphify/skills/graphify/references/cli.md
+++ b/plugins/tools/graphify/skills/graphify/references/cli.md
@@ -1,0 +1,106 @@
+# Graphify CLI Reference
+
+Captured from `graphify --help` on graphify 0.8.36. Run `graphify --help` to confirm against the installed version. Default graph path is `graphify-out/graph.json`; default output directory is `graphify-out/`.
+
+## Table of Contents
+
+- [Build & maintain](#build--maintain)
+- [Query & inspect](#query--inspect)
+- [Export & visualize](#export--visualize)
+- [Headless extraction](#headless-extraction)
+- [Cross-repo (global) graphs](#cross-repo-global-graphs)
+- [Git hooks & merge](#git-hooks--merge)
+- [Assistant registration](#assistant-registration)
+
+## Build & maintain
+
+Build is the bare path form: `graphify <path>` (e.g. `graphify .`). Build-time export flags (`--graphml`, `--svg`, `--neo4j`, `--wiki`, `--mcp`, `--mode deep`, `--update`) attach to this form.
+
+| Command | Purpose | Key flags |
+|---------|---------|-----------|
+| `graphify <path>` | Build/refresh the graph | `--mode deep`, `--update`, `--watch`, export flags |
+| `graphify update <path>` | Re-extract code via AST and update the graph (no LLM) | `--force`, `--no-cluster` |
+| `graphify cluster-only <path>` | Rerun clustering on an existing `graph.json`, regenerate report | `--no-viz`, `--no-label`, `--backend=<name>`, `--graph <path>` |
+| `graphify label <path>` | (Re)name communities with the configured LLM backend | `--backend=<name>` |
+| `graphify add <url>` | Fetch a URL, save to `./raw`, then update the graph | `--author "Name"`, `--contributor "Name"`, `--dir <path>` |
+| `graphify watch <path>` | Watch a folder and rebuild on code changes | — |
+| `graphify check-update <path>` | Cron-safe check of the `needs_update` flag | — |
+| `graphify clone <github-url>` | Clone a GitHub repo locally and print its path | `--branch <branch>`, `--out <dir>` |
+
+`update --force` overwrites `graph.json` even if the rebuild has fewer nodes (also `GRAPHIFY_FORCE=1`); use after refactors that delete code.
+
+## Query & inspect
+
+| Command | Purpose | Key flags |
+|---------|---------|-----------|
+| `graphify query "<question>"` | BFS traversal of `graph.json` for a question | `--dfs`, `--context C` (repeatable), `--budget N` (default 2000), `--graph <path>` |
+| `graphify path "A" "B"` | Shortest path between two nodes | `--graph <path>` |
+| `graphify explain "X"` | Plain-language explanation of a node and its neighbors | `--graph <path>` |
+| `graphify affected "X"` | Reverse traversal: nodes impacted by X | `--relation R` (repeatable), `--depth N` (default 2), `--graph <path>` |
+| `graphify save-result` | Save a Q&A result to `graphify-out/memory/` for the feedback loop | `--question`, `--answer`, `--type query\|path_query\|explain`, `--nodes N1 N2 ...`, `--memory-dir` |
+| `graphify diagnose multigraph` | Report same-endpoint edge collapse risk | `--json`, `--max-examples N`, `--directed`/`--undirected`, `--extract-path` |
+| `graphify benchmark [graph.json]` | Measure token reduction vs naive full-corpus reading | — |
+
+`query`, `path`, and `explain` operate on a raw AST-extracted graph. `affected` requires a clustered build (errors with `could not load graph: 'links'` on an unclustered extraction).
+
+## Export & visualize
+
+| Command / flag | Output |
+|----------------|--------|
+| `graphify . --graphml` | GraphML (Gephi, yEd) |
+| `graphify . --svg` | SVG vector graph |
+| `graphify . --neo4j` | Neo4j/Cypher MERGE statements |
+| `graphify . --wiki` | Wikipedia-style markdown |
+| `graphify . --mcp` | MCP stdio server |
+| `graphify export callflow-html` | Mermaid-based architecture / call-flow HTML |
+| `graphify tree` | D3 v7 collapsible-tree HTML (`--graph`, `--output`, `--root`, `--max-children` default 200, `--top-k-edges` default 12, `--label`) |
+
+## Headless extraction
+
+`graphify extract <path>` — headless full extraction (AST + semantic LLM) for CI/scripts.
+
+| Flag | Purpose |
+|------|---------|
+| `--backend B` | `gemini\|kimi\|claude\|openai\|deepseek\|ollama` (default: whichever API key is set) |
+| `--model M` | Override backend default model |
+| `--mode deep` | Aggressive INFERRED-edge semantic extraction |
+| `--max-workers N` | AST extraction subprocess count (default: cpu_count) |
+| `--token-budget N` | Per-chunk token cap for semantic extraction (default: 60000) |
+| `--max-concurrency N` | Parallel semantic chunks (default: 4; set 1 for local LLMs) |
+| `--api-timeout S` | Per-request LLM timeout (default: 600) |
+| `--out DIR` | Output dir (default: `<path>`); writes `<DIR>/graphify-out/` |
+| `--no-cluster` | Skip clustering, write raw extraction only |
+| `--postgres DSN` | Extract schema from a live PostgreSQL database |
+| `--global` / `--as <tag>` | Also merge the result into the global graph under a tag |
+
+## Cross-repo (global) graphs
+
+| Command | Purpose |
+|---------|---------|
+| `graphify global add <graph.json> [--as <tag>]` | Add/update a project graph in `~/.graphify/global-graph.json` |
+| `graphify global remove <tag>` | Remove a repo's nodes from the global graph |
+| `graphify global list` | List repos in the global graph |
+| `graphify global path` | Print the path to the global graph file |
+| `graphify merge-graphs <g1> <g2> [--out <path>]` | Merge two or more `graph.json` files into one cross-repo graph |
+
+## Git hooks & merge
+
+| Command | Purpose |
+|---------|---------|
+| `graphify hook install` | Install post-commit/post-checkout git hooks |
+| `graphify hook uninstall` | Remove git hooks |
+| `graphify hook status` | Check whether git hooks are installed |
+| `graphify merge-driver <base> <current> <other>` | Git merge driver: union-merge two `graph.json` files (set up via `hook install`) |
+
+## Assistant registration
+
+`graphify install [--platform P]` copies the graphify skill into a platform's config dir. `graphify uninstall [--purge]` removes it from all detected platforms. Per-platform subcommands write assistant-specific config:
+
+- `graphify claude install` — writes a graphify section to `CLAUDE.md` + a PreToolUse hook (Claude Code)
+- `graphify codex install` / `graphify aider install` / `graphify claw install` / `graphify droid install` — write a graphify section to `AGENTS.md`
+- `graphify cursor install` — writes `.cursor/rules/graphify.mdc`
+- `graphify gemini install` — writes a `GEMINI.md` section + BeforeTool hook
+- `graphify opencode install` — writes an `AGENTS.md` section + plugin
+- `graphify copilot install` / `graphify vscode install` — GitHub Copilot CLI / VS Code Copilot Chat
+
+Platform list (from `--help`): `claude|windows|codebuddy|codex|opencode|aider|amp|claw|droid|trae|trae-cn|gemini|cursor|antigravity|hermes|kiro|pi|devin`.

--- a/plugins/tools/graphify/skills/graphify/templates/mise.toml
+++ b/plugins/tools/graphify/skills/graphify/templates/mise.toml
@@ -1,0 +1,43 @@
+# Graphify knowledge-graph tool — copy into your project's mise.toml (or ~/.config/mise/config.toml).
+#
+# graphify ships on PyPI as the package `graphifyy` (double-y); the CLI command is `graphify`.
+# mise installs PyPI packages through its `pipx` backend, which needs an installer present.
+# This template uses `uv` as that installer (lighter than pipx) and enables uvx mode so a
+# single `mise install` resolves uv first, then graphifyy. Verified end-to-end on
+# mise 2026.5.15 (macOS arm64): `mise install` → `graphify --version` → graphify 0.8.36.
+
+[settings.pipx]
+uvx = true                    # use uv (not pipx) as the pipx-backend installer
+
+[tools]
+python = "3.12"               # graphify requires Python >= 3.10
+uv = "latest"                 # installer the pipx backend invokes
+"pipx:graphifyy" = "0.8.36"   # package is `graphifyy`; CLI command is `graphify`
+
+[tasks."graphify:build"]
+description = "Build/refresh the knowledge graph for a path (default: current dir) → graphify-out/graph.json + graph.html"
+run = "graphify ."
+
+[tasks."graphify:update"]
+description = "Re-extract code via AST only (no LLM) and update the graph"
+run = "graphify update ."
+
+[tasks."graphify:query"]
+description = "Natural-language BFS query over the graph (pass the question, e.g. mise graphify:query -- 'how is auth wired?')"
+run = "graphify query"
+
+[tasks."graphify:explain"]
+description = "Plain-language explanation of a node and its neighbors (pass the node name)"
+run = "graphify explain"
+
+[tasks."graphify:graphml"]
+description = "Export the graph as GraphML (Gephi/yEd)"
+run = "graphify . --graphml"
+
+[tasks."graphify:benchmark"]
+description = "Measure token reduction vs reading the raw corpus"
+run = "graphify benchmark"
+
+[tasks."graphify:verify"]
+description = "Verify graphify is installed and print its version"
+run = "graphify --version"

--- a/plugins/tools/graphify/skills/sources.md
+++ b/plugins/tools/graphify/skills/sources.md
@@ -1,0 +1,54 @@
+# Graphify Plugin Sources
+
+This file documents the sources used to create the graphify plugin skills.
+
+## graphify Skill
+
+### graphify on PyPI (primary)
+- **URL**: https://pypi.org/pypi/graphifyy/json
+- **Purpose**: Authoritative package name, version, license, Python floor, and optional-dependency extras
+- **Date Accessed**: 2026-06-08
+- **Key Topics**:
+  - Package `graphifyy` (CLI command `graphify`), version 0.8.36, MIT, requires Python >= 3.10
+  - Extras: pdf, office, google, video, mcp, neo4j, svg, leiden, ollama, openai, gemini, anthropic, bedrock, azure, sql, postgres, dm, terraform, chinese, all
+
+### graphify GitHub repository
+- **URL**: https://github.com/safishamsi/graphify
+- **Purpose**: Project overview, install path, build/query/export command examples, published benchmark figures
+- **Date Accessed**: 2026-06-08
+- **Key Topics**:
+  - `pip install graphifyy && graphify install`
+  - Build/export/query commands; `.graphifyignore`; MCP server; 71.5x / 5.4x / ~1x token-reduction figures
+
+### `graphify --help` (installed 0.8.36, primary)
+- **URL**: local execution — `graphify --help` after `mise install` of `pipx:graphifyy@0.8.36`
+- **Purpose**: Authoritative command and flag surface captured into references/cli.md
+- **Date Accessed**: 2026-06-08
+- **Key Topics**:
+  - build / update / cluster-only / label / add / watch / check-update / clone
+  - query / path / explain / affected / diagnose / benchmark / save-result
+  - extract backends; global cross-repo graphs; merge-graphs; hook install; per-platform install targets
+
+### mise pipx backend (install path)
+- **URL**: https://mise.jdx.dev (pipx backend) — verified via `/core:mise`
+- **Purpose**: Installing a PyPI package through mise; uvx-mode requirement
+- **Date Accessed**: 2026-06-08
+- **Key Topics**:
+  - `[settings.pipx] uvx = true` + `uv` tool so a single `mise install` resolves uv then `pipx:graphifyy`
+  - `mise ls-remote pipx:graphifyy` to verify versions
+
+## graphify-agents Skill
+
+### graphify GitHub repository (agent integration)
+- **URL**: https://github.com/safishamsi/graphify
+- **Purpose**: Query-the-graph-instead-of-reading-files model, MCP server, benchmark figures
+- **Date Accessed**: 2026-06-08
+- **Key Topics**: query/path/explain/affected; token budget; MCP stdio server; `graphify claude install`
+
+## Plugin Information
+
+- **Name**: graphify
+- **Version**: 0.1.0
+- **Description**: Graphify knowledge-graph tool: build a queryable graph of a codebase and query it instead of reading raw files
+- **Skills**: 2 skills covering the graphify CLI (install, build, export, query) and using the graph to reduce agent token usage
+- **Created**: 2026-06-08


### PR DESCRIPTION
- Add `plugins/tools/graphify` plugin with two skills: `graphify` (CLI: install/build/export/query) and `graphify-agents` (query-the-graph-instead-of-reading-files pattern, agent-loop integration, MCP)
- Ship `templates/mise.toml` installing `graphifyy` via mise pipx backend (`[settings.pipx] uvx = true` + `uv`) with example tasks: build, update, query, explain, graphml, benchmark, verify
- Add `references/cli.md` captured verbatim from `graphify --help` (0.8.36)
- Register graphify in marketplace.json and all-skills meta-plugin; bump all-skills 0.4.21→0.4.22 and marketplace metadata 1.0.21→1.0.22
- Both skills score 12/12 on the quality scorecard; `mise run test` green; gitleaks clean