### PR TITLE
docs(awman): update skill to 0.10.0 overlay semantics

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -33,7 +33,7 @@
       "source": "./plugins/tools/awman",
       "strict": true,
       "description": "awman: parallel AI code agent sessions with container isolation, worktrees, and a REST API",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "category": "tools",
       "keywords": ["awman", "agents", "workflows", "tmux", "claude-code", "container"],
       "license": "MIT"

--- a/plugins/tools/awman/.claude-plugin/plugin.json
+++ b/plugins/tools/awman/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "awman",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "awman: parallel AI code agent sessions with container isolation, worktrees, and a REST API",
   "author": { "name": "vinnie357" },
   "repository": "https://github.com/vinnie357/claude-skills",

--- a/plugins/tools/awman/skills/awman/SKILL.md
+++ b/plugins/tools/awman/skills/awman/SKILL.md
@@ -114,7 +114,9 @@ See `templates/0.10.0/commands.md` for the full v0.10.0 command surface with fla
 
 ## Agents
 
-Supported agents: `claude`, `codex`, `opencode`, `maki`, `gemini`, `antigravity`, `copilot`, `crush`, `cline`.
+Supported agents: `claude`, `codex`, `opencode`, `maki`, `antigravity`, `copilot`, `crush`, `cline`.
+
+> **`gemini` is deprecated** by Google upstream. Migrate to `antigravity` (`awman chat --agent antigravity` or `awman config set agent antigravity`). The `gemini` agent name remains accepted but logs a deprecation warning and has degraded system-prompt-injection support.
 
 Each agent has a Dockerfile in `.awman/Dockerfile.<agent>` (seeded from upstream templates). Customize the Dockerfile to add tools or environment configuration for that agent. The project base image path is configurable via the per-repo `dockerfile` config key (default `Dockerfile.dev`) as of 0.10.0.
 
@@ -149,6 +151,31 @@ See `references/config.md` for the full per-key schema (type, default, scope, me
 
 Overlay specs grant agent containers access to host resources: `dir(HOST:CONTAINER[:ro|rw])`, `ssh()`, `env(VAR)`, `skill(*)`/`skill(NAME)`, and — new in 0.10.0 — `context(global|repo|workflow[:ro])`. Context overlays combine a persistent host directory (`~/.awman/context/...`) with automatic system-prompt injection, giving agents a durable shared workspace across sessions; they default to `rw` so agents accumulate knowledge — pass `:ro` to lock them. On host-path conflicts, `:ro` always overrides `:rw`. See `references/config.md` for the full overlay grammar.
 
+### env passthrough example
+
+To make an agent use a local provider or custom endpoint, forward the relevant vars via `env()` overlays:
+
+```json
+{
+  "overlays": [
+    "env(ANTHROPIC_BASE_URL)",
+    "env(ANTHROPIC_API_KEY)"
+  ]
+}
+```
+
+Or one-off via CLI flag (repeatable, or comma-separated in a single flag):
+
+```sh
+awman chat --overlay "env(ANTHROPIC_BASE_URL)" --overlay "env(ANTHROPIC_API_KEY)"
+# or
+awman chat --overlay "env(ANTHROPIC_BASE_URL),env(ANTHROPIC_API_KEY)"
+```
+
+If `ANTHROPIC_BASE_URL` is not set on the host, awman silently omits it — not an error.
+
+> **`envPassthrough` is removed in 0.10.0.** The old `envPassthrough` array config key no longer works; `awman config get envPassthrough` returns a removal notice. Express env forwarding as `env()` overlay entries in the `overlays` array (config file, `AWMAN_OVERLAYS`, or `--overlay` flag) instead. See `references/config.md` for the migration table.
+
 ## API Mode
 
 `awman api start` runs a REST server on port 9876 (configurable via `--port`). It serves **HTTPS with a self-signed certificate by default** — pass `--dangerously-skip-tls` for plain HTTP in trusted local setups. It accepts bearer-token auth. Sessions are restricted to directories in `api.workDirs` (global config) or passed via `--workdirs`.
@@ -179,6 +206,8 @@ See `references/workflows.md` for grammar in both formats and worked examples.
 - **`docker-sbx-experimental` skips all overlays.** `dir()`, skills, and context mounts are not honored; networking is proxy-only; sandboxes persist between sessions and lose port mappings on stop.
 - **`--issue` and `--work-item` are mutually exclusive.** Bare `--issue <N>` requires a GitHub `origin` remote — use `owner/repo#N` or a URL otherwise.
 - **Context overlays default to `rw`.** Use `context(SCOPE:ro)` to stop agents from modifying accumulated knowledge.
+- **`envPassthrough` is removed.** The old config key returns a removal notice. Use `env()` overlay entries in the `overlays` array instead.
+- **`gemini` is deprecated.** Use `antigravity` as the replacement (`awman config set agent antigravity`).
 - **Frequent release cadence.** Re-run `awman --version` when output looks unexpected. Pin in mise to control when you upgrade.
 - **Lowercase keys only in workflow files.** Uppercase variants are parse errors.
 

--- a/plugins/tools/awman/skills/awman/references/config.md
+++ b/plugins/tools/awman/skills/awman/references/config.md
@@ -90,6 +90,14 @@ Per-repo overrides global on scalar conflicts; `overlays` merges additively.
 
 ## Overlays
 
+> **`envPassthrough` removed in 0.10.0.** The config key `envPassthrough` is gone; querying it via `awman config get envPassthrough` returns a removal notice. Express env forwarding as `env(VAR)` entries in the `overlays` array.
+>
+> **Migration:** replace `"envPassthrough": ["MY_VAR", "OTHER_VAR"]` in your config with:
+> ```json
+> "overlays": ["env(MY_VAR)", "env(OTHER_VAR)"]
+> ```
+> Or use the CLI flag per invocation: `--overlay "env(MY_VAR)"`. The `env()` overlay is silently omitted if the named variable is not set on the host.
+
 Overlays grant agent containers access to host resources. Each entry in the `overlays` array is a spec string:
 
 | Spec | Effect |
@@ -160,9 +168,15 @@ awman reads several `AWMAN_*` environment variables (override config at runtime)
     "workDirs": ["/home/user/my-project"],
     "port": 9876
   },
