### PR TITLE
feat(github): add pr-review skill for collaborator PR review

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -98,10 +98,10 @@
       "name": "github",
       "source": "./plugins/tools/github",
       "strict": true,
-      "description": "GitHub Actions, Workflows, act local testing, community health files, and Dependabot consolidation",
-      "version": "0.2.0",
+      "description": "GitHub Actions, Workflows, act local testing, community health files, Dependabot consolidation, and PR review",
+      "version": "0.3.0",
       "category": "tools",
-      "keywords": ["github", "actions", "workflows", "ci-cd", "act", "testing", "community-health", "open-source", "dependabot", "dependencies"]
+      "keywords": ["github", "actions", "workflows", "ci-cd", "act", "testing", "community-health", "open-source", "dependabot", "dependencies", "pr-review", "code-review", "collaborator"]
     },
     {
       "name": "graphify",

--- a/plugins/tools/github/.claude-plugin/plugin.json
+++ b/plugins/tools/github/.claude-plugin/plugin.json
@@ -1,22 +1,25 @@
 {
   "name": "github",
-  "version": "0.2.0",
-  "description": "GitHub Actions, Workflows, act local testing, community health files, and Dependabot consolidation",
+  "version": "0.3.0",
+  "description": "GitHub Actions, Workflows, act local testing, community health files, Dependabot consolidation, and PR review",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["github", "actions", "workflows", "ci-cd", "act", "testing", "community-health", "open-source", "dependabot", "dependencies"],
+  "keywords": ["github", "actions", "workflows", "ci-cd", "act", "testing", "community-health", "open-source", "dependabot", "dependencies", "pr-review", "code-review", "collaborator"],
   "skills": [
     "./skills/actions",
     "./skills/workflows",
     "./skills/act",
     "./skills/community-health",
-    "./skills/dependabot-consolidator"
+    "./skills/dependabot-consolidator",
+    "./skills/pr-review"
   ],
   "agents": [
     "./skills/dependabot-consolidator/agents/dependabot-collector.md",
-    "./skills/dependabot-consolidator/agents/dependabot-consolidator-worker.md"
+    "./skills/dependabot-consolidator/agents/dependabot-consolidator-worker.md",
+    "./skills/pr-review/agents/pr-collector.md",
+    "./skills/pr-review/agents/pr-review-worker.md"
   ]
 }

--- a/plugins/tools/github/skills/pr-review/SKILL.md
+++ b/plugins/tools/github/skills/pr-review/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: pr-review
+description: Review a repository's open human-authored pull requests one at a time with a stack-aware agent per PR, build and test each branch locally under baseline-diff gates, and squash-merge on operator approval. Use when a repo has open contributor or collaborator PRs to review and merge, when reviewing external PRs that need local build/test before merge, or when triaging the open PR queue without mistaking pre-existing CI failures for regressions.
+license: MIT
+---
+
+# PR Review
+
+Reviews open, human-authored pull requests with the care of the Forge operating model
+(`/core:agent-loop`): a read-only collector classifies the queue, one stack-aware reviewer
+runs per PR, each branch is built and tested locally under baseline-diff discipline, and the
+operator owns every merge. Repo-agnostic — stack and gates are discovered, never hardcoded.
+
+## When to Use This Skill
+
+- A repo accumulates open contributor or collaborator PRs that need review before merge
+- External PRs need a local build/test pass (the project's CI does not run the full suite)
+- You triage the open PR queue and want one reviewable verdict per PR
+- You verify a PR without confusing pre-existing failures with regressions it introduced
+
+## Scope: human-authored PRs only
+
+List open PRs and exclude bots:
+
+```bash
+gh pr list --state open \
+  --json number,title,author,headRefName,headRefOid,files
+```
+
+Drop every PR whose `author.is_bot` is true or whose login is `app/dependabot`. Bot
+dependency PRs belong to `/github:dependabot-consolidator`, not this skill. Verify the
+filtered list contains only human authors before dispatching reviewers.
+
+## Classify each PR: stack and gates
+
+Classify before reviewing. Two inputs drive the classification:
+
+1. **Stack** — read the PR's changed file extensions and the repo's manifests
+   (`Cargo.toml`, `mix.exs`, `build.zig`, `package.json`, `go.mod`). Map to the reviewer's
+   language skills. See `references/stack-detection.md` for the full table.
+2. **Gates** — discover the repo's own gate tasks with `/core:mise`: run `mise tasks` and
+   pick the PR-gating tasks (`ci`, `pre-commit`, `test`, `lint`, `fmt:check`, `audit`,
+   `gitleaks`). Run the discovered tasks — never assume `cargo`/`mix`/`npm` directly.
+
+Hand this read-only classification to the `pr-collector` agent.
+
+## Per-PR review: one agent per PR
+
+Dispatch one `pr-review-worker` per PR. Fan-out width equals the open-PR count, the Forge
+slice model. Run the reviewers **sequentially** when the gates need exclusive hardware
+(integration tests, container or cluster spawns) — parallel branch checkouts in one working
+tree pollute each other. Before any checkout, confirm the working tree carries no other
+worker's branch changes and no uncommitted *source* changes — operator-owned tracker files or
+untracked local dirs are fine to leave in place (see `agents/pr-review-worker.md`).
+
+Every reviewer loads, at minimum:
+
+```
+/core:git
+/core:mise
+/core:security
+/core:anti-fabrication
+```
+
+plus the stack-specific skills from the classification (for example `/rust:rust`,
+`/rust:testing`, `/rust:error-handling` for Rust; `/core:documentation` for docs;
+`/github:workflows`, `/github:actions` for Actions changes).
+
+## Verify with baseline-diff gates
+
+**THE key insight**: run each gate on `main` FIRST, then on the PR branch. Only a gate that
+was PASSING on `main` and is now FAILING on the branch is a regression worth blocking on.
+
+Gate discipline:
+
+1. Discover the gate tasks (`mise tasks`).
+2. Run each gate on `main`. Capture verbatim output. Record pass/fail.
+3. Check out the PR branch (`git checkout <headRefName>`). Run the same gates. Capture output.
+4. Classify: only gates PASSING on main and FAILING on branch block.
+5. Gates that fail identically on both sides are pre-existing — not regressions. A gate
+   failing on main and passing on the branch means the PR fixed it — note that.
+6. Check out `main` again before the next PR.
+
+Some gates run only on the operator machine (Apple Container clusters, hardware-dependent
+tests) and are skipped by hosted CI. Run those locally under the same baseline-diff
+discipline. See `references/baseline-diff-verification.md` and `/core:container`.
+
+Use `/github:act` to replay hosted CI gates locally when useful.
+
+## Review the diff
+
+Read `git diff main...<headRefName>` against `references/review-rubric.md`: correctness,
+security, test coverage, no leaked secrets, and match to the PR's stated intent. The reviewer
+emits a structured verdict — `approve` or `request-changes` with `file:line` findings and
+verbatim gate evidence. The reviewer never edits code and never merges.
+
+## Merge and close out
+
+Gate before merging:
+
+1. Green on local gates (baseline-diff verified)
+2. Green on remote CI (`gh pr checks` — all checks passing)
+3. Explicit operator go-ahead, per PR
+
+After operator approval:
+
+```bash
+gh pr merge <n> --squash
+```
+
+No attribution in the squash commit message. Confirm closure:
+
+```bash
+gh pr view <n> --json state
+```
+
+Verify `state` is `MERGED`. A `request-changes` PR gets a review comment instead and stays
+open. See `references/merge-and-closeout.md`.
+
+## Delegation
+
+- Read-only PR collection and classification → `agents/pr-collector.md`.
+- Per-PR baseline-diff gates and diff review → `agents/pr-review-worker.md`.
+
+**Stop-and-report gates** (worker halts, does not thrash):
+
+- A gate green on `main` but failing on the branch → STOP, report the gate name and output diff
+- A diff that needs code changes to pass → STOP, report `request-changes` with the failure
+- An ambiguous or contradictory PR intent → STOP, report what is unclear
+
+**Hard constraint**: agents never merge unilaterally. Merge is operator-approved and executed
+by this skill's close-out step.
+
+## Registration
+
+See `references/registration.md` for the marketplace.json, plugin.json, and sources.md edits,
+plus the two validators to run before committing.
+
+## Related skills
+
+- `/core:agent-loop` — the Forge operating model this skill mirrors (collector hands, per-slice principals, operator-owned merge)
+- `/core:anti-fabrication` — never claim a gate passed without showing command output
+- `/core:mise` — discover the repo's gate tasks instead of assuming a toolchain
+- `/core:container` — local integration gates using Apple Container
+- `/github:act` — replay hosted CI gates locally before merge
+- `/github:dependabot-consolidator` — the bot-PR counterpart this skill defers to
+
+## Anti-Fabrication
+
+- Never claim a gate passed without showing the command and its verbatim output.
+- Always run the baseline gate on `main` before blaming a PR for a failure.
+- Confirm PR closure with `gh pr view <n> --json state` — do not assert "it merged."
+- Classify stack from the changed files and manifests, not the PR title alone.
+- When reporting a blocking gate, show the `diff` of main-vs-branch output, not a paraphrase.
+
+See `/core:anti-fabrication` for the full discipline.

--- a/plugins/tools/github/skills/pr-review/agents/pr-collector.md
+++ b/plugins/tools/github/skills/pr-review/agents/pr-collector.md
@@ -1,0 +1,69 @@
+---
+name: pr-collector
+description: Read-only collector for open human-authored PRs. Use when listing and classifying a repo's non-bot pull requests and discovering its gate tasks before per-PR review.
+model: haiku
+tools: Bash, Read, Grep
+---
+
+You are the pr-collector. Your role is to list and classify a repository's open,
+human-authored pull requests and discover the repo's gate tasks, then emit a structured
+report. You make no git mutations.
+
+## Load skills
+
+Invoke each with the Skill tool and quote one sentence from each as proof:
+
+- /core:mise
+- /core:anti-fabrication
+
+## Workflow
+
+1. **Working-tree guard**: run `git status --short` and report it verbatim. The caller needs
+   to know whether the tree is clean before later branch checkouts.
+
+2. **List open PRs**:
+   ```bash
+   gh pr list --state open \
+     --json number,title,author,headRefName,headRefOid,files,additions,deletions,changedFiles
+   ```
+   Drop every entry where `author.is_bot` is true or login is `app/dependabot`. Confirm the
+   kept list contains only human authors. Bot PRs are out of scope.
+
+3. **Classify each PR by stack** from its changed file paths and the repo's manifests. Read
+   the file list (`gh pr view <n> --json files`) — do not infer stack from the title:
+   - `.rs` or `Cargo.toml` → rust
+   - `.ex` / `.exs` or `mix.exs` → elixir
+   - `.zig` or `build.zig` → zig
+   - `.ts` / `.js` or `package.json` → js
+   - `.md` or `docs/` only → documentation
+   - `.github/workflows/` or action/digest pins → gh-actions/security
+   See `../references/stack-detection.md` for the full skill-set mapping.
+
+4. **Discover gate tasks** with `/core:mise`: run `mise tasks` and report the PR-gating tasks
+   that exist (`ci`, `pre-commit`, `test`, `lint`, `fmt:check`, `audit`, `gitleaks`). Paste
+   the verbatim relevant lines.
+
+5. **Emit structured report**, one block per PR:
+   ```
+   PR #<n>: <title>
+     author: <login>
+     headRefName: <branch>
+     headRefOid: <short-sha>
+     stack: rust | elixir | zig | js | documentation | gh-actions/security
+     reviewer skills: /core:git, /core:mise, /core:security, /core:anti-fabrication, <stack skills>
+     size: +<additions>/-<deletions>, <changedFiles> files
+     risk: low | medium | high — <one-line reason>
+   ```
+   Then a `Gate tasks` section and the `git status --short` output.
+
+## Constraints
+
+- Do not run `git` commands that mutate the working tree (no checkout, no branch, no commit).
+- Do not call `gh pr merge`, `gh pr close`, or any write operation.
+- If `gh` is not authenticated or returns an error, report the error verbatim and stop.
+
+## Anti-fabrication
+
+- Show the raw `gh pr list` output before the classified report so the caller can verify.
+- Read the `files` field to classify stack; never guess from the title alone.
+- Report `mise tasks` output verbatim; do not invent task names.

--- a/plugins/tools/github/skills/pr-review/agents/pr-review-worker.md
+++ b/plugins/tools/github/skills/pr-review/agents/pr-review-worker.md
@@ -1,0 +1,104 @@
+---
+name: pr-review-worker
+description: Reviews one human-authored PR by running baseline-diff gates on main vs the branch and reviewing the diff against a rubric, then emits a structured verdict. Use when reviewing a single classified PR after the collector has run. Never edits code, never merges.
+model: sonnet
+tools: Bash, Read, Grep
+---
+
+You are the pr-review-worker. Your role is to review ONE pull request: run the repo's gate
+tasks on `main` and on the PR branch under baseline-diff discipline, review the diff against
+the rubric, and emit a structured verdict. You never edit code, never commit, never merge.
+
+## Load skills
+
+Invoke each with the Skill tool and quote one sentence from each as proof. Always:
+
+- /core:git
+- /core:mise
+- /core:security
+- /core:anti-fabrication
+
+Plus the stack-specific skills named in your dispatch (for example `/rust:rust`,
+`/rust:testing`, `/rust:error-handling`; `/core:documentation`; `/github:workflows`,
+`/github:actions`). See `../references/stack-detection.md`.
+
+## Inputs expected from the caller
+
+- PR number, `headRefName`, `headRefOid`
+- Stack and the reviewer skill list
+- Gate task list (from the collector's `mise tasks` discovery)
+- Main branch name (default: `main`)
+
+## Working-tree note
+
+Operator-owned uncommitted changes (for example a modified tracker file or an untracked
+local dir) are not yours to touch. Do not stash, revert, or commit them. They are harmless
+for build/test. Proceed with branch checkouts for the gate runs.
+
+## Execution order
+
+### 1. Baseline gate on main
+
+```bash
+git checkout main && git pull origin main
+mise run ci 2>&1 | tee /tmp/gate-main-ci.txt
+```
+
+Run each gate task the caller named (add `mise run pre-commit`, `mise run test`, integration
+tasks as instructed). Record PASS/FAIL per gate. Some gates run only on this machine (Apple
+Container clusters, hardware tests) — run them here under the same discipline.
+
+### 2. Check out the PR branch
+
+```bash
+git fetch origin
+git checkout <headRefName>
+```
+
+### 3. Branch gate
+
+```bash
+mise run ci 2>&1 | tee /tmp/gate-branch-ci.txt
+diff /tmp/gate-main-ci.txt /tmp/gate-branch-ci.txt
+```
+
+Run the same gate set as step 1.
+
+### 4. Baseline-diff classify
+
+- PASS on main, FAIL on branch → **regression**. Block. Report the gate name and the `diff`.
+- FAIL on main, FAIL on branch → pre-existing. Not a blocker. Show it on both sides.
+- PASS on main, PASS on branch → clean.
+- FAIL on main, PASS on branch → the PR fixed a pre-existing failure. Note it.
+
+### 5. Review the diff
+
+Read `git diff main...<headRefName>` against `../references/review-rubric.md`: correctness,
+security, test coverage, no leaked secrets, match to the PR's stated intent. Verify claims
+against the real source with Read/Grep — do not assume. For Actions/digest PRs, confirm pins
+are full commit SHAs and digests are correct.
+
+### 6. Return to main
+
+```bash
+git checkout main
+```
+
+## Hard constraints
+
+- **Never** run `gh pr merge`, `gh pr close`, `git commit`, or `git push`.
+- **Never** edit code or test files. You review; you do not fix.
+- Stop and report `request-changes` on a regression or a diff that needs code changes to
+  pass. Do not thrash.
+
+## Report format
+
+```
+PR #<n> REVIEW
+- Verdict: approve | request-changes
+- Baseline gates (main vs branch):
+  <gate>: main=<PASS/FAIL> branch=<PASS/FAIL> -> regression | pre-existing | clean
+- Gate evidence: <verbatim lines proving each result; pre-existing failures shown on both sides>
+- Diff review findings: <file:line + note, or "none">
+- Notes: <anything the operator needs to know before merge>
+```

--- a/plugins/tools/github/skills/pr-review/references/baseline-diff-verification.md
+++ b/plugins/tools/github/skills/pr-review/references/baseline-diff-verification.md
@@ -1,0 +1,65 @@
+# Baseline-Diff Verification
+
+The discipline that prevents blaming a PR for a failure it did not introduce: run every gate
+on `main` FIRST, then on the PR branch, and block only on a NEW failure.
+
+## Why
+
+A repo's `main` often carries pre-existing gate failures — a flaky integration test, a
+hardware-dependent gate that fails off-CI, a lint that was never green. If you run a gate only
+on the PR branch and see red, you cannot tell whether the PR caused it. Running the same gate
+on `main` first gives you the baseline to diff against.
+
+## Procedure
+
+1. **Enumerate gates** with `mise tasks`.
+2. **Run on main**, capturing verbatim output:
+   ```bash
+   git checkout main && git pull origin main
+   mise run ci 2>&1 | tee /tmp/gate-main-ci.txt
+   ```
+   Repeat for each gate the PR needs (`pre-commit`, `test`, integration tasks). Record
+   PASS/FAIL per gate.
+3. **Run on the branch**, same gates:
+   ```bash
+   git fetch origin && git checkout <headRefName>
+   mise run ci 2>&1 | tee /tmp/gate-branch-ci.txt
+   ```
+4. **Diff and classify**:
+   ```bash
+   diff /tmp/gate-main-ci.txt /tmp/gate-branch-ci.txt
+   ```
+
+| main | branch | verdict |
+|------|--------|---------|
+| PASS | FAIL | **regression** — block, report gate name + diff |
+| FAIL | FAIL | pre-existing — not a blocker; show on both sides |
+| PASS | PASS | clean |
+| FAIL | PASS | the PR fixed a pre-existing failure — note it |
+
+5. **Return to main** (`git checkout main`) before the next PR.
+
+## Local-only integration gates
+
+Some gates run only on the operator machine: Apple Container cluster spawns, hardware tests,
+anything hosted CI skips. Run these locally under the same main-then-branch discipline. They
+need exclusive hardware, so review PRs that exercise them **sequentially** — never spawn two
+cluster gates in one working tree at once. See `/core:container`.
+
+## Worked example — kina
+
+kina's hosted CI runs only `cargo fmt --check` + `cargo clippy` (tests need macOS + Apple
+Container and are disabled in the workflow). So the real gate is local:
+
+- `mise run ci` → fmt check → clippy → test
+- `mise run pre-commit` → the above + `cargo audit` + gitleaks
+- `mise run test:cluster` → spawns a real Apple Container cluster (exclusive hardware)
+
+A Rust PR there runs `mise run ci` on `main`, then on the branch, and diffs. If `test:cluster`
+fails identically on both sides it is pre-existing (a known harness issue), not a regression —
+exactly the call made on kina PR #36.
+
+## Anti-fabrication
+
+Never report a gate result without the verbatim command output. When a failure is
+pre-existing, show it failing on BOTH `main` and the branch — a paraphrase is not evidence.

--- a/plugins/tools/github/skills/pr-review/references/merge-and-closeout.md
+++ b/plugins/tools/github/skills/pr-review/references/merge-and-closeout.md
@@ -1,0 +1,44 @@
+# Merge and Close Out
+
+The operator-owned merge gate and the close-out steps. Agents never merge — this step runs in
+the supervised loop after a reviewer returns `approve` and the operator gives the go-ahead.
+
+## Pre-merge gate
+
+All three must hold before merging a PR:
+
+1. **Local gates green** — baseline-diff verified (gates run on `main` first), no regression.
+2. **Remote CI green** — `gh pr checks <n>` shows all checks passing.
+3. **Operator go-ahead** — explicit, per PR. Approval of one PR is not approval of the next.
+
+## Merge
+
+```bash
+gh pr merge <n> --squash
+```
+
+Squash merge only. No attribution and no `Co-Authored-By` in the squash commit message.
+
+## Confirm closure
+
+Do not assume the merge succeeded — a merge step can report failure after GitHub already
+merged, and vice versa. Confirm:
+
+```bash
+gh pr view <n> --json state,mergedAt
+```
+
+Verify `state` is `MERGED`. If a merge command errored but `state` is `MERGED`, the merge
+happened — proceed. If `state` is still `OPEN`, the merge did not happen — investigate.
+
+## request-changes path
+
+A PR the reviewer flagged `request-changes` is not merged. Post a review comment summarizing
+the blocking findings and leave the PR open for the author. Keep the comment terse and
+specific — list the `file:line` blockers and the gate evidence, no filler. The author pushes
+fixes; re-review from the baseline-diff step.
+
+## Out of scope
+
+Bot dependency PRs (`app/dependabot`) are not merged by this skill. Route them to
+`/github:dependabot-consolidator`.

--- a/plugins/tools/github/skills/pr-review/references/registration.md
+++ b/plugins/tools/github/skills/pr-review/references/registration.md
@@ -1,0 +1,56 @@
+# Registration
+
+How this skill is registered in the marketplace and the validators to run.
+
+## Files involved in registration
+
+Three files must be updated when adding or updating this skill:
+
+1. **marketplace.json** (repo root `.claude-plugin/marketplace.json`): the `github` plugin
+   entry. Bump `version`; extend `description` to mention PR review; add `"pr-review"`,
+   `"code-review"`, and `"collaborator"` to `keywords`.
+
+2. **plugin.json** (`plugins/tools/github/.claude-plugin/plugin.json`): the github plugin
+   manifest. Bump `version`; add `"./skills/pr-review"` to `skills[]`; add the two agent
+   files to the top-level `agents[]` array.
+
+3. **sources.md** (`plugins/tools/github/skills/sources.md`): add a `## PR Review` section.
+   The validator (check `source`) requires the skill directory name or frontmatter name to
+   appear here.
+
+## Two validators to run
+
+After every change to skill files or registration:
+
+```bash
+# Validate the github plugin structure
+nu test/validate-plugin.nu github
+
+# Validate skill quality across all plugins
+nu test/validate-skills-quality.nu
+```
+
+Both must pass (no new failures beyond the baseline) before committing.
+
+## Build checklist
+
+- [ ] `name:` in SKILL.md frontmatter equals the directory name `pr-review`
+- [ ] No `allowed-tools:` in SKILL.md frontmatter
+- [ ] `description:` contains "Use when", is ≤1024 chars, uses third person
+- [ ] SKILL.md body is ≤500 lines
+- [ ] Every reference and agent file basename is mentioned in SKILL.md body
+- [ ] Every path written in prose (e.g., `agents/pr-collector.md`) exists on disk
+- [ ] No cross-skill invocation (`/plugin:skill`) that does not resolve to a real local skill
+- [ ] Agent files use `tools:` as a comma-separated string, not a YAML list
+- [ ] `model:` in each agent is one of `haiku`, `sonnet`, `opus`
+- [ ] `sources.md` contains `pr-review` (or the frontmatter name)
+- [ ] `nu test/validate-plugin.nu github` passes
+- [ ] `nu test/validate-skills-quality.nu` passes with no new failures
+
+## Version bump policy
+
+- Skill-only changes (no new skills added): increment the patch segment of `version` in
+  plugin.json and marketplace.json.
+- New skill added: increment the minor segment (this skill: 0.2.0 → 0.3.0).
+- Breaking change to an existing skill interface: increment the minor segment and document in
+  sources.md.

--- a/plugins/tools/github/skills/pr-review/references/review-rubric.md
+++ b/plugins/tools/github/skills/pr-review/references/review-rubric.md
@@ -1,0 +1,52 @@
+# Review Rubric and Verdict Format
+
+What the per-PR reviewer checks, and the structured verdict it returns. The reviewer reads
+`git diff main...<headRefName>` and verifies claims against the real source — it never edits
+code and never merges.
+
+## Rubric
+
+Check each dimension against the diff and the surrounding code:
+
+- **Correctness** — the change does what the PR says; edge cases and error paths are handled;
+  no obvious logic inversion, off-by-one, or dropped result. For the diff's language, apply
+  the loaded stack skill (idiomatic error handling, ownership, async safety, etc.).
+- **Security** — no leaked secrets, no command injection, no unsafe deserialization, no
+  loosened permissions. For Actions/supply-chain PRs, confirm every action is pinned to a
+  full commit SHA (not a moving tag) and every image is pinned to a digest; verify the pin
+  resolves to the claimed version.
+- **Tests** — behavior changes carry tests; the diff does not delete or weaken coverage
+  without cause; tests assert the new behavior, not a tautology.
+- **No secrets** — corroborate with the repo's secret scanner (`mise run gitleaks` or
+  equivalent) under the baseline-diff discipline.
+- **Intent match** — the diff matches its title and description; no unrelated drive-by
+  changes smuggled in; docs claims match the code they describe.
+- **Scope and size** — the change is reviewable; unexpectedly large or cross-cutting diffs
+  get called out for the operator.
+
+## Findings
+
+Report each finding as `file:line — <what and why>`, ordered by severity. Distinguish:
+
+- **Blocking** — correctness or security defect, or a gate regression. Drives
+  `request-changes`.
+- **Non-blocking** — style, naming, a suggested simplification. Note it; does not block.
+
+## Verdict format
+
+```
+PR #<n> REVIEW
+- Verdict: approve | request-changes
+- Baseline gates (main vs branch):
+  <gate>: main=<PASS/FAIL> branch=<PASS/FAIL> -> regression | pre-existing | clean
+- Gate evidence: <verbatim lines; pre-existing failures shown on both sides>
+- Diff review findings:
+  - <file:line — blocking — note>
+  - <file:line — non-blocking — note>
+  (or "none")
+- Notes: <anything the operator needs to know before merge>
+```
+
+`approve` requires: every gate clean or pre-existing (no regression) AND no blocking finding.
+Anything else is `request-changes`. The reviewer presents the verdict; the operator decides
+the merge.

--- a/plugins/tools/github/skills/pr-review/references/stack-detection.md
+++ b/plugins/tools/github/skills/pr-review/references/stack-detection.md
@@ -1,0 +1,55 @@
+# Stack Detection and Gate Discovery
+
+How to classify a PR's stack and discover the repo's gate tasks, so the reviewer loads the
+right skills and runs the right gates — on any repo, not just Rust.
+
+## Stack classification
+
+Read the PR's changed file paths (`gh pr view <n> --json files`) and the repo's manifests.
+Classify from the files, never the title. A PR touching more than one stack loads the union
+of skill sets.
+
+| Signal (extensions / manifest) | Stack | Reviewer skills (beyond the always-load set) |
+|--------------------------------|-------|----------------------------------------------|
+| `.rs`, `Cargo.toml`, `Cargo.lock` | rust | `/rust:rust`, `/rust:testing`, `/rust:error-handling` (add `/rust:async`, `/rust:ownership` for concurrency/lifetime-heavy diffs) |
+| `.ex`, `.exs`, `mix.exs`, `mix.lock` | elixir | `/elixir:phoenix`, `/elixir:testing`, `/elixir:style`, `/elixir:ecto`, `/elixir:otp` (pick by what the diff touches) |
+| `.zig`, `build.zig` | zig | `/zig:zig`, `/zig:testing`, `/zig:build` |
+| `.ts`, `.js`, `package.json` | js | (no language skill in this marketplace — review with the always-load set; add `/ui:daisyui` for UI work) |
+| `.md`, `docs/` only | documentation | `/core:documentation` |
+| `.github/workflows/`, action pins, image digests | gh-actions/security | `/github:workflows`, `/github:actions`, `/core:security` |
+
+Always-load set (every reviewer, every PR): `/core:git`, `/core:mise`, `/core:security`,
+`/core:anti-fabrication`.
+
+## Gate discovery via /core:mise
+
+Discover the repo's own gate tasks instead of assuming a toolchain. Run `mise tasks` and pick
+the PR-gating tasks that exist:
+
+| Task name | Typical contents |
+|-----------|------------------|
+| `ci` | the canonical gate (format check, lint, test) |
+| `pre-commit` | `ci` plus security (audit, secret scan) |
+| `test` | unit + integration tests |
+| `lint` | linter (clippy, credo, etc.) |
+| `fmt:check` | formatter in check mode |
+| `audit` | dependency vulnerability audit |
+| `gitleaks` | secret scanner |
+
+Run `mise run <task>` for the discovered tasks. A haiku agent handles this discovery — the
+task list is structured data from one command.
+
+### When the repo has no mise
+
+Fall back to the language-native gate the manifest implies (`cargo test`/`cargo clippy`,
+`mix test`/`mix credo`, `zig build test`, `npm test`). The baseline-diff discipline is
+identical regardless of the runner.
+
+## Hosted CI vs local gates
+
+Hosted CI sometimes runs a subset (for example, only format + lint) because the full suite
+needs hardware the runner lacks — macOS, Apple Container, a GPU. In that case the **local**
+`mise run ci` / `mise run pre-commit` is the real gate. Run the full local set under the
+baseline-diff discipline — gate on `main` first, then the branch, blocking only on a new
+failure. kina is exactly this shape: its
+hosted CI runs `fmt`+`clippy` only; integration tests run locally against Apple Container.

--- a/plugins/tools/github/skills/sources.md
+++ b/plugins/tools/github/skills/sources.md
@@ -198,6 +198,25 @@ This file documents all sources used to create the skills in this plugin.
   - `git check-ignore Cargo.lock` needed before deciding whether to update the lockfile
   - Dependabot does not always auto-close superseded PRs; verify with `gh pr view`
 
+## PR Review (pr-review)
+
+### GitHub CLI — pull request commands
+- **URL**: https://cli.github.com/manual/gh_pr
+- **Purpose**: `gh pr list`, `gh pr view`, `gh pr checks`, `gh pr merge` — the API surface this skill drives for listing, inspecting, gating, and squash-merging PRs
+- **Key Topics**:
+  - `gh pr list --json author,headRefName,headRefOid,files` for collection and stack classification
+  - filtering bots via `author.is_bot` / `app/dependabot` (defers to dependabot-consolidator)
+  - `gh pr merge <n> --squash` and confirming `state` via `gh pr view --json state,mergedAt`
+
+### Recipe Origin
+- **Source**: kina (github.com/vinnie357/kina) external-collaborator PRs #37/#38/#39
+- **Purpose**: Proved the per-PR stack-aware review with local baseline-diff gates
+- **Key Learnings**:
+  - Hosted CI ran only `fmt`+`clippy`; the real gate was local `mise run ci` / `pre-commit`
+  - Stack discovered from changed files + manifests; gates discovered via `mise tasks`
+  - Reviewers run sequentially when integration gates need exclusive hardware (Apple Container)
+  - Mirrors the Forge operating model (`/core:agent-loop`): collector hands, per-PR principals, operator-owned merge
+
 ## Community Health Files
 
 ### Setting Up Your Project for Healthy Contributions


### PR DESCRIPTION
## What

Adds `/github:pr-review` — a repo-agnostic skill for reviewing open human-authored PRs one at a time, building/testing each branch locally under baseline-diff gates, and squash-merging on operator approval. Modeled on `/github:dependabot-consolidator` and the Forge operating model (`/core:agent-loop`).

## Triad

- **SKILL.md** — `/github:pr-review`
- **agents/pr-collector.md** (haiku, read-only) — lists non-bot PRs, classifies stack via manifests + extensions, discovers gates via `mise tasks`
- **agents/pr-review-worker.md** (sonnet) — per-PR baseline-diff gates + diff review + structured verdict; never edits, never merges
- **references/** — stack-detection, baseline-diff-verification, review-rubric, merge-and-closeout, registration

## Design notes

- Repo-agnostic: stack from `Cargo.toml`/`mix.exs`/`build.zig`/`package.json` + file extensions; gates discovered via `/core:mise`, never hardcoding cargo
- Baseline-diff discipline: run gates on `main` first, block only on a NEW failure
- Forge-care parallels: read-only collector hands, per-PR reviewer principals, adversarial separation, operator-owned merge
- Bot PRs are out of scope — they defer to `/github:dependabot-consolidator`

## Validation

- `nu test/validate-plugin.nu github` → 0 errors / 0 warnings
- `nu test/validate-skills-quality.nu` → pr-review 17/17, no new baseline failures
- Opus Forge review pass applied (working-tree rule scoped, ref→ref pointers inlined, zero hedging verbs, full baseline-diff matrix)

## Provenance

Built and dogfooded reviewing kina external-collaborator PRs #37/#38/#39.