### PR TITLE
fix(github): stop dependabot-consolidator-worker leaking a foreign tracker id into PR bodies

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -99,7 +99,7 @@
       "source": "./plugins/tools/github",
       "strict": true,
       "description": "GitHub Actions, Workflows, act local testing, community health files, Dependabot consolidation, and PR review",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "category": "tools",
       "keywords": ["github", "actions", "workflows", "ci-cd", "act", "testing", "community-health", "open-source", "dependabot", "dependencies", "pr-review", "code-review", "collaborator"]
     },

--- a/plugins/tools/github/.claude-plugin/plugin.json
+++ b/plugins/tools/github/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "GitHub Actions, Workflows, act local testing, community health files, Dependabot consolidation, and PR review",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/github/skills/dependabot-consolidator/agents/dependabot-consolidator-worker.md
+++ b/plugins/tools/github/skills/dependabot-consolidator/agents/dependabot-consolidator-worker.md
@@ -76,11 +76,13 @@ gh pr create --draft --title "chore(deps): consolidated dependabot updates" \
 ## Baseline-diff verification
 
 <paste gate comparison table>
-
-Closes claude-skills-76
 EOF
 )"
 ```
+
+Do NOT hardcode a `Closes #N` / `Closes <tracker>-N` line in the body. Add a closing
+reference ONLY if the CALLER gave you an issue in THIS repo to close — never carry a tracker
+ID from another repo (e.g. a `claude-skills-NN` bee) into the target repo's PR.
 
 ### Hard constraints
 


### PR DESCRIPTION
## Problem

The `dependabot-consolidator-worker` agent's example `gh pr create` body hardcoded `Closes claude-skills-76` (the bees issue for building the consolidator skill itself). The worker copied that boilerplate verbatim into every consolidation PR — kina PR #44 ended up with a `Closes claude-skills-76` line that references nothing in kina.

## Fix

- Remove the hardcoded `Closes claude-skills-76` from the example PR body.
- Instruct the worker to add a `Closes` reference only for an issue in the **target** repo given by the caller, and never to carry a tracker id from another repo.

## Verification

- `nu test/validate-plugin.nu github` → 0 errors / 0 warnings.