### PR TITLE
feat(skills): epic-sizing heuristics + dependency ordering

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -128,7 +128,7 @@
       "source": "./plugins/tools/linear",
       "strict": true,
       "description": "Linear project management: MCP/GraphQL API, VantageEx epic authoring, auditing, and grooming",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "category": "tools",
       "keywords": ["linear", "project-management", "epics", "graphql", "vantageex", "mcp"],
       "license": "MIT"

--- a/docs/vantageex-conventions.md
+++ b/docs/vantageex-conventions.md
@@ -1,0 +1,89 @@
+# VantageEx Project Conventions
+
+Project-specific conventions for the VantageEx codebase. These conventions apply to agents working on VantageEx epics and are **not** part of the universal `/linear:plan-epic` or `/linear:audit-epics` skills.
+
+## vantage_ex Read-Only Docs Adjunct
+
+### When to Include
+
+Include the `vantage_ex` repository as a docs adjunct **only when the epic's work touches the VantageEx codebase**. Epics scoped entirely to other repositories do not require it.
+
+Indicators that an epic touches VantageEx:
+
+- The epic description references VantageEx features, services, or infrastructure components
+- Issues target files in the `vantage_ex` repo
+- The work must align with existing VantageEx architecture decisions (ADRs)
+
+### Read-Only Constraint
+
+The `vantage_ex` adjunct repo is **reference material only**.
+
+- **Never edit, commit, or push** inside `vantage_ex`
+- Do not create branches, stage files, or run `git add`/`git commit`/`git push` within it
+- If a grep or read reveals something that needs to change in VantageEx itself, surface it as a separate issue — do not act on it in-place
+
+### Purpose
+
+Agents grep and read ADRs and design docs in `vantage_ex` while implementing, to align implementation decisions with existing VantageEx architecture. This prevents drift from established patterns for things like:
+
+- Secret management (ADR 008, ADR 026)
+- Execution and deployment models (ADR 030, ADR 035, ADR 071)
+- Multi-repo workspace conventions (ADR 043, ADR 095)
+- Bundle and source resolution (ADR 029, ADR 045, ADR 056, ADR 081)
+
+### Workspace Layout
+
+The `vantage_ex` repo appears as a **sibling clone** alongside the primary working repo in the agent workspace:
+
+```
+<workspace>/
+├── claude-skills/        # primary repo being modified
+└── vantage_ex/           # read-only adjunct (clone separately, do not modify)
+```
+
+To clone into position:
+
+```bash
+git clone <vantage_ex-remote> <workspace>/vantage_ex
+```
+
+### Where to Find ADRs and Design Docs
+
+**Architecture Decision Records (ADRs):**
+
+```
+vantage_ex/architecture/decisions/
+```
+
+Files follow the pattern `NNN-kebab-title.md` (e.g., `043-multi-repo-workspace-layout-convention.md`). As of the time this document was written, 95 ADRs exist (001 through 095). Always grep for relevant keywords rather than guessing numbers.
+
+**Design docs and conventions:**
+
+```
+vantage_ex/docs/
+```
+
+Notable subdirectories:
+
+- `docs/conventions/` — authoring conventions and patterns
+- `docs/audit/` — audit records
+- `docs/research/` — research notes
+
+Individual design docs in `docs/` include `loop-architecture.md`, `team-shapes.md`, `when-to-use-teams.md`, `bundle-authoring-conventions.md`, and others. Grep for relevant topics.
+
+### Recommended Grep Patterns
+
+Before implementing a feature that touches VantageEx conventions, run:
+
+```bash
+# Search ADRs for relevant patterns
+grep -rl "<keyword>" vantage_ex/architecture/decisions/
+
+# Search design docs
+grep -rl "<keyword>" vantage_ex/docs/
+
+# Read a specific ADR
+cat vantage_ex/architecture/decisions/<NNN>-<title>.md
+```
+
+Replace `<keyword>` with terms specific to the work at hand (e.g., `bundle`, `secrets`, `deployment`, `workspace`).

