### PR TITLE
docs(claude-code): point claude-statusline skill at ccstatusline prebuilt tool

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -63,7 +63,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills: plugin marketplace management and validation",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "category": "tools",
       "keywords": ["claude-code", "marketplace", "validation", "teams", "benchmark", "skill-update", "output-styles", "statusline", "workflows"]
     },

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/claude-statusline/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-statusline/SKILL.md
@@ -48,6 +48,16 @@ Fields:
 
 Claude Code ships a built-in `/statusline <description>` command that generates a script and updates settings for you (e.g. `/statusline show model name and context percentage with a progress bar`). Use `/statusline delete` to remove the configuration.
 
+## Prebuilt status-line tools
+
+Writing a script gives full control with zero dependencies. For a turnkey bar without scripting, community tools render the same stdin payload. The most widely used is **ccstatusline** (`sirmalloc/ccstatusline`, MIT) — a Node CLI with an interactive config TUI, powerline themes, gradients, Nerd-Font icons, and widgets for token speed, git PR status, block timers, and more. It needs no install and wires itself into `settings.json`:
+
+```json
+{ "statusLine": { "type": "command", "command": "npx -y ccstatusline@latest" } }
+```
+
+It requires Node/Bun on `PATH` and runs `npx` on each update (slower cold-start than a local script). The rest of this skill covers the hand-rolled path, which stays the right choice when you want no runtime dependency, deterministic latency, or behavior the tool does not expose.
+
 ## Stdin JSON Payload
 
 Every invocation receives a JSON object on stdin containing session metadata. Key top-level fields:

--- a/plugins/tools/claude-code/skills/sources.md
+++ b/plugins/tools/claude-code/skills/sources.md
@@ -257,6 +257,13 @@ This file documents the sources used to create the claude-code plugin skills.
   - Trust gate + `disableAllHooks` shared with hooks
 - **Used In**: skills/claude-statusline/SKILL.md, skills/claude-statusline/references/input-schema.md
 
+### ccstatusline (community tool reference)
+- **URL**: https://github.com/sirmalloc/ccstatusline
+- **Purpose**: Prebuilt npx-run statusline formatter cited as the turnkey alternative to a hand-rolled script
+- **Date Accessed**: 2026-06-26
+- **Key Topics**: `npx -y ccstatusline@latest` integration into the `statusLine` settings block; powerline/theme/Nerd-Font widget rendering of the same stdin payload our skill documents
+- **Used In**: skills/claude-statusline/SKILL.md
+
 ## Claude Workflows Skill
 
 ### Claude Code Workflows Documentation


### PR DESCRIPTION
- Add "Prebuilt status-line tools" section to claude-statusline SKILL.md pointing at ccstatusline (sirmalloc/ccstatusline) as the turnkey alternative to a hand-rolled script
- Keep the DIY guide as the documented default; note the trade-off (no runtime dependency, deterministic latency)
- Add ccstatusline as a community-tool reference in sources.md
- Bump claude-code plugin 0.2.8 -> 0.2.9 (plugin.json + marketplace.json)