### PR TITLE
feat(whamm): add whamm tool plugin and wasm cross-reference

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "A curated collection of Claude skills for development workflows",
-    "version": "1.0.23"
+    "version": "1.0.24"
   },
   "plugins": [
     {
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.29",
+      "version": "0.4.30",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"
@@ -216,9 +216,19 @@
       "source": "./plugins/wasm",
       "strict": true,
       "description": "WebAssembly skills: wasmtime runtime, component model, guest compilation, and host embedding",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "category": "language",
       "keywords": ["wasm", "webassembly", "wasmtime", "wasi", "component-model", "wit"],
+      "license": "MIT"
+    },
+    {
+      "name": "whamm",
+      "source": "./plugins/tools/whamm",
+      "strict": true,
+      "description": "whamm! WebAssembly bytecode instrumentation: mise install, the instr/info CLI, injection strategies, and the DTrace-inspired .mm monitor DSL",
+      "version": "0.1.0",
+      "category": "tools",
+      "keywords": ["whamm", "webassembly", "wasm", "instrumentation", "bytecode", "dtrace", "profiling"],
       "license": "MIT"
     },
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -103,6 +103,8 @@
     "./plugins/ui/skills/daisyui",
     "./plugins/wasm/skills/wasmtime",
     "./plugins/wasm/skills/wit",
+    "./plugins/tools/whamm/skills/whamm",
+    "./plugins/tools/whamm/skills/whamm-dsl",
     "./plugins/languages/zig/skills/zig",
     "./plugins/languages/zig/skills/language",
     "./plugins/languages/zig/skills/build",

--- a/plugins/tools/whamm/.claude-plugin/plugin.json
+++ b/plugins/tools/whamm/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "whamm",
+  "version": "0.1.0",
+  "description": "whamm! WebAssembly bytecode instrumentation: install via mise, the instr/info CLI, injection strategies, and the DTrace-inspired .mm monitor DSL",
+  "author": {
+    "name": "vinnie357"
+  },
+  "repository": "https://github.com/vinnie357/claude-skills",
+  "license": "MIT",
+  "keywords": ["whamm", "webassembly", "wasm", "instrumentation", "bytecode", "dtrace", "profiling", "wasmtime"],
+  "skills": [
+    "./skills/whamm",
+    "./skills/whamm-dsl"
+  ]
+}

--- a/plugins/tools/whamm/skills/sources.md
+++ b/plugins/tools/whamm/skills/sources.md
@@ -1,0 +1,54 @@
+# whamm Plugin Sources
+
+This document tracks the sources used to develop skills in the whamm plugin.
+
+## whamm Tool Skill
+
+- **URL:** https://github.com/ejrgilbert/whamm
+  - **Purpose:** Main repository, README, releases (v0.1.0, 2026-03-04)
+  - **Date Accessed:** 2026-06-18
+  - **Key Topics:** whamm tool overview, release assets, installation, CLI usage
+
+- **URL:** https://ejrgilbert.github.io/whamm/
+  - **Purpose:** Official documentation book (mdBook)
+  - **Date Accessed:** 2026-06-18
+  - **Key Topics:** Getting started, language reference, events, libraries, injection strategies
+
+- **URL:** https://github.com/ejrgilbert/whamm/releases
+  - **Purpose:** Release assets (whamm-linux-x86_64, whamm-macos-x86_64)
+  - **Date Accessed:** 2026-06-18
+  - **Key Topics:** Binary downloads, version tracking, platform-specific releases
+
+## whamm-dsl Skill
+
+- **URL:** https://ejrgilbert.github.io/whamm/intro/language.html
+  - **Purpose:** whamm DSL language specification
+  - **Date Accessed:** 2026-06-18
+  - **Key Topics:** Language syntax, operators, expressions, program structure
+
+- **URL:** https://ejrgilbert.github.io/whamm/intro/events.html
+  - **Purpose:** Event system and instrumentation points
+  - **Date Accessed:** 2026-06-18
+  - **Key Topics:** Event types, event matching, callback patterns
+
+- **URL:** https://ejrgilbert.github.io/whamm/intro/libraries.html
+  - **Purpose:** Standard library and built-in functions
+  - **Date Accessed:** 2026-06-18
+  - **Key Topics:** Available functions, data types, standard library reference
+
+- **URL:** https://ejrgilbert.github.io/whamm/intro/injection_strategies.html
+  - **Purpose:** Bytecode injection methodology and strategies
+  - **Date Accessed:** 2026-06-18
+  - **Key Topics:** Injection approaches, optimization, performance considerations
+
+- **URL:** https://ejrgilbert.github.io/whamm/intro/syntax/
+  - **Purpose:** Detailed syntax documentation pages
+  - **Date Accessed:** 2026-06-18
+  - **Key Topics:** Syntax reference, grammar, code examples
+
+## Plugin Information
+
+- **Name:** whamm
+- **Version:** 0.1.0
+- **Skills:** 2 (whamm, whamm-dsl)
+- **Created:** 2026-06-18