--- a/plugins/tools/linear/.claude-plugin/plugin.json
+++ b/plugins/tools/linear/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "linear",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Linear project management: MCP/GraphQL API, VantageEx epic authoring, auditing, and grooming",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/linear/commands/audit-epics.md
+++ b/plugins/tools/linear/commands/audit-epics.md
@@ -64,22 +64,7 @@ See `references/epic-sizing.md` for conventions.
 - Flag dependency cycles — halt: re-decompose required before queueing
 - Flag dependency chains deeper than 5 levels — serializes workers unnecessarily
 - Flag independent issues that are serialized without cause — reduces worker fan-out
-
-### Content Quality Checks
-- Check for implementation details (file paths, code blocks outside YAML)
-- Check that constraints are meaningful (not just defaults)
-
-### Epic Sizing Checks
-Run the sizing checks from the audit checklist (`references/audit-checklist.md`):
-- Count child issues in Linear; flag if the count exceeds the sizing convention (see "Epic Sizing Heuristics" in `references/epic-format.md`)
-- Flag if `## Repos` lists three or more repositories with large cross-cutting scope
-
-### Dependency Ordering Checks
-Run the dependency ordering checks from the audit checklist (`references/audit-checklist.md`):
-- Fetch child issues and their `blockedBy` edges from Linear
-- Flag if two or more issues exist but no dependency edges are declared
-- Detect and report dependency cycles; mark as error and halt if any cycle is found
-- Flag if a DAG source issue is itself marked `blockedBy` another issue
+- Flag a DAG source issue that is itself marked `blockedBy` another issue — inconsistent foundational ordering
 
 ## Generate Report
 

--- a/plugins/tools/linear/commands/audit-epics.md
+++ b/plugins/tools/linear/commands/audit-epics.md
@@ -50,6 +50,18 @@ For each issue, run every check from the audit checklist:
 - Check for implementation details (file paths, code blocks outside YAML)
 - Check that constraints are meaningful (not just defaults)
 
+### Epic Sizing Checks
+Run the sizing checks from the audit checklist (`references/audit-checklist.md`):
+- Count child issues in Linear; flag if the count exceeds the sizing convention (see "Epic Sizing Heuristics" in `references/epic-format.md`)
+- Flag if `## Repos` lists three or more repositories with large cross-cutting scope
+
+### Dependency Ordering Checks
+Run the dependency ordering checks from the audit checklist (`references/audit-checklist.md`):
+- Fetch child issues and their `blockedBy` edges from Linear
+- Flag if two or more issues exist but no dependency edges are declared
+- Detect and report dependency cycles; mark as error and halt if any cycle is found
+- Flag if a DAG source issue is itself marked `blockedBy` another issue
+
 ## Generate Report
 
 Use the `templates/0.1.0/audit-report.md` format:

--- a/plugins/tools/linear/commands/audit-epics.md
+++ b/plugins/tools/linear/commands/audit-epics.md
@@ -46,6 +46,25 @@ For each issue, run every check from the audit checklist:
 - For needs_help issues: check for blocker documentation
 - Use `gh pr list` and `gh pr view` to cross-reference PR URLs
 
+### Epic-Sizing Checks
+
+See `references/epic-sizing.md` for thresholds.
+
+- Flag epics with > 8 issues — signal to split the epic
+- Flag issues with > ~10 target files — exceeds one worker session
+- Flag multi-deliverable issue titles (joined by "and", "also", "then", "plus") — split them
+- Flag acceptance criteria that cannot be verified in a single worker session
+- Flag issues with cross-subsystem or cross-repo scope — split candidates
+
+### Dependency-Ordering Checks
+
+See `references/epic-sizing.md` for conventions.
+
+- Flag issues with implicit or missing dependency declarations (no blocking relations / bees deps)
+- Flag dependency cycles — halt: re-decompose required before queueing
+- Flag dependency chains deeper than 5 levels — serializes workers unnecessarily
+- Flag independent issues that are serialized without cause — reduces worker fan-out
+
 ### Content Quality Checks
 - Check for implementation details (file paths, code blocks outside YAML)
 - Check that constraints are meaningful (not just defaults)

