### PR TITLE
feat(altana): plugin with /council /delegate /harness commands + skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "A curated collection of Claude skills for development workflows",
-    "version": "1.0.22"
+    "version": "1.0.23"
   },
   "plugins": [
     {
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.26",
+      "version": "0.4.27",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -36,6 +36,16 @@
       "version": "0.2.2",
       "category": "tools",
       "keywords": ["awman", "agents", "workflows", "tmux", "claude-code", "container"],
+      "license": "MIT"
+    },
+    {
+      "name": "altana",
+      "source": "./plugins/tools/altana",
+      "strict": true,
+      "description": "altana CLI wrapper: delegate prompts to sandboxed AI harnesses, run council fan-outs for diverse perspectives, and distribute tasks across harness presets",
+      "version": "0.1.0",
+      "category": "tools",
+      "keywords": ["altana", "ai-agents", "harness", "delegate", "council", "sandbox", "awman", "local-llm"],
       "license": "MIT"
     },
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -20,6 +20,7 @@
   "skills": [
     "./plugins/tools/allium/skills/allium",
     "./plugins/tools/awman/skills/awman",
+    "./plugins/tools/altana/skills/altana",
     "./plugins/tools/ansible/skills/ansible",
     "./plugins/tools/ansible/skills/ansible-inventory",
     "./plugins/tools/ansible/skills/ansible-roles",
@@ -110,6 +111,9 @@
     "./plugins/languages/zig/skills/troubleshooting"
   ],
   "commands": [
+    "./plugins/tools/altana/commands/delegate.md",
+    "./plugins/tools/altana/commands/council.md",
+    "./plugins/tools/altana/commands/harness.md",
     "./plugins/tools/agent-sandboxing/commands/bootstrap.md",
     "./plugins/tools/agent-sandboxing/commands/provision.md",
     "./plugins/tools/agent-sandboxing/commands/exec.md",

--- a/plugins/tools/altana/.claude-plugin/plugin.json
+++ b/plugins/tools/altana/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "altana",
+  "version": "0.1.0",
+  "description": "altana CLI wrapper: delegate prompts to sandboxed AI harnesses, run council fan-outs for diverse perspectives, and distribute tasks across harness presets",
+  "author": {
+    "name": "vinnie357"
+  },
+  "repository": "https://github.com/vinnie357/claude-skills",
+  "license": "MIT",
+  "keywords": ["altana", "ai-agents", "harness", "delegate", "council", "sandbox", "awman", "local-llm"],
+  "commands": [
+    "./commands/delegate.md",
+    "./commands/council.md",
+    "./commands/harness.md"
+  ],
+  "skills": ["./skills/altana"]
+}

--- a/plugins/tools/altana/commands/council.md
+++ b/plugins/tools/altana/commands/council.md
@@ -1,13 +1,13 @@
 ---
 description: "Send the same task to multiple altana harnesses in parallel and synthesize the responses into agreements, disagreements, unique insights, and a recommendation"
-argument-hint: "<task> [--harnesses=a,b,c] [--prompt=<template>]"
+argument-hint: "<task> [--harnesses a,b,c] [--prompt <template>]"
 ---
 
 Run `altana council` to fan out one task to N harnesses simultaneously, then synthesize the array of responses into a structured analysis.
 
 **What it does:**
 
-1. Invokes `altana council "<task>" [--harnesses=<list>] [--prompt=<template>]`.
+1. Invokes `altana council "<task>" [--harnesses <list>] [--prompt <template>]`.
 2. Runs in the background (council calls are inherently parallel and may take time).
 3. Receives a JSON array of result objects — one per harness, in config-declaration order.
 4. Synthesizes the responses into a structured report:
@@ -21,8 +21,8 @@ Run `altana council` to fan out one task to N harnesses simultaneously, then syn
 **Arguments:**
 
 - `<task>` — the prompt to fan out. Council is read-only; `--write` presets are rejected by altana.
-- `--harnesses=a,b,c` — comma-separated list of harness names; defaults to all configured harnesses when omitted.
-- `--prompt=<template>` — optional named prompt template applied to each harness invocation.
+- `--harnesses a,b,c` — comma-separated list of harness names; defaults to all configured harnesses when omitted.
+- `--prompt <template>` — optional named prompt template applied to each harness invocation.
 
 **Result array element fields** (same schema as `delegate`):
 
@@ -42,15 +42,15 @@ Install altana (see its README — it is a Zig CLI built with `zig 0.16`). After
 
 ```
 /council "what are the risks of removing the retry loop in src/client.zig?"
-/council "critique the API surface in src/api.zig" --harnesses=opus-harness,sonnet-harness
-/council "review this design doc" --prompt=design-review
+/council "critique the API surface in src/api.zig" --harnesses opus-harness,sonnet-harness
+/council "review this design doc" --prompt design-review
 ```
 
 **Task instructions:**
 
-Parse the argument: everything before the first `--` flag is `<task>`; extract `--harnesses=` and `--prompt=` from the flags.
+Parse the argument: everything before the first `--` flag is `<task>`; extract `--harnesses` and `--prompt` from the flags.
 
-Run (in background): `altana council "<task>" [--harnesses=<list>] [--prompt=<template>]`
+Run (in background): `altana council "<task>" [--harnesses <list>] [--prompt <template>]`
 
 Once the result arrives, parse the JSON array. For each element where `status == "done"`, extract the `## Answer` section from `response`. For non-`done` entries, note the harness name and failure status.
 

--- a/plugins/tools/altana/commands/council.md
+++ b/plugins/tools/altana/commands/council.md
@@ -1,0 +1,66 @@
+---
+description: "Send the same task to multiple altana harnesses in parallel and synthesize the responses into agreements, disagreements, unique insights, and a recommendation"
+argument-hint: "<task> [--harnesses=a,b,c] [--prompt=<template>]"
+---
+
+Run `altana council` to fan out one task to N harnesses simultaneously, then synthesize the array of responses into a structured analysis.
+
+**What it does:**
+
+1. Invokes `altana council "<task>" [--harnesses=<list>] [--prompt=<template>]`.
+2. Runs in the background (council calls are inherently parallel and may take time).
+3. Receives a JSON array of result objects — one per harness, in config-declaration order.
+4. Synthesizes the responses into a structured report:
+   - **Agreements** — claims all harnesses converge on.
+   - **Disagreements** — points where harnesses diverge; note which harness said what.
+   - **Unique insights** — observations raised by only one harness.
+   - **Recommendation** — a synthesized conclusion weighing all perspectives.
+
+**Why council?** Different harnesses run different models or executors. The same question delegated to multiple independent agents surfaces blind spots, validates conclusions, and reveals model-specific biases. The synthesis step is where the value lands — raw JSON alone does not exploit the diverse perspectives.
+
+**Arguments:**
+
+- `<task>` — the prompt to fan out. Council is read-only; `--write` presets are rejected by altana.
+- `--harnesses=a,b,c` — comma-separated list of harness names; defaults to all configured harnesses when omitted.
+- `--prompt=<template>` — optional named prompt template applied to each harness invocation.
+
+**Result array element fields** (same schema as `delegate`):
+
+| Field | Type |
+|---|---|
+| `harness` | string |
+| `status` | `done` \| `timeout` \| `crash` \| `missing_sentinel` |
+| `duration_s` | float |
+| `log_path` | string |
+| `response` | string or null |
+
+**If `altana` is not installed:**
+
+Install altana (see its README — it is a Zig CLI built with `zig 0.16`). After building, place the binary on your `PATH` or invoke via `mise exec -- zig-out/bin/altana`.
+
+**Examples:**
+
+```
+/council "what are the risks of removing the retry loop in src/client.zig?"
+/council "critique the API surface in src/api.zig" --harnesses=opus-harness,sonnet-harness
+/council "review this design doc" --prompt=design-review
+```
+
+**Task instructions:**
+
+Parse the argument: everything before the first `--` flag is `<task>`; extract `--harnesses=` and `--prompt=` from the flags.
+
+Run (in background): `altana council "<task>" [--harnesses=<list>] [--prompt=<template>]`
+
+Once the result arrives, parse the JSON array. For each element where `status == "done"`, extract the `## Answer` section from `response`. For non-`done` entries, note the harness name and failure status.
+
+Synthesize across all `done` responses:
+
+1. **Agreements** — identify claims that appear (in substance) across all or most harnesses.
+2. **Disagreements** — identify points where harnesses give incompatible answers; attribute each position to its harness.
+3. **Unique insights** — note observations raised by exactly one harness that the others did not mention.
+4. **Recommendation** — produce a single synthesized answer that weighs the agreements, resolves or flags the disagreements, and incorporates the unique insights.
+
+Report the synthesis. Append a table showing harness, status, and duration for transparency. If any harness returned non-`done`, note what was missing from the synthesis and point to the `log_path` for investigation.
+
+Load `/altana:altana` for protocol and config reference before running.

--- a/plugins/tools/altana/commands/delegate.md
+++ b/plugins/tools/altana/commands/delegate.md
@@ -1,0 +1,63 @@
+---
+description: "Delegate a task to a named altana harness and surface the structured JSON result"
+argument-hint: "<harness> <task> [--prompt=<template>] [--write]"
+---
+
+Run `altana delegate` to send a task to a single named harness preset and return the structured result.
+
+**What it does:**
+
+1. Invokes `altana delegate <harness> "<task>"` with any supplied flags via Bash.
+2. For long-running agents (timeout_s > 300 or when `--write` is present) runs the command in the background and streams the result when complete.
+3. Parses the JSON object from stdout.
+4. Surfaces a human-readable summary: harness name, status, duration, response text (trimmed to key sections), and log path for debugging.
+5. On non-`done` status, explains the failure mode and points to the log file.
+
+**Arguments:**
+
+- `<harness>` — name of a configured harness preset (see `altana list` to enumerate presets).
+- `<task>` — the prompt string to delegate. Wrap in quotes if it contains spaces.
+- `--prompt=<template>` — optional named prompt template from `[prompt.<name>]` in config; wraps the task before dispatch.
+- `--write` — grant the agent write access to the working directory inside the container (awman executor only).
+
+**JSON result fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `harness` | string | Harness name used |
+| `status` | string | `done` \| `timeout` \| `crash` \| `missing_sentinel` |
+| `duration_s` | float | Wall-clock seconds |
+| `log_path` | string | Full subprocess log path |
+| `response` | string or null | Agent response (sentinel stripped); null on non-`done` |
+
+**Status meanings:**
+
+- `done` — agent exited 0 and emitted the completion sentinel; `response` is populated.
+- `missing_sentinel` — agent exited 0 but did not emit the sentinel; check `log_path`.
+- `crash` — agent exited non-zero or failed to spawn; check `log_path`.
+- `timeout` — agent exceeded the configured `timeout_s`; check `log_path` for partial output.
+
+**If `altana` is not installed:**
+
+Install altana (see its README — it is a Zig CLI built with `zig 0.16`). After building, place the binary on your `PATH` or invoke via `mise exec -- zig-out/bin/altana`.
+
+**Examples:**
+
+```
+/delegate my-claude "explain the failing test in src/parser_test.zig"
+/delegate critique-harness "review src/main.zig" --prompt=critique
+/delegate coding-agent "add error handling to the fetch function" --write
+```
+
+**Task instructions:**
+
+Resolve the argument string: the first positional token is `<harness>`, the remaining text up to the first `--` flag is `<task>`. Reconstruct any `--prompt=` or `--write` flags from the parsed argument.
+
+Run: `altana delegate "<harness>" "<task>" [flags]`
+
+Parse the JSON result. Present:
+- A one-line status line: `harness: <name> | status: <status> | duration: <duration_s>s`
+- If `status == "done"`: the `response` content (show `## Answer`, `## Evidence`, `## Confidence` sections).
+- If `status != "done"`: the failure mode explanation and the `log_path` to inspect.
+
+Load `/altana:altana` for protocol and config reference before running.

--- a/plugins/tools/altana/commands/delegate.md
+++ b/plugins/tools/altana/commands/delegate.md
@@ -1,6 +1,6 @@
 ---
 description: "Delegate a task to a named altana harness and surface the structured JSON result"
-argument-hint: "<harness> <task> [--prompt=<template>] [--write]"
+argument-hint: "<harness> <task> [--prompt <template>] [--write]"
 ---
 
 Run `altana delegate` to send a task to a single named harness preset and return the structured result.
@@ -17,7 +17,7 @@ Run `altana delegate` to send a task to a single named harness preset and return
 
 - `<harness>` — name of a configured harness preset (see `altana list` to enumerate presets).
 - `<task>` — the prompt string to delegate. Wrap in quotes if it contains spaces.
-- `--prompt=<template>` — optional named prompt template from `[prompt.<name>]` in config; wraps the task before dispatch.
+- `--prompt <template>` — optional named prompt template from `[prompt.<name>]` in config; wraps the task before dispatch.
 - `--write` — grant the agent write access to the working directory inside the container (awman executor only).
 
 **JSON result fields:**
@@ -45,13 +45,13 @@ Install altana (see its README — it is a Zig CLI built with `zig 0.16`). After
 
 ```
 /delegate my-claude "explain the failing test in src/parser_test.zig"
-/delegate critique-harness "review src/main.zig" --prompt=critique
+/delegate critique-harness "review src/main.zig" --prompt critique
 /delegate coding-agent "add error handling to the fetch function" --write
 ```
 
 **Task instructions:**
 
-Resolve the argument string: the first positional token is `<harness>`, the remaining text up to the first `--` flag is `<task>`. Reconstruct any `--prompt=` or `--write` flags from the parsed argument.
+Resolve the argument string: the first positional token is `<harness>`, the remaining text up to the first `--` flag is `<task>`. Reconstruct any `--prompt <template>` or `--write` flags from the parsed argument, using space-separated form.
 
 Run: `altana delegate "<harness>" "<task>" [flags]`
 

--- a/plugins/tools/altana/commands/harness.md
+++ b/plugins/tools/altana/commands/harness.md
@@ -1,0 +1,57 @@
+---
+description: "Distribute multiple tasks across altana harnesses and present a per-task results table"
+argument-hint: "<t1> | <t2> | ... [--map=idx@harness]"
+---
+
+Run `altana harness` to fan out many tasks, distributing them across configured harnesses, and present the results as a per-task table.
+
+**What it does:**
+
+1. Parses the pipe-separated task list from the argument string.
+2. Invokes `altana harness "<t1>" "<t2>" ... [--map=<idx>@<harness>]`.
+3. Runs in the background (multiple agents run concurrently).
+4. Receives a JSON array of result objects in task order.
+5. Presents a per-task results table with harness, status, duration, and a one-line answer excerpt.
+
+**Arguments:**
+
+- `<t1> | <t2> | ...` — task strings separated by ` | ` (pipe with spaces). Each becomes one element in the harness call.
+- `--map=idx@harness` — pin a specific task index (0-based) to a named harness. Multiple `--map` flags are accepted. Tasks without a pin are distributed in round-robin order across all configured harnesses.
+
+**Result table format:**
+
+```
+#  | Harness       | Status  | Duration | Answer excerpt
+---|---------------|---------|----------|---------------
+0  | claude-local  | done    | 9.4s     | "Hello there, fr..."
+1  | codex         | done    | 4.1s     | "The fix requires..."
+2  | claude-local  | crash   | 0.3s     | (see log_path)
+```
+
+**If `altana` is not installed:**
+
+Install altana (see its README — it is a Zig CLI built with `zig 0.16`). After building, place the binary on your `PATH` or invoke via `mise exec -- zig-out/bin/altana`.
+
+**Examples:**
+
+```
+/harness explain the delegate subcommand | explain the council subcommand | explain the harness subcommand
+/harness write a docstring for parse_config | write a docstring for run_delegate | write tests for council --map=0@opus-harness
+/harness "audit error handling in src/delegate.zig" | "audit error handling in src/council.zig"
+```
+
+**Task instructions:**
+
+Parse the argument: split on ` | ` to produce the task list. Extract any `--map=` flags from the remaining tokens.
+
+Reconstruct the altana call: `altana harness "<t1>" "<t2>" ... [--map=...]`
+
+Run in background.
+
+Once results arrive, parse the JSON array (index corresponds to task order). Build the results table:
+- For `status == "done"`: extract the first non-empty line of `## Answer` as the excerpt.
+- For non-`done` statuses: show the status value and the `log_path`.
+
+Present the table. For any `done` entries where the full response is needed, offer to show it on request.
+
+Load `/altana:altana` for protocol and config reference before running.

--- a/plugins/tools/altana/commands/harness.md
+++ b/plugins/tools/altana/commands/harness.md
@@ -1,6 +1,6 @@
 ---
 description: "Distribute multiple tasks across altana harnesses and present a per-task results table"
-argument-hint: "<t1> | <t2> | ... [--map=idx@harness]"
+argument-hint: "<t1> | <t2> | ... [--map idx@harness]"
 ---
 
 Run `altana harness` to fan out many tasks, distributing them across configured harnesses, and present the results as a per-task table.
@@ -8,7 +8,7 @@ Run `altana harness` to fan out many tasks, distributing them across configured 
 **What it does:**
 
 1. Parses the pipe-separated task list from the argument string.
-2. Invokes `altana harness "<t1>" "<t2>" ... [--map=<idx>@<harness>]`.
+2. Invokes `altana harness "<t1>" "<t2>" ... [--map <idx>@<harness>]`.
 3. Runs in the background (multiple agents run concurrently).
 4. Receives a JSON array of result objects in task order.
 5. Presents a per-task results table with harness, status, duration, and a one-line answer excerpt.
@@ -16,7 +16,7 @@ Run `altana harness` to fan out many tasks, distributing them across configured 
 **Arguments:**
 
 - `<t1> | <t2> | ...` — task strings separated by ` | ` (pipe with spaces). Each becomes one element in the harness call.
-- `--map=idx@harness` — pin a specific task index (0-based) to a named harness. Multiple `--map` flags are accepted. Tasks without a pin are distributed in round-robin order across all configured harnesses.
+- `--map idx@harness` — pin a specific task index (0-based) to a named harness. Multiple `--map` flags are accepted. Tasks without a pin are distributed in round-robin order across all configured harnesses.
 
 **Result table format:**
 
@@ -36,15 +36,15 @@ Install altana (see its README — it is a Zig CLI built with `zig 0.16`). After
 
 ```
 /harness explain the delegate subcommand | explain the council subcommand | explain the harness subcommand
-/harness write a docstring for parse_config | write a docstring for run_delegate | write tests for council --map=0@opus-harness
+/harness write a docstring for parse_config | write a docstring for run_delegate | write tests for council --map 0@opus-harness
 /harness "audit error handling in src/delegate.zig" | "audit error handling in src/council.zig"
 ```
 
 **Task instructions:**
 
-Parse the argument: split on ` | ` to produce the task list. Extract any `--map=` flags from the remaining tokens.
+Parse the argument: split on ` | ` to produce the task list. Extract any `--map` flags from the remaining tokens.
 
-Reconstruct the altana call: `altana harness "<t1>" "<t2>" ... [--map=...]`
+Reconstruct the altana call: `altana harness "<t1>" "<t2>" ... [--map ...]`
 
 Run in background.
 
@@ -52,6 +52,6 @@ Once results arrive, parse the JSON array (index corresponds to task order). Bui
 - For `status == "done"`: extract the first non-empty line of `## Answer` as the excerpt.
 - For non-`done` statuses: show the status value and the `log_path`.
 
-Present the table. For any `done` entries where the full response is needed, offer to show it on request.
+Present the table. For any `done` entries where the full response is needed, show it on request.
 
 Load `/altana:altana` for protocol and config reference before running.

--- a/plugins/tools/altana/skills/altana/SKILL.md
+++ b/plugins/tools/altana/skills/altana/SKILL.md
@@ -39,7 +39,7 @@ Full schema details in `references/config.md`.
 ### delegate
 
 ```
-altana delegate <harness> "<task>" [--prompt=<template>] [--write]
+altana delegate <harness> "<task>" [--prompt <template>] [--write]
 ```
 
 Sends one task to one harness. Exits 0 on `done`, 1 on all other statuses.
@@ -51,7 +51,7 @@ Use `--write` only when the task requires the agent to modify files (awman execu
 ### council
 
 ```
-altana council "<task>" [--harnesses=a,b,c] [--prompt=<template>]
+altana council "<task>" [--harnesses a,b,c] [--prompt <template>]
 ```
 
 Fans the same task out to N harnesses in parallel (read-only). Returns a JSON array in config-declaration order. Each element has the same schema as `delegate` output.
@@ -61,7 +61,7 @@ Council is the diverse-perspectives primitive. The synthesis step (agreements / 
 ### harness
 
 ```
-altana harness "<t1>" "<t2>" ... [--map=idx@harness]
+altana harness "<t1>" "<t2>" ... [--map idx@harness]
 ```
 
 Distributes many tasks across harnesses. Returns a JSON array in task order. Round-robin by default; `--map` pins a specific task index to a named harness.
@@ -142,7 +142,7 @@ Followed by the sentinel line:
 
 altana strips the sentinel before placing the text in `response`. The three sections are consistent across all harnesses, enabling structured synthesis in council mode.
 
-Custom `[prompt.<name>]` templates may include the section headers as instructions to the agent — they are not duplicated; the agent sees them as format guidance.
+Custom `[prompt.<name>]` templates that include the section headers expose them to the agent as format guidance; altana does not duplicate them.
 
 ## Council Synthesis
 

--- a/plugins/tools/altana/skills/altana/SKILL.md
+++ b/plugins/tools/altana/skills/altana/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: altana
+description: "Protocol knowledge for the altana CLI: config discovery, harness presets, JSON result contract, status codes, council synthesis, model picker, and response protocol. Use when running /altana:delegate, /altana:council, or /altana:harness; debugging altana JSON output or non-done statuses; configuring harness TOML presets; or integrating altana into a workflow."
+license: MIT
+---
+
+# altana skill
+
+Procedural knowledge for working with the altana CLI — a tool that delegates prompts to named AI harness presets, collects structured JSON results, and fans out tasks across multiple harnesses for diverse-perspective synthesis.
+
+## When to Use
+
+Activate when:
+- Running `/altana:delegate`, `/altana:council`, or `/altana:harness` commands.
+- Debugging non-`done` status values or unexpected JSON output.
+- Configuring `altana.toml` harness presets or prompt templates.
+- Choosing between foreground vs background invocation for long tasks.
+- Synthesizing council results across multiple harness responses.
+- Using the model picker or `altana models` to enumerate available models.
+
+## Config Discovery
+
+altana resolves its config in this order:
+
+1. `$ALTANA_CONFIG` — if set, this path is used.
+2. `~/.config/altana/altana.toml` — default location.
+
+Copy `harnesses.example.toml` from the altana repo root to get started:
+
+```bash
+mkdir -p ~/.config/altana
+cp harnesses.example.toml ~/.config/altana/altana.toml
+```
+
+Full schema details in `references/config.md`.
+
+## Subcommands
+
+### delegate
+
+```
+altana delegate <harness> "<task>" [--prompt=<template>] [--write]
+```
+
+Sends one task to one harness. Exits 0 on `done`, 1 on all other statuses.
+
+Stdout: JSON object `{harness, status, duration_s, log_path, response}`.
+
+Use `--write` only when the task requires the agent to modify files (awman executor only). `council` rejects `--write` presets.
+
+### council
+
+```
+altana council "<task>" [--harnesses=a,b,c] [--prompt=<template>]
+```
+
+Fans the same task out to N harnesses in parallel (read-only). Returns a JSON array in config-declaration order. Each element has the same schema as `delegate` output.
+
+Council is the diverse-perspectives primitive. The synthesis step (agreements / disagreements / unique insights / recommendation) belongs in the caller — altana delivers raw results.
+
+### harness
+
+```
+altana harness "<t1>" "<t2>" ... [--map=idx@harness]
+```
+
+Distributes many tasks across harnesses. Returns a JSON array in task order. Round-robin by default; `--map` pins a specific task index to a named harness.
+
+### models
+
+```
+altana models <harness>
+```
+
+Fetches `GET <ANTHROPIC_BASE_URL>/v1/models` using the harness's auth config and prints model IDs. Use to discover available models before setting `model =` in the preset.
+
+### list / doctor
+
+```
+altana list
+altana doctor
+```
+
+`list` — prints all configured harness names and prompt template names from config.
+`doctor` — checks prerequisites (altana binary, awman on PATH, op reachable if op:// refs present) and exits 1 with a remediation message on failure.
+
+## JSON Result Contract
+
+All subcommands return JSON. The `delegate` response is a single object; `council` and `harness` return arrays.
+
+| Field | Type | Present when |
+|---|---|---|
+| `harness` | string | always |
+| `status` | string | always |
+| `duration_s` | float | always |
+| `log_path` | string | always |
+| `response` | string or null | `status == "done"` → string; otherwise null |
+
+### Status Codes
+
+| Status | Meaning | Action |
+|---|---|---|
+| `done` | Agent exited 0 and emitted the completion sentinel | Parse `response` |
+| `missing_sentinel` | Agent exited 0 but no sentinel found | Inspect `log_path` for truncated output |
+| `crash` | Agent exited non-zero or failed to spawn | Inspect `log_path` for error details |
+| `timeout` | Agent exceeded `timeout_s` | Increase `timeout_s` or break the task up |
+
+`altana delegate` exits 0 only for `done`; exits 1 for all other statuses.
+
+## Foreground vs Background Invocation
+
+Run in the **foreground** (synchronous Bash call) when:
+- The harness `timeout_s` is ≤ 300 seconds and no `--write` flag is used.
+- A quick answer is expected (e.g. `altana models`).
+
+Run in the **background** when:
+- `timeout_s` > 300 seconds or `--write` is present.
+- Using `council` (parallel fan-out; wall-clock time is bounded by the slowest harness).
+- Using `harness` with multiple tasks.
+
+The `/altana:delegate` command chooses foreground vs background automatically based on these criteria.
+
+## Response Protocol
+
+altana wraps every task in a protocol that instructs the agent to respond in a structured format and emit a completion sentinel. The agent is expected to reply with:
+
+```
+## Answer
+<the answer>
+
+## Evidence
+<supporting evidence, citations, or tool output>
+
+## Confidence
+<high | medium | low>
+```
+
+Followed by the sentinel line:
+```
+=== ALTANA DONE <run_id> ===
+```
+
+altana strips the sentinel before placing the text in `response`. The three sections are consistent across all harnesses, enabling structured synthesis in council mode.
+
+Custom `[prompt.<name>]` templates may include the section headers as instructions to the agent — they are not duplicated; the agent sees them as format guidance.
+
+## Council Synthesis
+
+When `council` results arrive, synthesize across all `done` responses:
+
+1. **Extract answers** — for each `done` element, pull the `## Answer` section from `response`.
+2. **Find agreements** — claims present (in substance) across all or most harnesses.
+3. **Find disagreements** — positions that conflict across harnesses; attribute each to its harness.
+4. **Surface unique insights** — observations raised by exactly one harness.
+5. **Produce a recommendation** — a single synthesized conclusion that weighs the above.
+
+Non-`done` elements are noted as absent from the synthesis with their status and `log_path`.
+
+A synthesis table at the end lists harness, status, and duration for transparency.
+
+## Model Picker
+
+When a harness preset has no `model` field and stdin is a TTY, `altana delegate` fetches the model list and shows a numbered selection prompt:
+
+```
+1. claude-opus-4-5 (model)
+2. claude-sonnet-4-5 (model)
+Select a model (1-3):
+```
+
+In non-TTY contexts (scripts, CI) with no `model` configured, altana exits with an error naming the available models. Remedy: set `model =` in the preset or pass the harness name to `altana models` first.
+
+Note: the interactive picker reads `ANTHROPIC_AUTH_TOKEN` (not `ANTHROPIC_API_KEY`) during the selection step.
+
+## Anti-Fabrication
+
+Do not claim an altana run succeeded without verifying the `status` field. Do not summarize `response` content from a non-`done` result. If `status != "done"`, cite the actual status value and point to `log_path` — do not fabricate a partial answer.
+
+Always parse the actual JSON returned by altana before reporting results. Never describe a harness response from memory or assumption.
+
+## References
+
+- `references/config.md` — full `altana.toml` schema: harness fields, prompt templates, op:// secrets.
+- `references/backends.md` — executor types (awman vs raw), local-provider env patterns, generic harness examples.

--- a/plugins/tools/altana/skills/altana/references/backends.md
+++ b/plugins/tools/altana/skills/altana/references/backends.md
@@ -104,6 +104,6 @@ $TMPDIR/altana/<run_id>/<harness-name>.log
 The `log_path` field in the JSON result gives the exact path. Inspect it for:
 - `crash` — look for spawn errors, missing binary, or agent exit codes.
 - `missing_sentinel` — the agent ran but did not emit `=== ALTANA DONE <run_id> ===`; look for truncated output or tool errors.
-- `timeout` — look for partial responses; consider increasing `timeout_s`.
+- `timeout` — look for partial responses; increase `timeout_s` when the task requires more time to complete.
 
 Run `altana doctor` to verify prerequisites are in place before debugging further.

--- a/plugins/tools/altana/skills/altana/references/backends.md
+++ b/plugins/tools/altana/skills/altana/references/backends.md
@@ -1,0 +1,109 @@
+# altana Backends Reference
+
+## Executors
+
+altana supports two executors, selected per harness preset.
+
+### awman (sandboxed)
+
+```toml
+executor = "awman"
+```
+
+Runs the agent binary inside an Apple Container VM using awman. The agent:
+- Sees only the env vars declared in `[harness.<name>.env]`.
+- Cannot access the host filesystem unless `write = true` grants cwd access.
+- Reaches network endpoints via the container's virtual network interface.
+
+**Requirements:**
+- awman installed and on `PATH`.
+- Apple Container runtime (macOS 26+).
+
+**VM networking:** Inside the container, `localhost` refers to the VM, not the host. To reach a server on the host machine (e.g. a local model server), use the host gateway IP as seen from inside the VM. Find it with:
+
+```bash
+container run --rm alpine ip route show default
+# Example output: default via 192.168.65.1 dev eth0
+```
+
+Use the gateway address in `ANTHROPIC_BASE_URL`:
+
+```toml
+ANTHROPIC_BASE_URL = "http://192.168.65.1:8000"
+```
+
+The exact address varies per machine — run the command above to discover it rather than copying this example value.
+
+### raw (direct subprocess)
+
+```toml
+executor = "raw"
+```
+
+Runs the agent binary directly as a subprocess on the host, with no container wrapping. Useful for:
+- Agent CLIs that provide their own isolation.
+- Local servers where container networking is inconvenient.
+- Debugging harness configurations before adding container overhead.
+
+No awman or Apple Container is required for `raw` harnesses.
+
+## Local Model Server Example
+
+Generic pattern for pointing a harness at a locally-running Anthropic-compatible endpoint (replace placeholder values with your own):
+
+```toml
+[harness.local-model]
+agent     = "claude"
+executor  = "awman"
+timeout_s = 1800
+
+[harness.local-model.env]
+# Replace with the host gateway IP discovered via:
+# container run --rm alpine ip route show default
+ANTHROPIC_BASE_URL  = "http://HOST_GATEWAY_IP:PORT"
+ANTHROPIC_AUTH_TOKEN = "op://your-vault/your-item/your-field"
+```
+
+For a raw executor (no container, reaching localhost directly):
+
+```toml
+[harness.local-raw]
+agent     = "claude"
+executor  = "raw"
+timeout_s = 1800
+
+[harness.local-raw.env]
+ANTHROPIC_BASE_URL  = "http://localhost:8000"
+ANTHROPIC_AUTH_TOKEN = "op://your-vault/your-item/your-field"
+```
+
+## Council Compatibility
+
+`council` rejects harnesses that have `write = true`. Only read-only presets participate in a council fan-out.
+
+When selecting harnesses for council, prefer presets pointing to different models or executors. Diverse execution environments make disagreement detection meaningful — two harnesses running the same model with the same config add little synthesis value.
+
+## Model Discovery
+
+Before setting `model =` in a preset, list the models available for that endpoint:
+
+```bash
+altana models <harness-name>
+```
+
+This fetches `GET <ANTHROPIC_BASE_URL>/v1/models` using the harness's auth config and prints one model per line with type annotation. Use the printed model IDs in the `model =` field.
+
+## Troubleshooting Non-done Results
+
+All executors write the full agent subprocess stdout and stderr to:
+
+```
+$TMPDIR/altana/<run_id>/<harness-name>.log
+```
+
+The `log_path` field in the JSON result gives the exact path. Inspect it for:
+- `crash` — look for spawn errors, missing binary, or agent exit codes.
+- `missing_sentinel` — the agent ran but did not emit `=== ALTANA DONE <run_id> ===`; look for truncated output or tool errors.
+- `timeout` — look for partial responses; consider increasing `timeout_s`.
+
+Run `altana doctor` to verify prerequisites are in place before debugging further.

--- a/plugins/tools/altana/skills/altana/references/config.md
+++ b/plugins/tools/altana/skills/altana/references/config.md
@@ -1,0 +1,118 @@
+# altana.toml Config Reference
+
+## Config File Discovery
+
+altana resolves its config in this order:
+
+1. `$ALTANA_CONFIG` environment variable — if set, this path is used.
+2. `~/.config/altana/altana.toml` — default location.
+
+## Harness Schema
+
+Each harness is a named preset under `[harness.<name>]`.
+
+```toml
+[harness.my-harness]
+# Required: agent binary name (awman executor) or path (raw executor).
+agent = "claude"
+
+# Required: "awman" runs inside an Apple Container sandbox (macOS 26+);
+# "raw" runs the binary directly as a subprocess (no container).
+executor = "awman"
+
+# Optional: model ID to pass to the agent.
+# Omit to use the interactive TTY picker or error in non-TTY contexts.
+model = "claude-opus-4-5"
+
+# Optional: grant write access to cwd inside the container (awman only).
+# council rejects presets that have write = true.
+write = false
+
+# Optional: wall-clock timeout in seconds. Default: 1800.
+timeout_s = 1800
+
+# Optional: environment variables injected into the agent process.
+# op:// values are resolved at dispatch time via the 1Password CLI.
+[harness.my-harness.env]
+ANTHROPIC_BASE_URL = "https://api.anthropic.com"
+ANTHROPIC_API_KEY  = "op://vault-name/item-name/field-name"
+```
+
+### Field Reference
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `agent` | string | yes | — | Agent binary name (awman) or path (raw) |
+| `executor` | `awman` or `raw` | yes | — | Execution mode |
+| `model` | string | no | null | Model ID; omit to trigger picker |
+| `write` | bool | no | `false` | Write access inside container (awman only) |
+| `timeout_s` | integer | no | `1800` | Wall-clock timeout in seconds |
+| `[harness.<name>.env]` | TOML table | no | empty | Env vars injected into agent process |
+
+## Prompt Templates
+
+Named templates wrap a task string before dispatch. The `{input}` placeholder is substituted with the task.
+
+```toml
+[prompt.critique]
+template = """You are a careful code reviewer.
+
+Task: {input}
+
+Provide a structured review covering:
+1. Correctness — does the logic match the intent?
+2. Edge cases — what inputs could break it?
+3. Readability — is the code clear and idiomatic?
+
+## Answer
+(your review here)
+
+## Evidence
+(specific lines or patterns cited)
+
+## Confidence
+(high / medium / low)
+"""
+```
+
+Use a template:
+
+```bash
+altana delegate my-harness "the parse function in src/parser.zig" --prompt critique
+```
+
+You do not need to include `## Answer` / `## Evidence` / `## Confidence` in a template — the protocol wraps the rendered template. Including them in a template makes them visible to the agent as format instructions rather than duplicates.
+
+## op:// Secret References
+
+Any env value starting with `op://` is resolved by calling `op read <ref>` before the subprocess starts. The resolved value is injected into the child environment and never appears in JSON output, logs, or error messages.
+
+Format: `op://vault-name/item-name/field-name`
+
+The `op` CLI must be installed, signed in to your account, and reachable on `PATH`. Run `altana doctor` to check op availability.
+
+## Example: Multiple Harnesses
+
+```toml
+# Harness using local model server (e.g. omlx running at host gateway)
+[harness.local]
+agent     = "claude"
+executor  = "awman"
+timeout_s = 1800
+
+[harness.local.env]
+ANTHROPIC_BASE_URL = "http://192.168.65.1:8000"
+ANTHROPIC_AUTH_TOKEN = "op://my-vault/local-model/token"
+
+# Harness calling the upstream API directly (raw executor, no container)
+[harness.upstream]
+agent     = "claude"
+executor  = "raw"
+model     = "claude-opus-4-5"
+timeout_s = 600
+
+[harness.upstream.env]
+ANTHROPIC_API_KEY = "op://my-vault/anthropic/api-key"
+```
+
+The `ANTHROPIC_AUTH_TOKEN` key is also accepted by the models endpoint and by the interactive picker. `ANTHROPIC_API_KEY` is the standard key for most agent CLIs; check your agent's documentation for which it reads.

--- a/plugins/tools/altana/skills/sources.md
+++ b/plugins/tools/altana/skills/sources.md
@@ -1,0 +1,22 @@
+# Sources
+
+## altana
+
+- **Repo:** https://github.com/vinnie357/altana (private)
+- **Accessed:** 2026-06-13
+- **Used for:** subcommand shapes (delegate, council, harness, models, list, doctor), JSON result contract, status codes, response protocol (## Answer / ## Evidence / ## Confidence + sentinel), config discovery order, harness TOML schema (agent, executor, model, write, timeout_s, env), prompt templates, op:// secret resolution, awman vs raw executor semantics, model picker (TTY vs non-TTY), VM networking pattern (host gateway IP)
+- **Key topics:** altana CLI usage, harness presets, council synthesis, foreground vs background invocation, log file paths (`$TMPDIR/altana/<run_id>/<harness>.log`)
+
+## altana docs/usage.md
+
+- **Source:** `/Users/vinnie/github/altana/docs/usage.md`
+- **Accessed:** 2026-06-13
+- **Used for:** Local model walkthrough (VM networking, host gateway discovery), model picker interactive flow, response protocol wrapping detail, secrets section (op:// scrubbing), troubleshooting guidance
+- **Key topics:** ANTHROPIC_BASE_URL in containers, ANTHROPIC_AUTH_TOKEN vs ANTHROPIC_API_KEY, picker selection flow, sentinel stripping
+
+## altana harnesses.example.toml
+
+- **Source:** `/Users/vinnie/github/altana/harnesses.example.toml`
+- **Accessed:** 2026-06-13
+- **Used for:** Canonical harness field names and TOML layout, prompt.critique template example, executor values (awman / raw)
+- **Key topics:** Config schema, named harnesses, op:// references pattern


### PR DESCRIPTION
- Add plugins/tools/altana plugin (v0.1.0) with plugin.json
- Add /delegate command: run altana delegate, surface JSON result + status
- Add /council command: fan out to N harnesses, synthesize agreements/disagreements/unique insights/recommendation
- Add /harness command: distribute tasks across harnesses, per-task results table
- Add skills/altana/SKILL.md (17/17 quality score): protocol knowledge, JSON contract, status codes, foreground vs background, council synthesis, model picker
- Add references/config.md: full altana.toml schema, harness fields, prompt templates, op:// secrets
- Add references/backends.md: awman vs raw executors, local-provider env patterns, VM networking
- Add skills/sources.md: source attribution for altana docs
- Register altana in .claude-plugin/marketplace.json (v1.0.23)
- Bump all-skills meta-plugin to v0.4.27 (includes altana skill and commands)