--- a/plugins/tools/whamm/skills/whamm-dsl/SKILL.md
+++ b/plugins/tools/whamm/skills/whamm-dsl/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: whamm-dsl
+description: Guide for the whamm! `.mm` monitor DSL — the DTrace-inspired language for WebAssembly instrumentation. Use when writing or reading `.mm` scripts, composing match rules, choosing variable kinds, writing predicates, or understanding bound variables at a probe site.
+license: MIT
+---
+
+# whamm-dsl — The `.mm` Monitor Language
+
+A `.mm` script is the instrumentation program whamm! injects into a WebAssembly binary (or compiles for engine-support). Each script contains global declarations followed by one or more **probes**. whamm! statically analyses match rules to decide which probes apply at each site, folding away constant guards before injection.
+
+For installing whamm! and running instrumented modules, load the companion **whamm** skill in this plugin.
+
+## When to Use This Skill
+
+Activate when:
+- Writing `.mm` monitor scripts to instrument WebAssembly binaries
+- Reading or debugging existing `.mm` files
+- Choosing the right match rule, mode, or predicate for a probe
+- Selecting between `var`, `unshared var`, `report var`, and `frame var`
+- Understanding which bound variables are available at a given probe site
+- Using libraries (`use whamm_core;`) or the `@static`/`@init` call modifiers
+- Looking up type syntax (tuples, maps, strings, type bounds)
+
+## Script structure
+
+A `.mm` file contains, in order:
+
+1. **`use` declarations** — `use lib;` imports a named library.
+2. **Global variable declarations** — `report var`, `var`, etc. declared at file scope.
+3. **Function definitions** — `name(args) -> ret { .. }` (NOT YET IMPLEMENTED).
+4. **Probes** — one or more match-rule blocks, each optionally gated by a predicate.
+
+## Match rules
+
+```
+provider:package:event:mode / predicate / { actions }
+```
+
+The predicate is optional. Without it: `provider:package:event:mode { actions }`.
+
+**Hierarchy:** `wasm` (provider) → package → event → mode.
+
+| Package | Events | Modes |
+|---------|--------|-------|
+| `opcode` | any opcode name or glob | `before`, `after`, `alt` |
+| `func` | _(any function)_ | `entry`, `exit` (`unwind` planned) |
+| `block` | `end` | _(none)_ |
+| _(none)_ | `begin`, `end`, `report` | _(none — top-level probes)_ |
+
+**Globbing examples:**
+
+```
+wasm:opcode:*:before              # all opcodes, before
+wasm::*if:before                  # if + br_if (empty package = wildcard)
+wasm:opcode:*load*|*store*:before # all memory loads and stores
+wasm:opcode:call|return_call:before
+```
+
+**Type bounds** narrow polymorphic args: `wasm:opcode:call(arg0: i32):before` matches only call sites where `arg0` is i32.
+
+Full event and bound-variable tables: see [`references/events.md`](references/events.md).
+
+## Predicated probes & modes
+
+```mm
+wasm:opcode:call:before / pc == 25 && arg0 == 1 / {
+    count++;
+}
+```
+
+whamm! performs **constant folding** on static vars (`pc`, `fid`, `imm0`, …). At a site where `pc != 25`, the probe is not injected at all. At `pc == 25` the dynamic guard `arg0 == 1` is emitted inline.
+
+**Modes:**
+- `before` — inject before the opcode executes.
+- `after` — inject after; result vars `res0`, `res1`, … hold the opcode's outputs.
+- `alt` — replace the opcode; call `drop_args()` to discard its input args.
+- `entry` / `exit` — inject at function entry or exit.
+
+## Variables
+
+| Kind | Declared as | Lifetime | Typical use |
+|------|-------------|----------|-------------|
+| `var` | `var x: T;` or `var x: T = v;` | Reinitialised on each probe invocation | Temporaries |
+| `unshared var` | `unshared var x: T;` | One instance per match site; retained across visits | Per-callsite counters |
+| `report var` | `report var x: T;` | Alias for `report unshared var`; printed at program end via WASI | Output accumulators |
+| `frame var` | `frame var x: T;` | Stored on the function frame; shared between `func:entry` and `func:exit` | Entry→exit state |
+| `shared var` | `shared var x: T;` | Single instance across ALL sites | NOT YET IMPLEMENTED |
+
+Variables declared **inside** a probe body behave as `unshared var` by default.
+
+Full type syntax — ints, floats, str, tuples, maps: see [`references/language.md`](references/language.md).
+
+## A first script
+
+Count every WebAssembly opcode executed:
+
+```mm
+report var count: u32;
+
+wasm:opcode:*:before {
+    count++;
+}
+```
+
+`report var` is global and printed automatically when the instrumented module exits (via WASI). No `wasm:report` block required for simple scalars.
+
+## Verifying bound variables
+
+The bound-variable lists in this skill are derived from the whamm documentation. Per `/core:anti-fabrication`, confirm the exact variables available at a given match rule with `whamm info --rule "<rule>"` at the installed version rather than assuming — the authoritative set is what the binary reports.
+
+## References
+
+- [`references/language.md`](references/language.md) — types, var kinds with examples, operators, strings, tuples, maps; functions (planned)
+- [`references/events.md`](references/events.md) — full provider hierarchy, available vs planned, all bound-variable tables
+- [`references/libraries.md`](references/libraries.md) — `use`, whamm_core built-ins, string memory interop, `@static`/`@init`, `wasm:report` override
+- [`references/examples.md`](references/examples.md) — annotated `.mm` scripts: instruction count, branch monitor, call graph, cache simulator, string interop
+
+Companion skill for install and CLI: **whamm** (same plugin).