--- a/plugins/tools/linear/commands/plan-epic.md
+++ b/plugins/tools/linear/commands/plan-epic.md
@@ -33,6 +33,8 @@ Before creating:
 - Confirm slug is kebab-case and under 30 chars
 - Confirm at least one repo is specified
 - Confirm the body is self-contained: no local-filesystem paths (`~/.claude/...`, `/Users/<name>/...`) used as the source of truth. Embed design plans inline under a `## Design context` section, or link to other epics by Linear URL.
+- **Sizing check**: confirm the objective's scope can decompose into approximately 6–8 independently-shippable issues (the adopted sizing convention; see "Epic Sizing Heuristics" in `references/epic-format.md`). If the scope appears to require significantly more issues, spans many repositories with large cross-cutting changes, or contains work that could be separately delivered, prompt the user to consider splitting into multiple epics.
+- **Dependency-ordering check**: confirm that the anticipated issues can be ordered topologically (foundational work first, no cycles). If the user has described ordering intent, include a `## Dependencies` section in the epic body; see "Dependency Ordering" in `references/epic-format.md` for format and rules.
 
 ## Body Format Rules
 
@@ -44,6 +46,8 @@ Apply the format rules from the `/linear` skill's "Epic Body Format Rules" secti
 - Bodies are self-contained: embed design context inline, cross-link other epics by Linear URL, never reference local-filesystem paths.
 
 See `plugins/tools/linear/skills/linear/SKILL.md` "Epic Body Format Rules" for the canonical wording.
+
+When the epic's anticipated issue ordering is known, include a `## Dependencies` section in the produced body declaring which issues depend on which others, with foundational issues listed first. The team leader translates this into formal `blockedBy` edges in Linear during decomposition. See "Dependency Ordering" in `references/epic-format.md` for format and rules.
 
 ## Create in Linear
 

--- a/plugins/tools/linear/commands/plan-epic.md
+++ b/plugins/tools/linear/commands/plan-epic.md
@@ -23,6 +23,18 @@ Interactively collect from the user:
 - **Constraints**: Optional. Note that defaults apply (mise run ci, no attribution, squash merge, feature/<slug>)
 - **Team**: Optional. Default: lead=sonnet, default_model=haiku, escalation=haiku->sonnet->opus
 
+## Size & Order
+
+Apply `references/epic-sizing.md` to the issues you intend to create:
+
+- **Decompose** the epic into 3–8 independently completable issues. If the count would exceed 8, split the epic.
+- **Size each issue** to one worker session: ≤ ~10 target files, one deliverable, one subsystem, verifiable by a single acceptance check. Reject multi-deliverable titles (joined by "and/also/then/plus") — split them.
+- **Declare dependencies explicitly** using Linear blocking relations. Never rely on implicit ordering.
+- **Order topologically**: foundation issues (schemas, references, interfaces) first, then core, integration, and verification. No cycles — if a cycle is detected, re-decompose before proceeding.
+- **Keep chains shallow**: dependency depth < 5 levels; do not serialize issues that can run in parallel.
+
+See `references/epic-sizing.md` for thresholds and the full checklist.
+
 ## Validate
 
 Before creating:

