### PR TITLE
feat(git): add dual-gate CI policy for squash merges

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.28",
+      "version": "0.4.29",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -63,7 +63,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills: plugin marketplace management and validation",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "category": "tools",
       "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark", "skill-update", "output-styles", "statusline", "workflows"]
     },
@@ -72,7 +72,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "category": "development",
       "keywords": ["git", "documentation", "code-review", "tools", "beads", "bees", "container", "tdd", "agent-loop", "forge"]
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/agent-loop/SKILL.md
+++ b/plugins/core/skills/agent-loop/SKILL.md
@@ -188,7 +188,7 @@ Glob patterns like `/core:*` do not expand in Agent prompts. List skill names ex
 - **Commits**: Conventional commits, no attribution, no Co-Authored-By
 - **PRs**: Minimal format (title + bullet list), no templates, no attribution
 - **TDD**: Code without tests is not complete
-- **CI**: `mise run ci` must pass before any PR or merge
+- **CI (dual gate)**: Gate 1 — local `mise run ci` green before every commit; Gate 2 — local + remote `gh pr checks` green before any squash merge (see `/core:git` Dual-Gate CI Policy)
 - **Branches**: One feature branch per epic (`feature/<epic-slug>`)
 - **Merge**: Squash merge only, user approves
 
@@ -199,11 +199,11 @@ Every agent worker (Tier 3) follows these steps:
 1. Create feature branch
 2. Write tests first (TDD)
 3. Implement
-4. Run local CI (`mise run ci`) — fix until 0 failures
+4. **Gate 1** — Run local CI (`mise run ci`) — fix until 0 failures
 5. Commit without attribution
 6. Run gitleaks scan on committed changes — fix if secrets detected
 7. Push, create PR
-8. Watch remote CI (`gh pr checks --watch`) — fix and push until passing
+8. **Gate 2** — Watch remote CI (`gh pr checks --watch`) — fix and push until local + remote are green (merge-ready)
 9. Close bees issue, notify leader of PR status and URL
 
 Agents never merge — they report the PR URL to the team leader.

--- a/plugins/core/skills/git/SKILL.md
+++ b/plugins/core/skills/git/SKILL.md
@@ -71,27 +71,41 @@ gh pr create --title "feat(auth): add JWT authentication" --body "- Add JWT gene
 
 ## PR Workflow
 
-1. **Local CI**: `mise run ci` — fix until 0 failures
+1. **Gate 1 — Local CI**: `mise run ci` — fix until 0 failures
 2. **Commit**: Conventional commit, no attribution
 3. **Gitleaks**: Scan committed changes for secrets (`/core:security`)
 4. **Push**: `git push -u origin <branch>`
 5. **Create PR**: `gh pr create` with minimal format (title + bullets)
-6. **Watch CI**: `gh pr checks --watch` (wait for CI to complete)
+6. **Gate 2 — Watch remote CI**: `gh pr checks --watch` (wait for CI to complete)
 7. **After CI passes** (if using bees):
    - `bees close <task-id>`
    - `git add .bees/ && git commit -m "chore(bees): close <task-id>"`
    - `git push`
-8. **Notify**: "CI passed, PR ready for merge review"
+8. **Notify** (Gate 2 satisfied — local + remote green): "CI passed, PR ready for merge review"
 9. **Cleanup** (after user merges):
    - `git checkout main && git pull`
    - `git branch -d <branch>`
 10. **Continue**: `bees ready` for next task
 
+## Dual-Gate CI Policy
+
+Two gates protect main. Neither is optional.
+
+**Gate 1 — Local (before every commit).** `mise run ci` runs green — tests, lint, and format, 0 failures — before each `git commit`. A red local CI means the commit is broken: fix it locally, never push past it. Scan staged changes with gitleaks before push (`/core:security`).
+
+**Gate 2 — Remote (before every squash merge).** Squash-merge a PR only when **both** conditions hold:
+
+1. Local `mise run ci` is green on the branch HEAD being merged, **and**
+2. `gh pr checks` reports every remote check passing.
+
+No `gh pr merge --squash` while either gate is red. The user approves the merge; agents never merge.
+
 ## Merge Strategy
 
-Always squash merge PRs:
+Squash merge only, and only after both Dual-Gate CI gates are green:
 
 ```bash
+gh pr checks <number>          # Gate 2: confirm remote green (local CI already green)
 gh pr merge <number> --squash
 ```
 

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/templates/CLAUDE.md
+++ b/plugins/tools/claude-code/templates/CLAUDE.md
@@ -50,8 +50,8 @@ Phase 4: Submit loop
 - we never commit or pr with attribution
 - we give summary prs without a changes section as git has the diff
 - agents never merge — they report PR URL and wait
-- step order: local CI → commit → gitleaks → push → PR → watch remote CI → notify
-- we wait for ci to pass then ask the user to squash merge and delete the merged branch
+- dual-gate step order (see /core:git Dual-Gate CI Policy): Gate 1 local CI → commit → gitleaks → push → PR → Gate 2 watch remote CI (local + remote green) → notify
+- once both gates are green we ask the user to squash merge and delete the merged branch
 - once merged, close the tracker issue (bees or beads), commit the tracker state, and push
 - we checkout main, pull and delete our merged feature branch
 - we go back to Phase1 to work a new epic


### PR DESCRIPTION
- Add canonical `## Dual-Gate CI Policy` section to `/core:git` SKILL.md: Gate 1 (local `mise run ci` green before every commit) and Gate 2 (local + remote `gh pr checks` green before any squash merge)
- Gate the Merge Strategy section on both gates being green; show the Gate 2 `gh pr checks` precondition inline before `gh pr merge --squash`
- Label Gate 1 / Gate 2 in the git PR Workflow steps
- Propagate the named gates into agent-loop SKILL.md (Quick Reference + Worker Execution Order steps 4/8)
- Name the dual gate in the claude-code plugin's templates/CLAUDE.md Phase 4 submit loop
- Bump versions: core 0.2.14→0.2.15, claude-code 0.2.7→0.2.8, all-skills 0.4.28→0.4.29 (plugin.json + marketplace.json synced)