--- a/plugins/tools/whamm/skills/whamm-dsl/references/events.md
+++ b/plugins/tools/whamm/skills/whamm-dsl/references/events.md
@@ -1,0 +1,148 @@
+# whamm-dsl Events Reference
+
+The authoritative source for bound variables at any specific match rule is:
+
+```bash
+whamm info --rule "wasm:opcode:call:before"
+```
+
+This reference documents the provider hierarchy and bound variables known at v0.1.0.
+
+## Provider hierarchy
+
+```
+wasm                          ← provider
+  opcode                      ← package
+    <opcode-name-or-glob>     ← event
+      before | after | alt    ← mode
+  func                        ← package
+    (any function)            ← event (no name; matches all functions)
+      entry | exit            ← mode  (unwind is planned, not available)
+  block                       ← package
+    end                       ← event
+      (no mode)
+  (top-level)
+    begin                     ← special probe, no mode
+    end                       ← special probe, no mode
+    report                    ← special probe, no mode
+```
+
+## Available vs planned
+
+| Probe | Status |
+|-------|--------|
+| `wasm:opcode:*:before` | Available |
+| `wasm:opcode:*:after` | Available |
+| `wasm:opcode:*:alt` | Available |
+| `wasm:func:*:entry` | Available |
+| `wasm:func:*:exit` | Available |
+| `wasm:func:*:unwind` | **Planned — not yet available** |
+| `wasm:block:end` | Available |
+| `wasm:begin` | Available |
+| `wasm:end` | Available |
+| `wasm:report` | Available |
+| `shared var` | **Planned — not yet available** |
+
+## Event globbing
+
+Empty package acts as a wildcard across packages:
+
+```
+wasm::*if:before     # matches wasm:opcode:if:before AND wasm:opcode:br_if:before
+```
+
+Pipe-separated alternatives:
+
+```
+wasm:opcode:call|return_call:before
+wasm:opcode:*load*|*store*:before
+```
+
+Type bounds narrow by argument type at match time:
+
+```
+wasm:opcode:call(arg0: i32):before
+```
+
+## Bound variables — provider level (`wasm`, all probes)
+
+These variables are available in every whamm probe:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `probe_id` | `i32` | Engine-assigned probe identifier |
+| `fid` | `u32` | Index of the function containing the probe site |
+| `pc` | `u32` | Program counter (bytecode offset) of the probe site |
+| `opidx` | `u32` | Instruction index within the function |
+| `at_func_end` | `bool` | True if the probe is at the last instruction of the function |
+| `fname` | `str` | Name of the enclosing function (static) |
+| `local0`, `local1`, … | dynamic | Local variable values (type depends on function signature) |
+
+`fid`, `pc`, `opidx` are **static** — whamm! constant-folds predicates on them at compile time. A predicate `/ pc == 25 /` eliminates the probe entirely at non-matching sites.
+
+## Bound variables — `wasm:opcode` common
+
+Available in all `wasm:opcode:*` probes in addition to the provider-level vars:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `opname` | `str` | Textual name of the opcode (e.g. `"call"`) |
+| `bytecode` | `u16` | Numeric opcode value |
+| `category_id` | `u32` | Numeric category of the opcode |
+| `category_name` | `str` | Textual category (e.g. `"control"`, `"memory"`) |
+| `arg0`, `arg1`, … | dynamic | Stack arguments consumed by the opcode (type varies) |
+| `imm0`, `imm1`, … | dynamic | Immediate (static) operands of the opcode |
+| `res0`, `res1`, … | dynamic | Result values (**`after` mode only**) |
+
+## Bound variables — opcode-specific
+
+### `call` and `return_call`
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `imm0` | `u32` | Target function index (static) |
+| `target_fn_name` | `str` | Name of the target function (static) |
+| `target_imp_module` | `str` | Import module name if imported, empty for locals (static) |
+| `target_fn_type` | `str` | `"local"` or `"import"` (static) |
+
+Bound functions available in `alt` mode:
+
+- `alt_call_by_id(id: i32)` — redirect call to function by index
+- `alt_call_by_name(name: str)` — redirect call to function by name
+
+### `br_if`
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `arg0` | dynamic | Condition value on the stack |
+| `imm0` | `u32` | Branch label (static) |
+
+### `br_table`
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `arg0` | dynamic | Branch index |
+| `num_targets` | `u32` | Number of targets in the table (static) |
+| `target` | `u32` | Resolved target: `arg0 <= num_targets-1 ? arg0 : num_targets` |
+
+### `*load*` / `*store*` (all memory load and store opcodes)
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `data_size` | `u32` | Number of bytes transferred |
+| `addr` | `u32` | Base address (alias: `arg0`) |
+| `effective_addr` | `u32` | `addr + offset` |
+| `offset` | `u64` | Static memory offset operand (static) |
+| `is_write` | `bool` | True for store opcodes |
+
+### `call_indirect`
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `table_entry_idx` | dynamic | Index into the indirect call table |
+
+### `wasm:block:end`
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `instr_count` | `u32` | Number of instructions in the block |

--- a/plugins/tools/whamm/skills/whamm-dsl/references/examples.md
+++ b/plugins/tools/whamm/skills/whamm-dsl/references/examples.md
@@ -1,0 +1,133 @@
+# whamm-dsl Examples
+
+All scripts below are verbatim `.mm` examples. Each fires at the match sites described; output is emitted via WASI at program exit unless otherwise noted.
+
+---
+
+## Instruction count
+
+Counts every WebAssembly opcode executed. The `report var` scalar is printed automatically at exit.
+
+```mm
+report var count: u32;
+
+wasm:opcode:*:before {
+    count++;
+}
+```
+
+**What it instruments:** every opcode in the module, before execution.
+**What it reports:** total opcode count for the run, printed to stdout on exit.
+
+---
+
+## Branch monitor
+
+Tracks how often each conditional branch is taken and records indirect branch table distribution.
+
+```mm
+// Matches _if and br_if events
+wasm::*if:before {
+  report unshared var taken: i32;
+  report unshared var total: i32;
+
+  var was_taken: bool = arg0 != 0;
+  taken = taken + (was_taken as i32);
+  total++;
+}
+
+wasm::br_table:before {
+  report unshared var taken_branches: map<u32, u32>;
+
+  var index: u32 = arg0 <= (num_targets - 1) ? arg0 : num_targets;
+  taken_branches[index]++;
+}
+```
+
+**What it instruments:** `if`, `br_if` (via `*if` glob), and `br_table` opcodes.
+**What it reports:** per-site taken/total counts for conditionals; per-target counts for branch tables.
+
+---
+
+## Call graph
+
+Records a weighted directed call graph: `(caller_fid, callee_fid) → count`. Handles direct calls, tail calls, and indirect/reference calls via a tracking flag that resolves the callee at `func:entry`. Uses `whamm_core.print_map_as_csv` for output.
+
+```mm
+use whamm_core;
+
+// (from, to) -> count
+report var call_graph: map<(u32, u32), u32>;
+var tracking_target: bool;
+var caller: u32;
+
+wasm:opcode:call|return_call:before {
+    call_graph[(fid, imm0)]++;
+}
+
+wasm:opcode:*call_indirect|*call_ref:before {
+    tracking_target = true;
+    caller = fid;
+}
+
+wasm:func:entry {
+    if (tracking_target) {
+        call_graph[(caller, fid)]++;
+        tracking_target = false;
+    }
+}
+
+wasm:report {
+    whamm_core.print_map_as_csv(0);
+}
+```
+
+**What it instruments:** direct/tail calls (at the call opcode), indirect/reference calls (resolved at callee entry).
+**What it reports:** CSV of `(caller_fid, callee_fid, count)` rows via `wasm:report` override.
+
+---
+
+## Cache simulator
+
+Simulates a cache and accumulates hit/miss counts across all memory load and store opcodes. Uses a custom `cache` library that exports `check_access(effective_addr, data_size) -> i32`. The return value packs hit and miss counts into the high and low 16 bits.
+
+```mm
+use cache;
+
+wasm:opcode:*load*|*store*:before {
+    report var hit: u32;
+    report var miss: u32;
+
+    var result: i32 = cache.check_access(effective_addr as i32, data_size as i32);
+    var num_hits: i32 = (result & 0xFFFF0000) >> 16;
+    var num_misses: i32 = (result & 0x0000FFFF);
+
+    hit = hit + (num_hits as u32);
+    miss = miss + (num_misses as u32);
+}
+```
+
+**What it instruments:** all memory load and store opcodes.
+**What it reports:** total cache hits and misses accumulated across the run.
+
+---
+
+## String interop
+
+Demonstrates writing a static string into whamm_core's linear memory and printing it via `puts`. Fires on every `drop` opcode.
+
+```mm
+use whamm_core;
+
+wasm:opcode:drop:before {
+    var s: str = "hello world!";
+    var l: u32 = s.len();
+    var ptr: i32 = whamm_core.mem_alloc(l as i32);
+    write_str(memid(whamm_core), ptr, s);
+    whamm_core.puts(ptr, l as i32);
+    whamm_core.mem_free(ptr);
+}
+```
+
+**What it instruments:** every `drop` opcode in the module.
+**What it reports:** prints `"hello world!"` to stdout each time a `drop` executes; demonstrates `mem_alloc`/`write_str`/`puts`/`mem_free` interop pattern.