--- a/plugins/tools/linear/skills/linear/SKILL.md
+++ b/plugins/tools/linear/skills/linear/SKILL.md
@@ -299,6 +299,7 @@ For the full state machine and cross-system mapping, read `references/workflow-s
 | `references/graphql-api.md` | Full GraphQL query catalog |
 | `references/epic-format.md` | VantageEx epic specification |
 | `references/audit-checklist.md` | Epic validation checks |
+| `references/epic-sizing.md` | Epic sizing heuristics and dependency-ordering conventions |
 | `references/workflow-states.md` | State machine and cross-system mapping |
 
 ## Templates

--- a/plugins/tools/linear/skills/linear/references/audit-checklist.md
+++ b/plugins/tools/linear/skills/linear/references/audit-checklist.md
@@ -117,7 +117,7 @@ Structured validation checks for VantageEx epic compatibility. Each check has a 
 
 ## Epic-Sizing Checks
 
-See `references/epic-sizing.md` for full heuristics and thresholds.
+See `epic-sizing.md` for full heuristics and thresholds.
 
 ### Issue Count
 - **Severity**: warning
@@ -141,7 +141,7 @@ See `references/epic-sizing.md` for full heuristics and thresholds.
 
 ## Dependency-Ordering Checks
 
-See `references/epic-sizing.md` for full conventions.
+See `epic-sizing.md` for full conventions.
 
 ### Explicit Dependencies
 - **Severity**: error

--- a/plugins/tools/linear/skills/linear/references/audit-checklist.md
+++ b/plugins/tools/linear/skills/linear/references/audit-checklist.md
@@ -115,6 +115,35 @@ Structured validation checks for VantageEx epic compatibility. Each check has a 
 - **Check**: Constraints section (if present) contains meaningful boundaries, not just defaults
 - **Remediation**: Remove constraint section if it only restates defaults (mise run ci, no attribution, squash merge)
 
+## Epic Sizing Checks
+
+### Epic Not Oversized
+- **Severity**: warning
+- **Check**: If the epic has child issues in Linear, count them. Flag if the count exceeds the sizing convention (target: approximately 6–8 issues per epic — an adopted convention, not a measured limit). See the "Epic Sizing Heuristics" section of the epic format specification.
+- **Remediation**: Split the epic into multiple epics, each covering a smaller independently-deliverable scope.
+
+### No Multi-Repo Sprawl
+- **Severity**: warning
+- **Check**: If the `## Repos` section lists three or more repositories and the objective describes large cross-cutting changes affecting all of them, flag as a potential oversized epic.
+- **Remediation**: Consider splitting into repo-scoped epics, each targeting one or two repositories, linked by Linear URL.
+
+## Dependency Ordering Checks
+
+### Dependencies Declared
+- **Severity**: warning
+- **Check**: If the epic has two or more child issues in Linear, verify that at least one `blockedBy` dependency edge exists among them. If no dependency edges are declared and the issues are not logically independent of each other, flag as missing dependency ordering.
+- **Remediation**: Declare `blockedBy` edges in Linear to establish execution order. The epic body's `## Dependencies` section (if present) should guide this. See "Dependency Ordering" in the epic format specification.
+
+### No Dependency Cycles
+- **Severity**: error
+- **Check**: Verify that the dependency edges among the epic's child issues form a valid DAG (no cycles). A cycle exists when issue A directly or transitively depends on itself.
+- **Remediation**: Halt. Remove the cycle by eliminating one or more dependency edges and, if needed, restructuring the issue decomposition.
+
+### Foundational Work First
+- **Severity**: info
+- **Check**: Verify that issues with no incoming dependencies (DAG sources) are not themselves marked as `blockedBy` another issue. A source issue that is also blocked indicates an inconsistent dependency declaration.
+- **Remediation**: Review and correct `blockedBy` edges to ensure foundational work is unblocked and can start immediately.
+
 ## Running an Audit
 
 1. Fetch issues from Linear (by project, state, or specific key)

--- a/plugins/tools/linear/skills/linear/references/audit-checklist.md
+++ b/plugins/tools/linear/skills/linear/references/audit-checklist.md
@@ -115,6 +115,59 @@ Structured validation checks for VantageEx epic compatibility. Each check has a 
 - **Check**: Constraints section (if present) contains meaningful boundaries, not just defaults
 - **Remediation**: Remove constraint section if it only restates defaults (mise run ci, no attribution, squash merge)
 
