### PR TITLE
docs(altana): document interactive council mode, ready_marker, and fix gateway IP

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,7 +43,7 @@
       "source": "./plugins/tools/altana",
       "strict": true,
       "description": "altana CLI wrapper: delegate prompts to sandboxed AI harnesses, run council fan-outs for diverse perspectives, and distribute tasks across harness presets",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "tools",
       "keywords": ["altana", "ai-agents", "harness", "delegate", "council", "sandbox", "awman", "local-llm"],
       "license": "MIT"

--- a/plugins/tools/altana/.claude-plugin/plugin.json
+++ b/plugins/tools/altana/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "altana",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "altana CLI wrapper: delegate prompts to sandboxed AI harnesses, run council fan-outs for diverse perspectives, and distribute tasks across harness presets",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/altana/commands/council.md
+++ b/plugins/tools/altana/commands/council.md
@@ -1,15 +1,17 @@
 ---
 description: "Send the same task to multiple altana harnesses in parallel and synthesize the responses into agreements, disagreements, unique insights, and a recommendation"
-argument-hint: "<task> [--harnesses a,b,c] [--prompt <template>]"
+argument-hint: "<task> [--harnesses a,b,c] [--rounds N] [--interactive] [--prompt <template>]"
 ---
 
-Run `altana council` to fan out one task to N harnesses simultaneously, then synthesize the array of responses into a structured analysis.
+Run `altana council` to fan out one task to N harnesses simultaneously, then synthesize the array of responses into a structured analysis. Two modes are available: one-shot (default) and interactive (persistent-session, multi-round deliberation).
 
 **What it does:**
 
-1. Invokes `altana council "<task>" [--harnesses <list>] [--prompt <template>]`.
+1. Invokes `altana council "<task>" [--harnesses <list>] [--rounds N] [--interactive] [--prompt <template>]`.
 2. Runs in the background (council calls are inherently parallel and may take time).
 3. Receives a JSON array of result objects — one per harness, in config-declaration order.
+   - In one-shot mode each element has a single `response` string.
+   - In interactive mode each element carries a `rounds` array of `{round, response}` objects instead of a single `response`.
 4. Synthesizes the responses into a structured report:
    - **Agreements** — claims all harnesses converge on.
    - **Disagreements** — points where harnesses diverge; note which harness said what.
@@ -22,6 +24,8 @@ Run `altana council` to fan out one task to N harnesses simultaneously, then syn
 
 - `<task>` — the prompt to fan out. Council is read-only; `--write` presets are rejected by altana.
 - `--harnesses a,b,c` — comma-separated list of harness names; defaults to all configured harnesses when omitted.
+- `--rounds N` — number of deliberation rounds when `--interactive` is set; default 2.
+- `--interactive` — opens one persistent session per harness; from round 2 on each harness sees labeled digests of its peers' prior-round answers and can react. Synthesis remains the caller's responsibility.
 - `--prompt <template>` — optional named prompt template applied to each harness invocation.
 
 **Result array element fields** (same schema as `delegate`):
@@ -44,13 +48,14 @@ Install altana (see its README — it is a Zig CLI built with `zig 0.16`). After
 /council "what are the risks of removing the retry loop in src/client.zig?"
 /council "critique the API surface in src/api.zig" --harnesses opus-harness,sonnet-harness
 /council "review this design doc" --prompt design-review
+/council "compare these two API designs" --interactive --rounds 1 --harnesses claude-cloud,claude-local
 ```
 
 **Task instructions:**
 
-Parse the argument: everything before the first `--` flag is `<task>`; extract `--harnesses` and `--prompt` from the flags.
+Parse the argument: everything before the first `--` flag is `<task>`; extract `--harnesses`, `--rounds`, `--interactive`, and `--prompt` from the flags. Flags must appear after the task string (the working invocation order is `altana council "<task>" --flag value`).
 
-Run (in background): `altana council "<task>" [--harnesses <list>] [--prompt <template>]`
+Run (in background): `altana council "<task>" [--harnesses <list>] [--rounds N] [--interactive] [--prompt <template>]`
 
 Once the result arrives, parse the JSON array. For each element where `status == "done"`, extract the `## Answer` section from `response`. For non-`done` entries, note the harness name and failure status.
 