--- a/plugins/tools/whamm/skills/whamm-dsl/references/language.md
+++ b/plugins/tools/whamm/skills/whamm-dsl/references/language.md
@@ -1,0 +1,161 @@
+# whamm-dsl Language Reference
+
+## Types
+
+### Primitive types
+
+| Type | Width | Notes |
+|------|-------|-------|
+| `bool` | — | `true` / `false` |
+| `u8`, `i8` | 8-bit | unsigned / signed |
+| `u16`, `i16` | 16-bit | unsigned / signed |
+| `u32`, `i32` | 32-bit | unsigned / signed |
+| `u64`, `i64` | 64-bit | unsigned / signed |
+| `f32` | 32-bit | IEEE 754 float |
+| `f64` | 64-bit | IEEE 754 float |
+| `str` | static | Static string (internally `(mem_addr, length)`) |
+
+### str methods and escapes
+
+Strings are **static only** — they cannot be computed at runtime without library assistance (see `libraries.md`).
+
+Methods available on `str` values:
+
+```mm
+var s: str = "hello world!";
+s.len()              // u32 — byte length
+s.starts_with("he")  // bool
+s.ends_with("!")     // bool
+s.contains("world")  // bool
+```
+
+Supported escape sequences: `\n`, `\t`, `\"`, `\'`, `\\`, `\0`, `\xNN`, `\u{NNNN}`.
+
+### Tuples
+
+Tuples group heterogeneous values. Access fields with `.0`, `.1`, `.1.0`, etc.
+
+```mm
+var pair: (i32, i32) = (1, 2);
+var nested: (i32, (i32, i32)) = (0, (1, 2));
+var x: i32 = nested.1.0;  // 1
+```
+
+Tuples are valid as map keys.
+
+### Maps
+
+Maps are declared with `map<K, V>`. They initialise to empty automatically.
+
+```mm
+report var counts: map<u32, u32>;
+counts[fid]++;          // read or write; out-of-bounds access = wasm trap
+
+report var graph: map<(u32, u32), u32>;
+graph[(fid, imm0)]++;   // tuple key
+```
+
+## Variable kinds
+
+### `var` — temporary
+
+Reinitialised on every probe invocation. Use for values that should not persist across calls.
+
+```mm
+wasm:opcode:*:before {
+    var was_taken: bool = arg0 != 0;
+    // was_taken is re-declared fresh each time this probe fires
+}
+```
+
+### `unshared var` — per-site, retained
+
+One instance per match site. Retains its value across visits to that site. Declaring inside a probe body also creates an unshared var by default.
+
+```mm
+wasm::*if:before {
+    report unshared var total: i32;
+    total++;    // increments the counter specific to this call site
+}
+```
+
+### `report var` — output accumulator
+
+Alias for `report unshared var`. Values are flushed and printed at program end via WASI. Scalars print automatically; maps require `wham_core.print_map_as_csv` (see `libraries.md`).
+
+```mm
+report var count: u32;
+report var call_graph: map<(u32, u32), u32>;
+```
+
+### `frame var` — function frame storage
+
+Stored on the function's stack frame. Allows state to flow from `wasm:func:entry` to `wasm:func:exit` within the same invocation.
+
+```mm
+frame var entry_time: u64;
+
+wasm:func:entry {
+    entry_time = get_time();
+}
+
+wasm:func:exit {
+    report var elapsed: u64;
+    elapsed = elapsed + (get_time() - entry_time);
+}
+```
+
+### `shared var` — NOT YET IMPLEMENTED
+
+A single instance shared across ALL match sites. Declared as `shared var x: T;`. whamm! does not yet implement this kind; use `unshared var` or `report var` for accumulators.
+
+## Operators
+
+### Arithmetic
+
+`+`, `-`, `*`, `/`, `%` — standard integer/float arithmetic.
+`++`, `--` — post-increment / post-decrement on integer vars.
+
+### Logical
+
+`&&`, `||` — short-circuit boolean operators.
+`!` — logical NOT.
+
+### Ternary
+
+```mm
+var index: u32 = arg0 <= (num_targets - 1) ? arg0 : num_targets;
+```
+
+### Conditionals
+
+```mm
+if (was_taken) {
+    taken = taken + 1;
+} elif (something_else) {
+    // ...
+} else {
+    // ...
+};   // note trailing semicolon required
+```
+
+### Type casts
+
+```mm
+var l: u32 = s.len();
+var ptr: i32 = whamm_core.mem_alloc(l as i32);   // cast with `as`
+```
+
+## Type bounds on match rules
+
+Narrow a polymorphic probe to sites where an argument has a specific type:
+
+```mm
+wasm:opcode:call(arg0: i32):before {
+    // fires only at call sites where arg0 is i32
+}
+```
+
+## Functions — NOT YET IMPLEMENTED
+
+The syntax `name(args) -> ret { .. }` for user-defined functions is documented in the whamm design but not yet fully implemented at v0.1.0.