+## Epic-Sizing Checks
+
+See `references/epic-sizing.md` for full heuristics and thresholds.
+
+### Issue Count
+- **Severity**: warning
+- **Check**: Epic has 3–8 issues. Flag if > 8.
+- **Remediation**: Split the epic into two or more independent epics
+
+### Issue Scope
+- **Severity**: warning
+- **Check**: No issue targets > ~10 files; each has one deliverable; each is scoped to one subsystem/repo
+- **Remediation**: Split oversized issues; remove multi-deliverable titles (joined by "and/also/then/plus")
+
+### Acceptance Verifiability
+- **Severity**: warning
+- **Check**: Each issue's acceptance criteria can be verified in a single worker session
+- **Remediation**: Narrow acceptance scope or split the issue
+
+### No Cross-Subsystem Scope
+- **Severity**: info
+- **Check**: No single issue touches multiple subsystems or repos without an explicit split rationale
+- **Remediation**: Split into per-subsystem issues with explicit dependency declarations
+
+## Dependency-Ordering Checks
+
+See `references/epic-sizing.md` for full conventions.
+
+### Explicit Dependencies
+- **Severity**: error
+- **Check**: Every inter-issue dependency is declared via Linear blocking relations or bees `dep add`; none are implicit
+- **Remediation**: Add blocking relations for all known dependencies; never rely on arrival order
+
+### No Cycles
+- **Severity**: error
+- **Check**: The dependency graph has no cycles
+- **Remediation**: Extract the shared artifact into a new foundation issue; re-declare dependencies
+
+### Topological Order
+- **Severity**: warning
+- **Check**: Foundation issues (schemas, references, interfaces) precede their consumers; issues materialize foundation → core → integration → verification
+- **Remediation**: Reorder issues and add missing blocking relations to reflect topological order
+
+### Chain Depth
+- **Severity**: warning
+- **Check**: No dependency chain exceeds 5 levels from root to leaf
+- **Remediation**: Flatten chains by merging lightweight intermediate issues or parallelizing work
+
+### No False Dependencies
+- **Severity**: info
+- **Check**: Independent issues are not serialized unnecessarily
+- **Remediation**: Remove blocking relations between issues that have no real dependency; let workers fan out
+
 ## Running an Audit
 
 1. Fetch issues from Linear (by project, state, or specific key)