--- a/plugins/tools/altana/skills/altana/SKILL.md
+++ b/plugins/tools/altana/skills/altana/SKILL.md
@@ -51,10 +51,18 @@ Use `--write` only when the task requires the agent to modify files (awman execu
 ### council
 
 ```
-altana council "<task>" [--harnesses a,b,c] [--prompt <template>]
+altana council "<task>" [--harnesses a,b,c] [--rounds N] [--interactive] [--prompt <template>]
 ```
 
-Fans the same task out to N harnesses in parallel (read-only). Returns a JSON array in config-declaration order. Each element has the same schema as `delegate` output.
+Fans the same task out to N harnesses in parallel (read-only). Returns a JSON array in config-declaration order.
+
+**One-shot mode (default):** each array element has the same schema as `delegate` output — a single `response` string per harness. This is the default when `--interactive` is not supplied.
+
+**Interactive mode (`--interactive`):** opens one persistent session per harness and runs R rounds (controlled by `--rounds`, default 2). From round 2 on, each harness sees labeled digests of its peers' prior-round answers and can react. Each result element carries a `rounds` array of `{round, response}` objects instead of a single `response`. Synthesis remains the caller's responsibility in both modes.
+
+Interactive members require a `ready_marker` field in their harness config so altana knows when a turn is complete. See `references/config.md` for details.
+
+Flags must appear after the task string: `altana council "<task>" --interactive --rounds 1 --harnesses a,b`.
 
 Council is the diverse-perspectives primitive. The synthesis step (agreements / disagreements / unique insights / recommendation) belongs in the caller — altana delivers raw results.
 

--- a/plugins/tools/altana/skills/altana/references/backends.md
+++ b/plugins/tools/altana/skills/altana/references/backends.md
@@ -23,13 +23,13 @@ Runs the agent binary inside an Apple Container VM using awman. The agent:
 
 ```bash
 container run --rm alpine ip route show default
-# Example output: default via 192.168.65.1 dev eth0
+# Example output: default via 192.168.64.1 dev eth0
 ```
 
 Use the gateway address in `ANTHROPIC_BASE_URL`:
 
 ```toml
-ANTHROPIC_BASE_URL = "http://192.168.65.1:8000"
+ANTHROPIC_BASE_URL = "http://192.168.64.1:8000"
 ```
 
 The exact address varies per machine — run the command above to discover it rather than copying this example value.
@@ -82,6 +82,8 @@ ANTHROPIC_AUTH_TOKEN = "op://your-vault/your-item/your-field"
 `council` rejects harnesses that have `write = true`. Only read-only presets participate in a council fan-out.
 
 When selecting harnesses for council, prefer presets pointing to different models or executors. Diverse execution environments make disagreement detection meaningful — two harnesses running the same model with the same config add little synthesis value.
+
+`council --interactive` runs a persistent-session, multi-round deliberation where each harness sees labeled digests of its peers' prior-round answers before producing its next response. Interactive members must set `ready_marker` in their harness config — a string altana polls for to detect turn completion. For Claude Code the value is `← for agents`. Set `timeout_s` high (1800 or more) since the interactive loop is slower than a direct API call.
 
 ## Model Discovery
 

--- a/plugins/tools/altana/skills/altana/references/config.md
+++ b/plugins/tools/altana/skills/altana/references/config.md
@@ -31,11 +31,16 @@ write = false
 # Optional: wall-clock timeout in seconds. Default: 1800.
 timeout_s = 1800
 
+# Optional: string altana waits for to detect that an interactive-council
+# turn is complete. Required when this harness participates in council --interactive.
+# For Claude Code the value is: ← for agents
+ready_marker = "← for agents"
+
 # Optional: environment variables injected into the agent process.
 # op:// values are resolved at dispatch time via the 1Password CLI.
 [harness.my-harness.env]
 ANTHROPIC_BASE_URL = "https://api.anthropic.com"
-ANTHROPIC_API_KEY  = "op://vault-name/item-name/field-name"
+ANTHROPIC_API_KEY  = "op://<vault>/<item>/credential"
 ```
 
 ### Field Reference
@@ -47,6 +52,7 @@ ANTHROPIC_API_KEY  = "op://vault-name/item-name/field-name"
 | `model` | string | no | null | Model ID; omit to trigger picker |
 | `write` | bool | no | `false` | Write access inside container (awman only) |
 | `timeout_s` | integer | no | `1800` | Wall-clock timeout in seconds |
+| `ready_marker` | string | no (required for interactive council) | null | Marker string signaling an interactive-session turn is complete; Claude Code uses `← for agents` |
 | `[harness.<name>.env]` | TOML table | no | empty | Env vars injected into agent process |
 
 ## Prompt Templates
@@ -91,18 +97,54 @@ Format: `op://vault-name/item-name/field-name`
 
 The `op` CLI must be installed, signed in to your account, and reachable on `PATH`. Run `altana doctor` to check op availability.
 
+### Interactive-council member
+
+When a harness participates in `council --interactive`, altana opens a persistent tmux session and polls for `ready_marker` after each turn. The interactive Claude Code loop is significantly slower than a direct API call; set `timeout_s` high (1800 or more) to avoid premature timeouts.
+
+A harness reaching a local model server via an Apple Container network needs the host gateway IP. For the `default` apple-container network (192.168.64.0/24) the gateway is `192.168.64.1`. Discover it at runtime with:
+
+```bash
+container run --rm alpine ip route show default
+```
+
+Example interactive-council member using a local model endpoint:
+
+```toml
+[harness.claude-local]
+agent        = "claude"
+executor     = "awman"
+model        = "local-model-id"
+timeout_s    = 1800
+ready_marker = "← for agents"
+
+[harness.claude-local.env]
+ANTHROPIC_BASE_URL = "http://192.168.64.1:8000"
+ANTHROPIC_API_KEY  = "op://<vault>/<item>/credential"
+```
+
+A harness using a cloud subscription (no API token required) still needs `ready_marker` but does not need `ANTHROPIC_BASE_URL` or `ANTHROPIC_API_KEY`:
+
+```toml
+[harness.claude-cloud]
+agent        = "claude"
+executor     = "awman"
+model        = "claude-sonnet-4-5"
+timeout_s    = 1800
+ready_marker = "← for agents"
+```
+
 ## Example: Multiple Harnesses
 
 ```toml
-# Harness using local model server (e.g. omlx running at host gateway)
+# Harness using local model server (e.g. a local model running at host gateway)
 [harness.local]
 agent     = "claude"
 executor  = "awman"
 timeout_s = 1800
 
 [harness.local.env]
-ANTHROPIC_BASE_URL = "http://192.168.65.1:8000"
-ANTHROPIC_AUTH_TOKEN = "op://my-vault/local-model/token"
+ANTHROPIC_BASE_URL = "http://192.168.64.1:8000"
+ANTHROPIC_API_KEY  = "op://<vault>/<item>/credential"
 
 # Harness calling the upstream API directly (raw executor, no container)
 [harness.upstream]
@@ -112,7 +154,7 @@ model     = "claude-opus-4-5"
 timeout_s = 600
 
 [harness.upstream.env]
-ANTHROPIC_API_KEY = "op://my-vault/anthropic/api-key"
+ANTHROPIC_API_KEY = "op://<vault>/<item>/credential"
 ```
 
-The `ANTHROPIC_AUTH_TOKEN` key is also accepted by the models endpoint and by the interactive picker. `ANTHROPIC_API_KEY` is the standard key for most agent CLIs; check your agent's documentation for which it reads.
+`ANTHROPIC_API_KEY` is the standard env var for most agent CLIs. Check your agent's documentation for which env var it reads; some agents read `ANTHROPIC_AUTH_TOKEN` instead.


### PR DESCRIPTION
- Add --interactive and --rounds N flags to council.md argument-hint frontmatter
- Document one-shot vs interactive council behavior (rounds array vs single response)
- Add interactive example with flags after task string
- Expand SKILL.md council subsection to cover both modes, peer-digest mechanism, and ready_marker requirement
- Document ready_marker field in config.md field reference table and schema block
- Add interactive-council member subsection with example harness config using generic op:// placeholder
- Fix apple-container host gateway IP from 192.168.65.1 to 192.168.64.1 in config.md and backends.md
- Keep discover-the-gateway guidance (container run --rm alpine ip route show default) intact
- Add interactive note to council compatibility section in backends.md
- Bump altana plugin version 0.1.0 → 0.1.1 in plugin.json and marketplace.json