--- a/plugins/tools/whamm/skills/whamm-dsl/references/libraries.md
+++ b/plugins/tools/whamm/skills/whamm-dsl/references/libraries.md
@@ -1,0 +1,140 @@
+# whamm-dsl Libraries Reference
+
+## Importing a library
+
+```mm
+use whamm_core;
+```
+
+Place `use` declarations at the top of the `.mm` file, before probes. After importing, call functions as `lib.fn(args)`.
+
+```mm
+use whamm_core;
+
+wasm:opcode:drop:before {
+    var l: u32 = 12;
+    var ptr: i32 = whamm_core.mem_alloc(l as i32);
+    // ...
+    whamm_core.mem_free(ptr);
+}
+```
+
+## whamm_core built-ins
+
+`whamm_core` is the built-in standard library. Import it with `use whamm_core;`.
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `puts` | `(ptr: i32, len: i32)` | Print `len` bytes from linear memory at `ptr` to stdout |
+| `mem_alloc` | `(size: i32) -> i32` | Allocate `size` bytes; returns pointer into the library's linear memory |
+| `mem_free` | `(ptr: i32)` | Free a previously allocated pointer |
+| `print_map_as_csv` | `(map_id: i32)` | Print a `report var` map as CSV rows at program end |
+
+## String memory interop
+
+`str` values in whamm are static. To pass a string to a library function that operates on linear memory (e.g. `puts`), use these built-in interop helpers:
+
+| Helper | Description |
+|--------|-------------|
+| `memid(lib)` | Returns the memory ID of `lib`'s linear memory |
+| `write_str(memid, ptr, s)` | Writes string `s` into linear memory `memid` at address `ptr` |
+| `read_str(memid, ptr, len)` | Reads `len` bytes from linear memory `memid` at `ptr` into a `str` |
+
+### String interop example
+
+Write a static string into whamm_core's memory and print it:
+
+```mm
+use whamm_core;
+
+wasm:opcode:drop:before {
+    var s: str = "hello world!";
+    var l: u32 = s.len();
+    var ptr: i32 = whamm_core.mem_alloc(l as i32);
+    write_str(memid(whamm_core), ptr, s);
+    whamm_core.puts(ptr, l as i32);
+    whamm_core.mem_free(ptr);
+}
+```
+
+## `@static` call modifier
+
+`@static lib.fn(..)` calls the function at **match (compile) time**, not at runtime.
+
+- Use for calls that must happen once during instrumentation, e.g. registering a cache configuration.
+- The function must be side-effect-free for the bytecode-rewriting path (state is lost between rewriting and execution).
+- On the `wei` (engine-support) path, `@static` state persists because the engine holds the library module.
+
+```mm
+use cache;
+
+wasm:opcode:*load*|*store*:before {
+    @static cache.init(64, 4);   // called at match time
+    var result: i32 = cache.check_access(effective_addr as i32, data_size as i32);
+}
+```
+
+## `@init` call modifier
+
+`@init lib.fn()` runs the function at **probe initialisation** (program start), once per script load.
+
+```mm
+use whamm_core;
+
+wasm:begin {
+    @init whamm_core.setup();
+}
+```
+
+## `wasm:report` override
+
+By default, `report var` scalars print automatically. To customise output — e.g. print a map as CSV — add a `wasm:report` probe:
+
+```mm
+use whamm_core;
+
+report var call_graph: map<(u32, u32), u32>;
+
+// ... probes that populate call_graph ...
+
+wasm:report {
+    whamm_core.print_map_as_csv(0);
+}
+```
+
+`print_map_as_csv(0)` prints the first `report var` map declared in the script. Index corresponds to declaration order among `report var` maps.
+
+### Call graph example (uses whamm_core and report override)
+
+```mm
+use whamm_core;
+
+// (from, to) -> count
+report var call_graph: map<(u32, u32), u32>;
+var tracking_target: bool;
+var caller: u32;
+
+wasm:opcode:call|return_call:before {
+    call_graph[(fid, imm0)]++;
+}
+
+wasm:opcode:*call_indirect|*call_ref:before {
+    tracking_target = true;
+    caller = fid;
+}
+
+wasm:func:entry {
+    if (tracking_target) {
+        call_graph[(caller, fid)]++;
+        tracking_target = false;
+    }
+}
+
+wasm:report {
+    whamm_core.print_map_as_csv(0);
+}
+```
+
+## Custom libraries
+
+Any Wasm module that exports the expected functions can be used as a whamm library. Custom libraries follow the same `use`/`lib.fn()` pattern as `whamm_core`. The `cache` library in the cache simulator example (see `examples.md`) is a custom library that exports `check_access(effective_addr, data_size) -> i32`.