--- a/plugins/tools/linear/skills/linear/references/epic-format.md
+++ b/plugins/tools/linear/skills/linear/references/epic-format.md
@@ -9,6 +9,8 @@
 - [Title and Slug](#title-and-slug)
 - [Description Sections](#description-sections)
 - [Instructions Flow](#instructions-flow)
+- [Epic Sizing Heuristics](#epic-sizing-heuristics)
+- [Dependency Ordering](#dependency-ordering)
 - [Anti-Patterns](#anti-patterns)
 - [Example Epic](#example-epic)
 
@@ -145,6 +147,24 @@ Example:
 claude, local
 ```
 
+### `## Dependencies` (Optional)
+
+Declares the intended dependency ordering among the issues this epic will decompose into. The team leader uses this section when creating issues in Linear to record formal `blockedBy` edges.
+
+Format: plain prose or a bullet list describing which issues depend on which others. Foundational issues (no incoming dependencies) are listed first.
+
+Example:
+
+```
+## Dependencies
+
+- Set up auth service (foundational — no prerequisites)
+- Add login endpoint → depends on: Set up auth service
+- Add token refresh → depends on: Add login endpoint
+```
+
+Do not declare cycles. See "Dependency Ordering" in this document for rules.
+
 
 ## Title and Slug
 
@@ -211,6 +231,35 @@ Epic bodies are read by workers on any machine. Local-filesystem paths (e.g. `~/
 - **Embed**, do not reference. When the epic depends on a design plan, ADR draft, or research note authored locally, paste the content into the epic body under a `## Design context` (or similarly named) section.
 - **Cross-link by URL**, not path. When two epics relate, link by Linear issue URL (`https://linear.app/<workspace>/issue/<KEY>`), never by filesystem path.
 - **Split when too large**. When design context exceeds a comfortable body length, split into paired epics — one docs epic, one implementation epic — each self-contained and linked to its partner by URL.
+
+## Epic Sizing Heuristics
+
+An epic must decompose into a small set of independently-shippable issues, each completable by a single worker within one session (one feature branch → one PR), without exhausting the worker's time or token budget.
+
+**Adopted convention**: aim for approximately 6–8 issues per epic. This figure is an adopted project convention, not an empirically measured limit. Use it as a planning signal, not an absolute rule.
+
+**When to split**: split an epic into multiple epics when it:
+- Would require more issues than the convention suggests,
+- Spans many repositories with large cross-cutting changes, or
+- Contains sections that can be sequenced as separate deliverables.
+
+**Prefer vertical slices over horizontal layers.** A vertical slice delivers a thin end-to-end capability (e.g., a single feature from UI to database). A horizontal layer delivers a whole tier (e.g., all database migrations). Vertical slices ship incrementally; horizontal layers tend to block downstream work.
+
+Do not describe scope as "simple", "quick", or "straightforward" without verification. Scope assessment requires analysis of the actual codebase.
+
+## Dependency Ordering
+
+Issue dependencies within an epic must be declared explicitly and form a valid directed acyclic graph (DAG).
+
+**Rules**:
+- Order issues topologically: earlier issues must unblock later ones.
+- Place foundational and shared work first; no issue should depend on work that has not yet been created or started.
+- **No cycles**: if a dependency cycle is detected (issue A blocks issue B which blocks issue A), halt decomposition and resolve the cycle before proceeding.
+- Record dependency edges via the tracker's native mechanism (e.g., Linear's `blockedBy` / dependency edges). Do not describe ordering only in comments or prose.
+
+**Declare ordering intent in the epic body** using a `## Dependencies` section (see Optional Sections). The team leader translates this into formal tracker edges during decomposition.
+
+**Anti-pattern**: decomposing all issues as fully parallel (no declared dependencies) when logical sequencing exists. If one issue lays foundations that others require, the dependency must be declared.
 
 ## Anti-Patterns
 

--- a/plugins/tools/linear/skills/linear/references/epic-sizing.md
+++ b/plugins/tools/linear/skills/linear/references/epic-sizing.md
@@ -1,0 +1,96 @@
+# Epic Sizing and Dependency-Ordering Reference
+
+Heuristics for decomposing epics into right-sized issues and ordering them correctly for autonomous worker sessions.
+
+## Why Sizing Matters
+
+Epics are executed by autonomous workers with finite per-session context/token budgets and time limits. An oversized epic yields issues that a single worker cannot finish in one session — context overflow, partial work, and dropped acceptance criteria result.
+
+Decompose every epic into independently completable issues before it enters the queue.
+
+## Epic-Sizing Heuristics
+
+### Issue Count
+
+- Target **3–8 issues** per epic.
+- Fewer than 3 often signals the work is a single issue, not an epic.
+- More than ~8 is a signal to split the epic into two or more independent epics.
+
+### Issue Scope
+
+Size each issue to one worker session:
+
+- **Files**: roughly ≤ ~5–10 target files per issue.
+- **Context**: completable in a single focused context window without reading the whole codebase.
+- **Verification**: verifiable by one acceptance check at completion.
+- **Deliverable**: one deliverable per issue. Titles joined by "and", "also", "then", or "plus" usually hide multiple issues — split them.
+- **Subsystem**: one subsystem or repo per issue where possible. Cross-subsystem or cross-repo scope is a split candidate.
+
+### Token-Budget Rule of Thumb
+
+If an issue would require reading the entire codebase or generating thousands of lines of code, it exceeds a worker token budget — split it.
+
+### Epic Objective Check
+
+An epic objective with multiple deliverables joined by "and" or "separately" → split into multiple epics or clearly independent issues with explicit dependency declarations.
+
+## Oversize Red Flags
+
+Mechanically flag an epic or issue when any of these apply:
+
+| Signal | Threshold |
+|--------|-----------|
+| Too many issues | > 8 issues in the epic |
+| Oversized issue | > ~10 target files in one issue |
+| Multi-deliverable title | Title contains "and", "also", "then", or "plus" joining distinct outcomes |
+| Unverifiable acceptance | Acceptance criteria cannot be checked in a single worker session |
+| Cross-repo/cross-subsystem scope | Single issue touches more than one subsystem or repository |
+
+## Dependency-Ordering Conventions
+
+### Declare Dependencies Explicitly
+
+- Use Linear blocking relations (or `bees dep add`) to declare every dependency.
+- Never rely on implicit ordering or convention — if it is not declared, workers may execute out of order.
+
+### Topological Order
+
+Materialize issues in topological order: **foundation → core → integration → verification**.
+
+| Layer | Examples |
+|-------|---------|
+| Foundation | Schemas, reference docs, interfaces, shared types |
+| Core | Business logic, primary implementations |
+| Integration | Wiring components together, adapter layers |
+| Verification | End-to-end tests, audit checks, documentation updates |
+
+Foundational and shared artifacts come first; all consumers must declare a dependency on them.
+
+### Cycle Prevention
+
+- No cycles — if a cycle is detected, halt decomposition and re-decompose before queuing.
+- A cycle means two or more issues block each other; the fix is to extract the shared dependency into a new foundation issue.
+
+### Chain Depth
+
+- Keep dependency chains shallow: fewer than 5 levels from root to leaf.
+- Deep chains serialize workers unnecessarily and extend wall-clock time.
+
+### No False Dependencies
+
+- Independent issues must remain parallelizable.
+- Do not serialize issues that could run concurrently — false dependencies reduce worker fan-out and slow delivery.
+
+## Checklist (Quick Reference)
+
+Before queueing an epic's issues:
+
+- [ ] Issue count is 3–8
+- [ ] Each issue scope: ≤ ~10 files, one deliverable, one subsystem
+- [ ] No multi-deliverable titles (no "and/also/then/plus")
+- [ ] Each acceptance criterion is verifiable in one session
+- [ ] All dependencies declared explicitly (blocking relations or bees deps)
+- [ ] Issues ordered topologically (foundation first)
+- [ ] No dependency cycles
+- [ ] Dependency chain depth < 5
+- [ ] Independent issues are not falsely serialized

--- a/plugins/tools/linear/skills/linear/templates/0.1.0/audit-report.md
+++ b/plugins/tools/linear/skills/linear/templates/0.1.0/audit-report.md
@@ -32,6 +32,11 @@
 | PR on completed | error | pass/fail/n-a | |
 | Branch convention | warning | pass/fail/n-a | |
 | No implementation details | warning | pass/fail | |
+| Epic not oversized | warning | pass/fail/n-a | Issues: [count] |
+| No multi-repo sprawl | warning | pass/fail/n-a | |
+| Dependencies declared | warning | pass/fail/n-a | |
+| No dependency cycles | error | pass/fail/n-a | |
+| Foundational work first | info | pass/fail/n-a | |
 
 **Remediation**:
 - [Action item 1]

--- a/plugins/tools/linear/skills/linear/templates/0.1.0/epic.md
+++ b/plugins/tools/linear/skills/linear/templates/0.1.0/epic.md
@@ -80,6 +80,20 @@ escalation:
   on_ambiguity: ask_user
 ```
 
+## Dependencies (Optional)
+
+> Declare the intended dependency ordering among the issues this epic will decompose into.
+> The team leader records these as `blockedBy` edges in Linear during decomposition.
+>
+> List foundational issues first. Use the format:
+> `issue-title → depends on: other-issue-title`
+> or note `(foundational — no prerequisites)` for starting work.
+>
+> No cycles. See "Dependency Ordering" in `references/epic-format.md` for rules.
+
+- [foundational issue] (foundational — no prerequisites)
+- [dependent issue] → depends on: [foundational issue]
+
 ---
 
 > **That's it.** The team leader handles decomposition into issues and task assignment.


### PR DESCRIPTION
## feat(skills): epic-sizing heuristics + dependency ordering

Epic delivered on branch feature/featskills-epic-sizing-heuristics-dependency-ordering. D1 (universal): epic-sizing heuristics + dependency-ordering conventions were already encoded and committed in the universal /linear:plan-epic and /linear:audit-epics skills plus the epic-sizing.md reference (commits 0b2183e, 9a45544, 9f91342) with explicit thresholds (3-8 issues per epic, <=~10 target files per issue, dependency depth <5, topological foundation->core->integration->verification ordering, cycle detection). D2 (VantageEx-project-specific, NOT in the universal skill): added docs/vantageex-conventions.md documenting the convention to include the vantage_ex repo as a READ-ONLY docs adjunct when an epic touches the VantageEx codebase, so agents can grep ADRs + design docs while implementing (commit 4443b35). Scope assumption recorded: because the epic uses one feature branch in claude-skills and the state machine opens its PR from that branch, D2 was placed in claude-skills (new top-level docs/ file) outside the universal skill command files rather than in the vantage_ex repo, so it appears in the reviewable PR. The unrelated uncommitted CLAUDE.md change was intentionally left out of scope. bees issue claude-skills-1 closed.
## Evidence

- AC addressed: D1 epic-sizing heuristics in /linear:plan-epic -> confirmed, plan-epic.md 'Size & Order' section: decompose into 3-8 issues, size each to one worker session (<=~10 files), dependency depth <5 (committed 0b2183e).
- AC addressed: D1 dependency-ordering in /linear:plan-epic -> confirmed, plan-epic.md: declare blocking relations explicitly, order topologically foundation->core->integration->verification.
- AC addressed: D1 epic-sizing + dependency checks in /linear:audit-epics -> confirmed, audit-epics.md flags >8 issues, >~10 files, multi-deliverable titles, unverifiable acceptance, cross-repo scope, implicit deps, cycles, chains >5 (committed 9a45544).
- AC addressed: D1 thresholds reference -> confirmed, epic-sizing.md defines issue count 3-8, scope <=5-10 files/one deliverable/one subsystem, token-budget split rule, oversize red-flags table, dependency conventions.
- AC addressed: D2 VantageEx vantage_ex read-only docs adjunct convention, NOT in universal skill -> confirmed, new file docs/vantageex-conventions.md (commit 4443b35); git show --stat HEAD shows ONLY this file (no edits to plan-epic.md/audit-epics.md/epic-sizing.md/CLAUDE.md).
- AC addressed: D2 content -> WHEN (line 7-9 'only when the epic work touches the VantageEx codebase'), READ-ONLY (line 17-21 'Never edit, commit, or push inside vantage_ex'), PURPOSE (line 27 'grep and read ADRs and design docs while implementing'), HOW/layout (line 41 sibling clone 'vantage_ex/ read-only adjunct'), real cited paths vantage_ex/architecture/decisions/ (95 ADRs) and vantage_ex/docs/.
- dev-verification: ran `mise run ci` in claude-skills on HEAD 4443b35 -> all 5 suites PASS; plus content verification via grep on docs/vantageex-conventions.md confirming read-only/ADR/when/vantage_ex elements present (no live HTTP service exists for this docs/skills repo, so CI + content grep is the verification gate).
- test results: mise run ci PASS - test:version-bumps (linear 0.1.6->0.1.7), test:plugins (25 local + 1 external valid), test:claude PASS, test:marketplace (marketplace.json valid), test:skills-quality (95 skills validated) - HEAD sha 4443b35.
- branch pushed: origin feature/featskills-epic-sizing-heuristics-dependency-ordering 9f91342..4443b35; commit 4443b35 confirmed on remote.
- bees: claude-skills-1 closed (committed 4443b35; CI green).