### PR TITLE
chore(all-skills): sync pr-review skill into meta-plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.30",
+      "version": "0.4.31",
       "category": "meta",
       "keywords": ["all", "complete", "bundle"],
       "license": "MIT"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -70,6 +70,7 @@
     "./plugins/tools/github/skills/act",
     "./plugins/tools/github/skills/community-health",
     "./plugins/tools/github/skills/dependabot-consolidator",
+    "./plugins/tools/github/skills/pr-review",
     "./plugins/tools/graphify/skills/graphify",
     "./plugins/tools/graphify/skills/graphify-agents",
     "./plugins/tools/agent-sandboxing/skills/sandbox",


### PR DESCRIPTION
- Add the github pr-review skill path to the all-skills meta-plugin (drift from an earlier merged PR that did not run update-all-skills)
- Bump all-skills 0.4.30 -> 0.4.31 (plugin.json + marketplace.json)