--- a/plugins/tools/whamm/skills/whamm/SKILL.md
+++ b/plugins/tools/whamm/skills/whamm/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: whamm
+description: Install and operate whamm!, the WebAssembly bytecode instrumentation tool. Use when instrumenting or profiling a .wasm binary, counting opcodes or function calls, choosing between bytecode-rewriting and engine-support (wei) injection strategies, or running an instrumented module with wasmtime or Wizard.
+license: MIT
+---
+
+# whamm — WebAssembly Instrumentation Tool
+
+Entry point for installing, configuring, and running whamm! (v0.1.0). whamm! instruments compiled `.wasm` binaries using a DTrace-inspired `.mm` monitor script; no source changes to the target application are required.
+
+For the `.mm` language itself — probe syntax, events, libraries, and examples — load the companion **whamm-dsl** skill in this plugin.
+
+## When to Use This Skill
+
+Activate when:
+- Instrumenting or profiling a `.wasm` binary without modifying source
+- Counting opcodes, tracking function calls, or measuring memory access patterns in a WebAssembly module
+- Installing whamm via `mise` or building from source
+- Choosing between bytecode-rewriting and wei (engine-support) injection strategies
+- Running an instrumented module with `wasmtime` (rewriting path) or Wizard engine (wei path)
+
+## Install (mise github backend)
+
+Copy the stanzas from `templates/mise.toml` into your project's `mise.toml`. Full explanation of asset patterns, Rosetta caveat, and build-from-source steps lives in `references/installation.md`.
+
+```toml
+[tools."github:ejrgilbert/whamm"]
+version = "0.1.0"
+
+[tools."github:ejrgilbert/whamm".platforms]
+linux-x64   = { asset_pattern = "whamm-linux-x86_64" }
+macos-x64   = { asset_pattern = "whamm-macos-x86_64" }
+macos-arm64 = { asset_pattern = "whamm-macos-x86_64" }  # Rosetta 2
+```
+
+Verify the install:
+
+```bash
+mise install
+whamm --help
+```
+
+v0.1.0 ships bare binaries for `x86_64` only. On Apple Silicon without Rosetta 2, build from source — see `references/installation.md`.
+
+## CLI quickstart
+
+Full flag reference lives in `references/cli.md`. Core commands:
+
+```bash
+# Instrument: bytecode-rewriting path
+whamm instr --app app.wasm --script monitor.mm -o out.wasm
+
+# Compile monitor for engine-support (wei) path — no --app
+whamm instr --script monitor.mm --wei -o monitor.wasm
+
+# Inspect bound variables available at a match rule
+whamm info --rule "wasm:opcode:call:before"
+
+# Global help
+whamm --help
+```
+
+Set `RUST_LOG={error|warn|info|debug|trace|off}` to control verbosity.
+
+## End-to-end workflow (bytecode-rewriting path)
+
+1. Write a `.mm` monitor script (see `whamm-dsl` skill).
+2. Instrument the target module:
+   ```bash
+   whamm instr --app app.wasm --script monitor.mm -o out.wasm
+   ```
+3. Run the instrumented module. The rewriting path requires `whamm_core.wasm` preloaded at runtime:
+   ```bash
+   wasmtime run \
+     --env TO_CONSOLE=true \
+     --preload whamm_core=whamm_core.wasm \
+     out.wasm
+   ```
+
+`whamm_core.wasm` is NOT included in the prebuilt release binary. Build it from source — see `references/installation.md`.
+
+## End-to-end workflow (wei / Wizard engine path)
+
+1. Compile the monitor without `--app`:
+   ```bash
+   whamm instr --script monitor.mm --wei -o monitor.wasm
+   ```
+2. Run with Wizard engine:
+   ```bash
+   wizeng \
+     --env=TO_CONSOLE=true \
+     --monitors=monitor.wasm+whamm_core.wasm \
+     app.wasm
+   ```
+
+The Wizard engine attaches probes at runtime; the target `.wasm` is not modified.
+
+## Injection strategies
+
+Two strategies exist: **bytecode rewriting** (any runtime, `--app` required at instr time, intrusive) and **engine support via `--wei`** (Wizard engine only, non-intrusive, supports JIT optimization and persistent `@static` state). A full comparison table covering intrusiveness, runtime compatibility, JIT optimization, and `@static` state behavior lives in `references/injection-strategies.md`.
+
+## The .mm language
+
+Load the **whamm-dsl** skill in this plugin for probe syntax, event matching, built-in variables, library functions, and annotated `.mm` examples. This skill (whamm) covers the tool only.
+
+## Verification
+
+Treat `whamm info --rule "<match-rule>"` as the authoritative source for the bound variables available at a probe site, and confirm probe output against an actual instrumented run. This follows `/core:anti-fabrication` — verify behavior with the tool at the installed version, do not infer it.
+
+## References
+
+- `templates/mise.toml` — mise stanzas with platform asset patterns and task definitions
+- `references/installation.md` — mise github backend explained, build-from-source steps, whamm_core.wasm, verification
+- `references/cli.md` — all flags for `whamm instr`, `whamm info`, RUST_LOG, both run paths
+- `references/injection-strategies.md` — strategy comparison table and selection guide

--- a/plugins/tools/whamm/skills/whamm/references/cli.md
+++ b/plugins/tools/whamm/skills/whamm/references/cli.md
@@ -1,0 +1,114 @@
+# whamm CLI Reference
+
+## Global flags
+
+```bash
+whamm --help          # Print help and exit
+```
+
+Set `RUST_LOG` in the environment to control log verbosity:
+
+| Value   | Effect |
+|---------|--------|
+| `error` | Errors only |
+| `warn`  | Warnings and errors |
+| `info`  | Informational messages (default) |
+| `debug` | Detailed debug output |
+| `trace` | Full trace (very verbose) |
+| `off`   | Suppress all log output |
+
+```bash
+RUST_LOG=debug whamm instr --app app.wasm --script monitor.mm -o out.wasm
+```
+
+---
+
+## whamm instr
+
+Instruments a WebAssembly module using a `.mm` monitor script.
+
+### Bytecode-rewriting path
+
+```bash
+whamm instr --app app.wasm --script monitor.mm -o out.wasm
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--app <path>` | Yes (rewriting) | Path to the input `.wasm` binary |
+| `--script <path>` | Yes | Path to the `.mm` monitor script |
+| `-o <path>` | Yes | Output path for the instrumented `.wasm` |
+
+The rewriting path embeds probe logic directly into the module's bytecode using the `wirm` Rust library. The output `.wasm` runs on any WebAssembly runtime that can preload `whamm_core.wasm`.
+
+### Engine-support (wei) path
+
+```bash
+whamm instr --script monitor.mm --wei -o monitor.wasm
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--script <path>` | Yes | Path to the `.mm` monitor script |
+| `--wei` | Yes | Compile for engine support (Wizard Engine Interface) |
+| `-o <path>` | Yes | Output path for the compiled monitor module |
+| `--app` | No | Omit — the engine attaches probes at runtime |
+
+The `--wei` flag compiles the `.mm` script into a generic monitor `.wasm` module. No target binary is specified at compile time; the engine attaches probes when loading the monitor module alongside the target.
+
+---
+
+## whamm info
+
+Inspects available bound variables for a given event match rule.
+
+```bash
+whamm info --rule "wasm:opcode:call:before"
+```
+
+| Flag | Description |
+|------|-------------|
+| `--rule <rule>` | Event match rule to inspect (e.g. `"wasm:opcode:call:before"`) |
+| `-fv` | (optional) Full verbose output |
+
+Example with verbose flag:
+
+```bash
+whamm info -fv --rule "wasm:opcode:i32.load:before"
+```
+
+Prints the variables bound at the given probe site — names, types, and whether they are mutable. Use this to discover what data is available in a probe body before writing the `.mm` script.
+
+---
+
+## Running instrumented modules
+
+### Bytecode-rewriting path (wasmtime)
+
+The rewriting path requires `whamm_core.wasm` preloaded as a named module:
+
+```bash
+wasmtime run \
+  --env TO_CONSOLE=true \
+  --preload whamm_core=whamm_core.wasm \
+  out.wasm
+```
+
+- `--env TO_CONSOLE=true` — directs whamm_core to print probe output to stdout
+- `--preload whamm_core=whamm_core.wasm` — loads `whamm_core.wasm` as the `whamm_core` import namespace
+
+`whamm_core.wasm` must be built from source — it is not included in the prebuilt release binary. The `installation` reference covers the build step (`whamm:build-from-source`).
+
+### Engine-support path (Wizard engine)
+
+```bash
+wizeng \
+  --env=TO_CONSOLE=true \
+  --monitors=monitor.wasm+whamm_core.wasm \
+  app.wasm
+```
+
+- `--monitors` — comma- or plus-separated list of monitor modules to attach
+- `app.wasm` — the unmodified target binary
+
+The Wizard engine attaches the probes at runtime; `app.wasm` is never rewritten.