-  "overlays": ["env(ANTHROPIC_API_KEY)", "context(global)"]
+  "overlays": [
+    "env(ANTHROPIC_API_KEY)",
+    "env(ANTHROPIC_BASE_URL)",
+    "context(global)"
+  ]
 }
 ```
+
+`env(ANTHROPIC_BASE_URL)` forwards a custom API endpoint (e.g. a local provider) into every agent container. If the variable is not set on the host, awman silently omits it — no error. Replace the old `envPassthrough` array with individual `env()` entries like this.
 
 ## Example per-repo config
 
@@ -186,6 +200,7 @@ awman config set agent codex                                  # per-repo default
 awman config set --global runtime apple-containers            # Apple Containers (macOS 26+)
 awman config set --global runtime docker-sbx-experimental     # Docker Sandboxes microVMs
 awman config set --global api.workDirs "/home/user/my-project"
+awman config set overlays "env(ANTHROPIC_BASE_URL)"           # add one overlay (per-repo)
 awman config show                                             # verify merged effective config
 ```
 

--- a/plugins/tools/awman/skills/sources.md
+++ b/plugins/tools/awman/skills/sources.md
@@ -6,6 +6,11 @@ awman was previously named **amux** (repo `prettysmartdev/amux`). The skill was 
 
 ## Release History
 
+### skill update 0.2.1 → 0.2.2 (2026-06-12)
+- **Source verified**: `docs/08-overlays.md` (https://github.com/prettysmartdev/awman/blob/main/docs/08-overlays.md, accessed 2026-06-12) and `docs/03-agent-sessions.md` (accessed 2026-06-12)
+- **Changes**: Added `envPassthrough` removal notice + `env()` overlay migration example to SKILL.md and references/config.md. Added `gemini` deprecation note with `antigravity` migration guidance. Added env-passthrough worked example (ANTHROPIC_BASE_URL pattern) to SKILL.md Overlays section. Updated example global config in references/config.md to show env passthrough via `overlays` array. Added two items to Known Sharp Edges.
+- **Discrepancy noted**: Upstream `docs/08-overlays.md` "Removed forms" section says `envPassthrough` is "deprecated"; live awman 0.10.0 session returns a hard REMOVAL notice ("the 'envPassthrough' field was removed"). The skill documents the live behavior (removed) and notes the upstream wording discrepancy.
+
 ### v0.10.0 (2026-06-11, skill updated 2026-06-11)
 - **URL**: https://github.com/prettysmartdev/awman/releases/tag/v0.10.0
 - **Summary**: Additive release, no config migration required. New experimental `docker-sbx-experimental` runtime (microVM-per-session via Docker's `sbx` CLI; macOS arm64 / Windows x86_64; no overlay support, proxy-only networking, persistent sandboxes). New `--issue <ref>` GitHub integration on `new spec` / `exec workflow` / `exec prompt` (auth: gh CLI → GITHUB_TOKEN → unauthenticated). Workflow setup/teardown phases gained `poll_ci` steps and `on_failure` remediation blocks with retries. New `context()` overlays (global/repo/workflow scopes, durable on-disk workspace + system-prompt injection). Configurable base Dockerfile (`dockerfile` key, default `Dockerfile.dev`) and XDG base-dir support. Fix: Codex deprecated `--full-auto` flag in yolo mode. Docs tree renumbered: new `01-concepts.md`, `11-github-integration.md`, `12-runtimes.md`; workflows moved `04` → `05`; the standalone headless-mode page was removed.


### PR DESCRIPTION
- Replace envPassthrough guidance with 0.10.0 overlays array + env() overlay semantics
- Add env passthrough worked example (ANTHROPIC_BASE_URL pattern) to SKILL.md Overlays section
- Add envPassthrough removal notice with migration example to references/config.md
- Add gemini → antigravity deprecation note to agent list and Known Sharp Edges
- Update example global config in references/config.md to show env forwarding via overlays array
- Add skill update entry in sources.md with upstream doc access date and discrepancy note
- Bump plugin version 0.2.1 → 0.2.2 in plugin.json and marketplace.json

## Validation

`mise run ci` output tail:
```
[test:version-bumps]   ✓ awman: 0.2.1 → 0.2.2
[test:version-bumps] ✅ All modified plugins have version bumps
[test:plugins] ✅ plugin: awman
[test:plugins] ✨ All plugins are valid!
[test:skills-quality] Skill quality validation complete! Baselined failures remaining to burn down: 166
Finished in 5.04s
```