### PR TITLE
fix(claude-code): correct repo-root resolution in skill-update sources scripts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -53,7 +53,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills: plugin marketplace management and validation",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "category": "tools",
       "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark", "skill-update", "output-styles", "statusline", "workflows"]
     },

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/skill-update/scripts/sources-check.nu
+++ b/plugins/tools/claude-code/skills/skill-update/scripts/sources-check.nu
@@ -9,7 +9,7 @@
 
 # Resolve the repo root relative to this script's location
 def repo-root [] {
-    $env.FILE_PWD | path join ".." ".." ".." ".." ".." ".." ".." | path expand
+    $env.FILE_PWD | path join ".." ".." ".." ".." ".." ".." | path expand
 }
 
 # Load marketplace.json and return plugins list

--- a/plugins/tools/claude-code/skills/skill-update/scripts/sources-init.nu
+++ b/plugins/tools/claude-code/skills/skill-update/scripts/sources-init.nu
@@ -8,7 +8,7 @@
 
 # Resolve the repo root relative to this script's location
 def repo-root [] {
-    $env.FILE_PWD | path join ".." ".." ".." ".." ".." ".." ".." | path expand
+    $env.FILE_PWD | path join ".." ".." ".." ".." ".." ".." | path expand
 }
 
 # Load marketplace.json

--- a/plugins/tools/claude-code/skills/skill-update/scripts/sources-report.nu
+++ b/plugins/tools/claude-code/skills/skill-update/scripts/sources-report.nu
@@ -9,7 +9,7 @@
 
 # Resolve the repo root relative to this script's location
 def repo-root [] {
-    $env.FILE_PWD | path join ".." ".." ".." ".." ".." ".." ".." | path expand
+    $env.FILE_PWD | path join ".." ".." ".." ".." ".." ".." | path expand
 }
 
 # Load marketplace.json

--- a/plugins/tools/claude-code/skills/skill-update/scripts/sources-stale.nu
+++ b/plugins/tools/claude-code/skills/skill-update/scripts/sources-stale.nu
@@ -9,7 +9,7 @@
 
 # Resolve the repo root relative to this script's location
 def repo-root [] {
-    $env.FILE_PWD | path join ".." ".." ".." ".." ".." ".." ".." | path expand
+    $env.FILE_PWD | path join ".." ".." ".." ".." ".." ".." | path expand
 }
 
 # Load marketplace.json

--- a/plugins/tools/claude-code/skills/skill-update/scripts/sources-validate-urls.nu
+++ b/plugins/tools/claude-code/skills/skill-update/scripts/sources-validate-urls.nu
@@ -9,7 +9,7 @@
 
 # Resolve the repo root relative to this script's location
 def repo-root [] {
-    $env.FILE_PWD | path join ".." ".." ".." ".." ".." ".." ".." | path expand
+    $env.FILE_PWD | path join ".." ".." ".." ".." ".." ".." | path expand
 }
 
 # Load marketplace.json


### PR DESCRIPTION
- Fix off-by-one in repo-root path resolution: seven '..' joins from the scripts directory resolves to /Users/vinnie/github instead of the repo root /Users/vinnie/github/claude-skills; correct count is six
- Apply fix consistently across all five scripts in plugins/tools/claude-code/skills/skill-update/scripts/: sources-validate-urls.nu, sources-check.nu, sources-report.nu, sources-stale.nu, sources-init.nu
- Bump claude-code plugin version 0.2.6 → 0.2.7 in plugin.json and marketplace.json