--- a/plugins/tools/whamm/skills/whamm/references/injection-strategies.md
+++ b/plugins/tools/whamm/skills/whamm/references/injection-strategies.md
@@ -1,0 +1,65 @@
+# whamm Injection Strategies
+
+whamm! supports two injection strategies. The choice determines the CLI flags, runtime requirements, and behavioral guarantees.
+
+---
+
+## Strategy 1: Bytecode Rewriting
+
+whamm reads the target `.wasm` binary into an AST (using the `wirm` Rust library), locates probe sites, injects the compiled probe logic inline, and writes a new `.wasm` output file. The target module is permanently modified.
+
+**Compile time:**
+```bash
+whamm instr --app app.wasm --script monitor.mm -o out.wasm
+```
+
+**Run time:**
+```bash
+wasmtime run --env TO_CONSOLE=true --preload whamm_core=whamm_core.wasm out.wasm
+```
+
+---
+
+## Strategy 2: Engine Support (wei)
+
+whamm compiles the `.mm` script into a generic monitor module (a `.wasm` file) without referencing any target binary. The Wizard engine loads the monitor alongside the target at runtime and attaches the probes dynamically.
+
+**Compile time:**
+```bash
+whamm instr --script monitor.mm --wei -o monitor.wasm
+```
+
+**Run time:**
+```bash
+wizeng --env=TO_CONSOLE=true --monitors=monitor.wasm+whamm_core.wasm app.wasm
+```
+
+---
+
+## Comparison
+
+| Property | Bytecode Rewriting | Engine Support (wei) |
+|----------|-------------------|----------------------|
+| `--app` required at compile time | Yes | No |
+| Target `.wasm` modified | Yes (intrusive) | No (non-intrusive) |
+| Runtime compatibility | Any runtime (wasmtime, wasmer, node, etc.) | Wizard engine only |
+| Attach timing | Compile time (static) | Runtime (dynamic) |
+| JIT optimization of probes | No | Yes (Wizard can JIT probes) |
+| `@static` library state persists across calls | No (rewriting resets module state) | Yes |
+| `whamm_core.wasm` needed at runtime | Yes (`--preload`) | Yes (`--monitors`) |
+| Use case | Broad runtime compatibility, one-shot analysis | Low-overhead production monitoring, stateful probes |
+
+---
+
+## Selecting a strategy
+
+Use **bytecode rewriting** when:
+- The target runtime is not Wizard (wasmtime, wasmer, Node.js WASI, Deno, etc.)
+- You need a self-contained instrumented binary to distribute or archive
+- Probe persistence across module instantiation is not required
+
+Use **engine support (wei)** when:
+- The Wizard engine is available
+- Probes must not modify the original binary (auditing, production tracing)
+- You need `@static` state that survives across probe invocations
+- JIT-optimized probe execution matters for low overhead at high call frequency

--- a/plugins/tools/whamm/skills/whamm/references/installation.md
+++ b/plugins/tools/whamm/skills/whamm/references/installation.md
@@ -1,0 +1,119 @@
+# whamm Installation Reference
+
+## mise github backend (preferred)
+
+The mise `github` backend installs tools directly from GitHub release assets. No plugin required — built into mise.
+
+### Template stanzas
+
+```toml
+[tools."github:ejrgilbert/whamm"]
+version = "0.1.0"
+
+[tools."github:ejrgilbert/whamm".platforms]
+linux-x64   = { asset_pattern = "whamm-linux-x86_64" }
+macos-x64   = { asset_pattern = "whamm-macos-x86_64" }
+macos-arm64 = { asset_pattern = "whamm-macos-x86_64" }
+```
+
+**How `asset_pattern` works.** mise downloads the release asset whose filename matches the pattern string. v0.1.0 assets are bare binaries (no archive): `whamm-linux-x86_64` and `whamm-macos-x86_64`. The pattern must be an exact substring match or glob against the asset filename.
+
+**x86_64 only.** v0.1.0 (2026-03-04) ships two assets — Linux x86_64 and macOS x86_64. No arm64 or Windows asset exists in this release. The `macos-arm64` platform entry maps to the x86_64 binary so mise does not fail on Apple Silicon; macOS runs it under Rosetta 2.
+
+**Version pinning.** Pin to `"0.1.0"` explicitly. Use the `/claude-code:skill-update` skill to check for newer releases and bump the pin intentionally. Never set `version = "latest"` for a binary tool without a lock mechanism — silent upgrades can break scripts.
+
+### Install and verify
+
+```bash
+mise install
+whamm --help
+```
+
+Expected: the whamm help text prints without error.
+
+### Rosetta 2 caveat
+
+On Apple Silicon Macs, Rosetta 2 translates the x86_64 binary at runtime. To check whether Rosetta is available:
+
+```bash
+arch -x86_64 echo "rosetta ok"
+```
+
+If Rosetta is absent or you need a native arm64 binary, build from source (section below).
+
+---
+
+## Build from source
+
+Build from source when:
+- Running Apple Silicon without Rosetta 2
+- Building `whamm_core.wasm` (required for the bytecode-rewriting runtime path)
+- Developing whamm itself
+
+### Prerequisites
+
+- Rust toolchain via `rustup`
+- `cargo`
+- For `whamm_core.wasm`: the `wasm32-wasip1` target
+
+### Steps
+
+```bash
+# Clone the repository
+git clone https://github.com/ejrgilbert/whamm
+cd whamm
+
+# Debug build (faster compile, slower binary)
+make
+
+# Release build (includes whamm_core.wasm)
+make release
+```
+
+The `make release` target:
+1. Compiles the `whamm` CLI to `target/release/whamm`
+2. Adds the `wasm32-wasip1` Rust target if absent
+3. Builds `whamm_core` with `cargo build -p whamm_core --target wasm32-wasip1 --release`
+4. Outputs `whamm_core.wasm` to `embedded/release/whamm_core.wasm`
+
+### Post-build setup
+
+```bash
+# Add the binary to PATH (add to shell profile for persistence)
+export PATH="$PWD/target/release:$PATH"
+
+# Set WHAMM_HOME to the repository root
+export WHAMM_HOME="$PWD"
+```
+
+`WHAMM_HOME` tells whamm where to find `whamm_core.wasm` and related embedded assets.
+
+### Building whamm_core separately
+
+If you already have the whamm binary but need `whamm_core.wasm`:
+
+```bash
+rustup target add wasm32-wasip1
+cargo build -p whamm_core --target wasm32-wasip1 --release
+# Output: embedded/release/whamm_core.wasm
+```
+
+---
+
+## Prebuilt binary and whamm_core.wasm
+
+The prebuilt release binary (`whamm-linux-x86_64`, `whamm-macos-x86_64`) does NOT include `whamm_core.wasm` as a separate downloadable asset in v0.1.0. `whamm_core.wasm` is required at runtime for the bytecode-rewriting path when `TO_CONSOLE=true` output is used. Build from source to obtain it.
+
+---
+
+## Verification
+
+```bash
+# Confirm whamm is on PATH and responds
+whamm --help
+
+# Inspect bound variables for a specific event rule
+whamm info -fv --rule "wasm:opcode:i32.load:before"
+```
+
+The `info` command lists which variables are bound at the given probe site. If whamm is installed correctly, it prints a table of variable names and types; it does not require a `.wasm` file at this stage.

--- a/plugins/tools/whamm/skills/whamm/templates/mise.toml
+++ b/plugins/tools/whamm/skills/whamm/templates/mise.toml
@@ -1,0 +1,40 @@
+# whamm — WebAssembly bytecode instrumentation tool
+# Copy these definitions into your project's mise.toml
+# Source: https://github.com/ejrgilbert/whamm/releases  (verified v0.1.0, 2026-03-04)
+
+[tools."github:ejrgilbert/whamm"]
+version = "0.1.0"  # pin; bump intentionally per /claude-code:skill-update
+
+# v0.1.0 ships bare-binary assets for x86_64 only.
+[tools."github:ejrgilbert/whamm".platforms]
+linux-x64   = { asset_pattern = "whamm-linux-x86_64" }
+macos-x64   = { asset_pattern = "whamm-macos-x86_64" }
+# No native arm64 asset in v0.1.0 — the x86_64 macOS binary runs under Rosetta 2.
+# On Apple Silicon without Rosetta, prefer `mise run whamm:build-from-source` below.
+macos-arm64 = { asset_pattern = "whamm-macos-x86_64" }
+
+[tasks."whamm:verify"]
+description = "Confirm whamm is on PATH"
+run = "whamm --help"
+
+[tasks."whamm:instrument"]
+description = "Instrument app.wasm with a .mm script (bytecode rewriting)"
+run = "whamm instr --app {{arg(name='app')}} --script {{arg(name='script')}} -o {{arg(name='out')}}"
+
+[tasks."whamm:run"]
+description = "Run an instrumented module with wasmtime + whamm_core"
+run = "wasmtime run --env TO_CONSOLE=true --preload whamm_core=whamm_core.wasm {{arg(name='out')}}"
+
+# Fallback / required for whamm_core.wasm + Apple Silicon native builds.
+[tasks."whamm:build-from-source"]
+description = "Build whamm + whamm_core.wasm from source (needed for arm64 and for whamm_core)"
+run = """
+#!/usr/bin/env nu
+# requires: rustup, cargo
+git clone https://github.com/ejrgilbert/whamm
+cd whamm
+make release
+print $"whamm binary: (pwd)/target/release/whamm"
+print $"whamm_core:   (pwd)/embedded/release/whamm_core.wasm"
+print "Add target/release to PATH and set WHAMM_HOME to this dir."
+"""

--- a/plugins/wasm/.claude-plugin/plugin.json
+++ b/plugins/wasm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "WebAssembly skills: wasmtime runtime, component model, guest compilation, and host embedding",
   "author": {
     "name": "vinnie357"

--- a/plugins/wasm/skills/wasmtime/SKILL.md
+++ b/plugins/wasm/skills/wasmtime/SKILL.md
@@ -65,6 +65,10 @@ Use WASIp2 for new projects. WASIp1 remains supported for existing code. See [ov
 | [host-rust.md](references/host-rust.md) | Wasmtime Rust API, WASI context setup, Component Model bindgen!, async support, plugin system patterns |
 | [host-elixir.md](references/host-elixir.md) | Wasmex API, GenServer integration, memory access, host callbacks, supervision patterns |
 
+## WebAssembly instrumentation (whamm)
+
+whamm! instruments compiled `.wasm` modules by inserting probes through bytecode rewriting, using a DTrace-inspired `.mm` DSL for profiling, opcode counting, cache simulation, and call graph analysis. Run instrumented modules on wasmtime by preloading the whamm core library: `wasmtime run --env TO_CONSOLE=true --preload whamm_core=whamm_core.wasm out.wasm`. For CLI installation (mise github backend), the `.mm` language, and instrumentation strategies, see the `whamm` and `whamm-dsl` skills in the whamm plugin (`/plugin install whamm@vinnie357`).
+
 ## Common Pitfalls
 
 - **Wrong target triple**: Use `wasm32-wasip2` for Component Model, `wasm32-wasip1` for legacy WASI, `wasm32-unknown-unknown` for bare modules


### PR DESCRIPTION
- Add `plugins/tools/whamm` plugin with two skills: `whamm` (install/CLI/injection strategies/workflow) and `whamm-dsl` (the DTrace-inspired `.mm` monitor language)
- Provide a mise github-backend install template (`github:ejrgilbert/whamm` v0.1.0) with platform asset patterns, instrument/run/verify tasks, and a build-from-source fallback for arm64 + whamm_core.wasm
- Document the x86_64-only release assets and Rosetta caveat (no native Apple Silicon binary in v0.1.0)
- Add a brief whamm instrumentation cross-reference to the wasmtime skill (`wasmtime --preload whamm_core=...`)
- Register whamm in marketplace.json (category tools, v0.1.0), bump wasm 0.1.3→0.1.4, update all-skills meta-plugin, bump marketplace metadata
- mise test green; both whamm skills score 17/17 on the quality scorecard