### PR TITLE
chore(awman): update awman to 0.11.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.43",
+      "version": "0.4.44",
       "category": "meta",
       "keywords": [
         "all",
@@ -42,7 +42,7 @@
       "source": "./plugins/tools/awman",
       "strict": true,
       "description": "awman: parallel AI code agent sessions with container isolation, worktrees, and a REST API",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "category": "tools",
       "keywords": [
         "awman",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.43",
+  "version": "0.4.44",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/awman/.claude-plugin/plugin.json
+++ b/plugins/tools/awman/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "awman",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "awman: parallel AI code agent sessions with container isolation, worktrees, and a REST API",
   "author": { "name": "vinnie357" },
   "repository": "https://github.com/vinnie357/claude-skills",

--- a/plugins/tools/awman/skills/awman/SKILL.md
+++ b/plugins/tools/awman/skills/awman/SKILL.md
@@ -12,8 +12,8 @@ awman is a Rust CLI and TUI for running AI coding agents (Claude Code, Codex, Op
 
 awman was previously named **amux**. See "Migrating from amux" below.
 
-Source: https://github.com/prettysmartdev/awman (accessed 2026-06-11)
-License: Apache-2.0 | Latest at research time: v0.10.0 (2026-06-11)
+Source: https://github.com/prettysmartdev/awman (accessed 2026-07-13)
+License: Apache-2.0 | Latest at research time: v0.11.0 (2026-07-13)
 
 ## When to Use This Skill
 
@@ -42,22 +42,22 @@ A container runtime, set via the global-only `runtime` config key (`awman config
 
 Mise is the recommended install path. It manages the version, pins reproducibly, and uses the GitHub releases backend — no extra dependencies.
 
-A ready-to-copy pin lives at `templates/0.10.0/mise.toml` in this skill — copy it into the target repo's `mise.toml` (or merge under `[tools]`) and run `mise install`.
+A ready-to-copy pin lives at `templates/0.11.0/mise.toml` in this skill — copy it into the target repo's `mise.toml` (or merge under `[tools]`) and run `mise install`.
 
 **Global pin (one-time, any project):**
 ```sh
-mise use -g github:prettysmartdev/awman@0.10.0
+mise use -g github:prettysmartdev/awman@0.11.0
 ```
 
 **Per-project pin (recommended for repos that run awman):**
 ```sh
-cp templates/0.10.0/mise.toml <your-repo>/mise.toml   # then: cd <your-repo> && mise install
+cp templates/0.11.0/mise.toml <your-repo>/mise.toml   # then: cd <your-repo> && mise install
 ```
 
 The template's contents:
 ```toml
 [tools]
-"github:prettysmartdev/awman" = "0.10.0"
+"github:prettysmartdev/awman" = "0.11.0"
 ```
 
 **Verify:**
@@ -97,7 +97,9 @@ awman config show
 | `awman ready [--refresh]` | Verify environment; `--refresh` re-audits and rebuilds the agent Dockerfile |
 | `awman chat [--agent <name>] [--auto] [--yolo]` | Interactive agent session in a TUI tab |
 | `awman exec prompt "<text>" [--issue <ref>]` | One-off prompt without a persistent session |
-| `awman exec workflow <path> [--work-item <nnnn> \| --issue <ref>] [--yolo] [--worktree]` | Run a multi-step workflow file |
+| `awman exec workflow <path> [--work-item <nnnn> \| --issue <ref>] [--yolo] [--worktree] [--max-concurrent <n>]` | Run a multi-step workflow file |
+| `awman exec workflow --dynamic --work-item <N> [--leader <agent::model>]` | Leader agent designs and runs a workflow (0.11.0) |
+| `awman clean [--dry-run] [--yes]` | Remove stopped containers, dangling images, completed-workflow data (0.11.0) |
 | `awman new spec\|workflow\|skill [--interview] [--issue <ref>]` | Scaffold a work item, workflow, or custom skill |
 | `awman specs amend <nnnn>` | Update an existing work item |
 | `awman status [--watch]` | Session/workflow dashboard |
@@ -106,11 +108,27 @@ awman config show
 | `awman remote run\|session` | Drive a remote awman api server |
 | `awman` (no args) | Open the TUI |
 
-See `templates/0.10.0/commands.md` for the full v0.10.0 command surface with flags and examples.
+See `templates/0.11.0/commands.md` for the full v0.11.0 command surface with flags and examples.
 
 ## GitHub Issue Integration (0.10.0)
 
 `--issue <ref>` on `new spec`, `exec workflow`, and `exec prompt` fetches a GitHub issue and injects it. Reference forms: bare number (`--issue 84`, requires a GitHub `origin` remote), shorthand (`--issue owner/repo#84`), or full URL. Auth resolution: `gh` CLI → `GITHUB_TOKEN` → unauthenticated REST (public repos, 60 requests/hour). For `exec workflow` the issue populates the `{{work_item_*}}` template variables exactly as `--work-item` does; `--issue` and `--work-item` are mutually exclusive.
+
+## Dynamic Workflows (0.11.0)
+
+`awman exec workflow --dynamic --work-item <N>` launches a **leader agent** that reads the work item, designs a `workflow.toml`, and executes it — no hand-authored workflow file. `--dynamic` auto-enforces `--yolo`, `--worktree`, and the `context(workflow)` overlay; passing them explicitly is a no-op, and `--dynamic` rejects a workflow path, `--plan`, or a missing `--work-item`.
+
+Leader resolution (highest wins): `--leader <agent::model>` flag → `dynamicWorkflows.defaultLeader` config → `--model` on the project default agent → project default agent and model. The `dynamicWorkflows` config section constrains the plan: `agentsToModels` (approved agent→model map; empty falls back to Dockerfile discovery), `maxConcurrentSteps` (advisory, not runtime-enforced), and `guidance` (project instructions injected into the leader prompt, max 50 × 1,000 chars). An invalid generated workflow triggers a repair agent up to 3 times. See `references/config.md` for the key schema.
+
+## Parallel Execution (0.11.0)
+
+Workflow steps with identical `depends_on` sets form a parallel group and run **concurrently**. Cap simultaneous containers with `maxConcurrentAgents`; precedence: `--max-concurrent` flag → `AWMAN_MAX_CONCURRENT_AGENTS` env → repo config → global config → **unlimited**. `1` disables parallelism; `0` is rejected. A failed step without `abort_on_failure` lets siblings continue; `abort_on_failure = true` kills all active peers. Stuck detection (30 s) and yolo countdowns (60 s) track per container.
+
+TUI: `Ctrl-S` rotates focus between parallel containers; `Ctrl-G` toggles a git sidebar (per-file `+/-` counts, ~2 s refresh, compact `+X -Y` in the status bar when closed); `Ctrl-,` opens the config dialog (`Ctrl+N` adds nested `dynamicWorkflows` entries).
+
+## Cleanup and Failure Logs (0.11.0)
+
+`awman clean [--dry-run] [--yes]` removes stopped containers, dangling awman-labeled images, and completed-workflow data (repo `.awman/workflows/` state, `~/.awman/context/workflows/` dirs). In-progress workflows and active containers are preserved. Failed step output (~100 lines) lands in `~/.awman/logs/{workflow-id}-{step-name}-{container-name}.log` — created on demand, **never auto-cleaned** (not even by `awman clean`). Teardown `on_failure` remediation agents receive the failed command's output as a readable file; setup `on_failure` agents do not. See `references/workflows.md`.
 
 ## Agents
 
@@ -208,6 +226,10 @@ See `references/workflows.md` for grammar in both formats and worked examples.
 - **Context overlays default to `rw`.** Use `context(SCOPE:ro)` to stop agents from modifying accumulated knowledge.
 - **`envPassthrough` is removed.** The old config key returns a removal notice. Use `env()` overlay entries in the `overlays` array instead.
 - **`gemini` is deprecated.** Use `antigravity` as the replacement (`awman config set agent antigravity`).
+- **`--dynamic` force-enables `--yolo`, `--worktree`, and `context(workflow)`.** There is no supervised dynamic mode.
+- **Unset `maxConcurrentAgents` means unlimited parallelism.** `1` disables it; `0` is rejected.
+- **`~/.awman/logs/` grows unbounded.** `awman clean` does not remove failure logs.
+- **Setup-step `on_failure` gets no automatic output capture.** Only teardown steps hand the failure output to the remediation agent.
 - **Frequent release cadence.** Re-run `awman --version` when output looks unexpected. Pin in mise to control when you upgrade.
 - **Lowercase keys only in workflow files.** Uppercase variants are parse errors.
 
@@ -217,9 +239,10 @@ See `references/workflows.md` for grammar in both formats and worked examples.
 - `references/workflows.md` — Workflow grammar in TOML and YAML
 - `references/config.md` — Per-key config schema for both scopes
 - `references/command-reference.md` — Full CLI surface with flags and examples
-- `templates/0.10.0/commands.md` — Immutable v0.10.0 command snapshot
-- `templates/0.9.1/commands.md` — Immutable v0.9.1 command snapshot (previous version)
+- `templates/0.11.0/commands.md` — Immutable v0.11.0 command snapshot
+- `templates/0.10.0/commands.md` — Immutable v0.10.0 command snapshot (previous version)
+- `templates/0.9.1/commands.md` — Immutable v0.9.1 command snapshot
 
 ## Anti-Fabrication
 
-Run `awman --version` and `awman config show` before asserting that any documented behavior matches the installed binary. awman is pre-1.0 and minor bumps carry breaking changes. Every command form in this skill traces to upstream docs sourced from https://github.com/prettysmartdev/awman (accessed 2026-06-11). Mark any behavior not confirmed by that source as "requires verification against awman v0.10.0 source." Apply `/core:anti-fabrication` rules to all outputs produced with this skill active.
+Run `awman --version` and `awman config show` before asserting that any documented behavior matches the installed binary. awman is pre-1.0 and minor bumps carry breaking changes. Every command form in this skill traces to upstream docs sourced from https://github.com/prettysmartdev/awman (accessed 2026-07-13). Mark any behavior not confirmed by that source as "requires verification against awman v0.11.0 source." Apply `/core:anti-fabrication` rules to all outputs produced with this skill active.

--- a/plugins/tools/awman/skills/awman/references/api.md
+++ b/plugins/tools/awman/skills/awman/references/api.md
@@ -1,9 +1,9 @@
 # awman REST API
 
-Reference for the awman REST API server as of v0.10.0.
+Reference for the awman REST API server as of v0.11.0.
 
 Source: https://github.com/prettysmartdev/awman/blob/main/docs/09-api-mode.md and
-docs/10-remote-mode.md — accessed 2026-06-11.
+docs/10-remote-mode.md — accessed 2026-07-13.
 
 **Prefer `awman remote` over raw curl** when driving the server from a shell. The `awman remote` CLI carries auth, sets the session header, and formats output — raw curl is appropriate only when integrating from external systems that cannot invoke awman.
 
@@ -22,7 +22,7 @@ awman api logs                                                       # tail logs
 awman api kill                                                       # graceful shutdown (30s grace)
 ```
 
-The plaintext API key prints once on first `awman api start`; only its SHA-256 hash is stored at `~/.awman/api/api_key.hash`. Save the key — it is not recoverable. The default port is configurable via the `api.port` global config key (`awman config set --global api.port <n>`); `--port` overrides it per start.
+The plaintext API key prints once on first `awman api start`; only its SHA-256 hash is stored at `~/.awman/api/api_key.hash`. Save the key — it is not recoverable. The default port is configurable via the `api.port` global config key (`awman config set --global api.port <n>`); `--port` overrides it per start. `--dangerously-skip-auth` disables authentication for that process lifetime only — the `api_key.hash` file is untouched and the next normal start re-enables auth.
 
 ### TLS
 
@@ -61,7 +61,7 @@ awman config set --global api.workDirs "/home/user/my-project"
 
 ## FIFO command queue
 
-Within a single session, only one command runs at any moment; commands are processed in strict FIFO order. **Submission never blocks** — `POST /v1/commands` returns immediately with a `command_id` (HTTP 202, or 201 on success) and the command is enqueued. When a session is transitioning to `closing`, new submissions return HTTP 409 `"session is closing"`.
+Within a single session, only one command runs at any moment; commands are processed in strict FIFO order. **Submission never blocks** — `POST /v1/commands` returns immediately with a `command_id` and the command is enqueued (`status: "queued"`) until a worker claims it. When a session is transitioning to `closing`, new submissions return HTTP 409 `"session is closing"`. Malformed `args` are validated only when a worker claims the command — the submit still returns a `command_id`, and the command lands in `status: "error"` with a `result.error` describing the problem.
 
 ---
 
@@ -88,12 +88,22 @@ Within a single session, only one command runs at any moment; commands are proce
 
 ### `POST /v1/sessions`
 
-Request: `{"workdir": "/absolute/path/to/project"}` (must be in the allowlist, else 403).
-Response (201): `{"id": "<session-id>", "workdir": "...", "status": "active", "created_at": "<ISO-8601>"}`.
+Two session types:
+
+```json
+{"type": "local",  "workdir": "/absolute/path/to/project"}
+{"type": "remote", "repo_url": "https://github.com/org/repo", "branch": "main"}
+```
+
+**Local** sessions bind to an existing allowlisted directory (else 403). **Remote** sessions clone the git repository into an isolated `~/.awman/sessions/{session_id}/repo/` on the server; the clone is deleted when the session closes — useful for ephemeral CI-style runs. Both return immediately:
+
+```json
+{ "session_id": "<session-id>" }
+```
 
 ### `POST /v1/commands`
 
-Required header: `x-awman-session: <session-id>`.
+Required header: `x-awman-session: <session-id>`. Valid `subcommand` values: `chat`, `ready`, `exec`, `remote`.
 
 ```json
 {
@@ -102,7 +112,16 @@ Required header: `x-awman-session: <session-id>`.
 }
 ```
 
-The `subcommand` + `args` mirror the CLI surface in `command-reference.md`. Response (202): `{"id": "<command-id>", "session_id": "<session-id>", "status": "running", "created_at": "<ISO-8601>"}`.
+The `subcommand` + `args` mirror the CLI surface in `command-reference.md`. For `exec workflow`, the workflow file path is a positional argument relative to the session workdir — never inline JSON. Returns immediately; the command is enqueued:
+
+```json
+{
+  "command_id": "<command-id>",
+  "flags_applied": { "yolo": true, "non_interactive": true }
+}
+```
+
+**`flags_applied`** reports the API-profile defaults: `non_interactive` is always `true` (HTTP workers have no terminal; cannot be turned off), and `yolo` defaults to `true` for commands that accept it — a default, not an override; a value in your `args` is kept.
 
 ### `GET /v1/commands/:id`
 
@@ -110,14 +129,27 @@ The `subcommand` + `args` mirror the CLI surface in `command-reference.md`. Resp
 {
   "id": "<command-id>",
   "session_id": "<session-id>",
-  "status": "running | completed | failed",
-  "created_at": "<ISO-8601>",
-  "completed_at": "<ISO-8601 | null>",
-  "exit_code": "<integer | null>"
+  "subcommand": "exec",
+  "args": ["workflow", "deploy.toml"],
+  "status": "queued",
+  "queued_at": "<ISO-8601>",
+  "queue_position": 2,
+  "exit_code": null,
+  "started_at": null,
+  "finished_at": null,
+  "log_path": "~/.awman/api/sessions/<session-id>/commands/<command-id>/output.log"
 }
 ```
 
-Poll until `status` is `completed` or `failed`. Buffered logs are also written to disk under `~/.awman/api/sessions/<session-id>/commands/<command-id>/`. For `exec workflow` commands, workflow state lands at `.../workflow.state.json`.
+| `status` | Meaning |
+|----------|---------|
+| `queued` | Enqueued; waiting for a worker (`queue_position` is 0-indexed; 0 = next) |
+| `running` | Claimed by a worker (`worker_id` present); container executing |
+| `done` | Completed with exit code 0 |
+| `error` | Completed with a non-zero exit code (`result.error` set) |
+| `cancelled` | Cancelled before execution (e.g. session kill) |
+
+Poll until `status` is `done` or `error`; a `result` object (`{"exit_code": ..., "error": ...}`) is present in those states. Buffered logs are also written to disk under `~/.awman/api/sessions/<session-id>/commands/<command-id>/`. For `exec workflow` commands, workflow state lands at `.../workflow.state.json`.
 
 ### `GET /v1/commands/:id/logs/stream`
 
@@ -136,7 +168,7 @@ No auth. `{"uptime_seconds": 3600, "active_sessions": 2, "running_commands": 1}`
 SESSION=$(curl -s -X POST http://localhost:9876/v1/sessions \
   -H 'Authorization: Bearer <api-key>' \
   -H 'Content-Type: application/json' \
-  -d '{"workdir":"/home/user/my-project"}' | jq -r '.id')
+  -d '{"type":"local","workdir":"/home/user/my-project"}' | jq -r '.session_id')
 
 # 2. Submit a command
 COMMAND=$(curl -s -X POST http://localhost:9876/v1/commands \
@@ -144,7 +176,7 @@ COMMAND=$(curl -s -X POST http://localhost:9876/v1/commands \
   -H "x-awman-session: $SESSION" \
   -H 'Content-Type: application/json' \
   -d '{"subcommand":"exec","args":["prompt","Fix the failing tests","--non-interactive"]}' \
-  | jq -r '.id')
+  | jq -r '.command_id')
 
 # 3. Stream logs until completion, then check final status
 curl -N http://localhost:9876/v1/commands/$COMMAND/logs/stream \

--- a/plugins/tools/awman/skills/awman/references/command-reference.md
+++ b/plugins/tools/awman/skills/awman/references/command-reference.md
@@ -1,8 +1,8 @@
 # awman Command Reference
 
-Exhaustive reference for all awman CLI subcommands, flags, and options as of v0.10.0.
+Exhaustive reference for all awman CLI subcommands, flags, and options as of v0.11.0.
 
-Source: https://github.com/prettysmartdev/awman (README + docs/, accessed 2026-06-11).
+Source: https://github.com/prettysmartdev/awman (README + docs/, accessed 2026-07-13).
 Run `awman <subcommand> --help` to verify flags match the installed binary. Pre-1.0 releases drift between minors.
 
 ---
@@ -91,6 +91,16 @@ awman config set --global runtime docker
 
 # Add allowlisted API workdirs (comma-separated)
 awman config set --global api.workDirs "/path1,/path2"
+
+# Nested dynamicWorkflows keys use dotted paths (0.11.0)
+awman config set dynamicWorkflows.defaultLeader claude::claude-opus-4-8
+awman config set dynamicWorkflows.maxConcurrentSteps 3
+awman config set dynamicWorkflows.agentsToModels.claude "claude-opus-4-8, claude-sonnet-4-6"
+awman config set dynamicWorkflows.guidance.0 "Never spawn more than two agents in parallel."
+
+# Cap parallel workflow containers (0.11.0)
+awman config set maxConcurrentAgents 3            # this repo
+awman config set --global maxConcurrentAgents 2   # all projects
 ```
 
 **Do not hand-edit the JSON files directly.** Use `awman config set` and verify with `awman config show`.
@@ -149,15 +159,67 @@ awman exec prompt "Fix this bug" --issue 84      # prompt text first, then issue
 
 ### `awman exec workflow`
 
-Execute a multi-step workflow file. Adds workflow-only flags `--worktree` and `--work-item <N>`.
+Execute a multi-step workflow file. Adds workflow-only flags `--worktree`, `--work-item <N>`, and `--max-concurrent <n>` (0.11.0).
 
 ```sh
 awman exec workflow ./workflows/refactor.toml
 awman exec workflow ./workflows/implement.toml --work-item 0027 --yolo --worktree
 awman exec workflow ./workflows/implement.toml --issue prettysmartdev/awman#84
+awman exec workflow ./workflows/implement.toml --work-item 0027 --max-concurrent 4
 ```
 
 `--work-item <nnnn>` injects template variables (`{{work_item_number}}`, `{{work_item_content}}`, etc.) into step prompts. `--issue <ref>` (0.10.0) fetches a GitHub issue and populates the same variables — mutually exclusive with `--work-item`. Reference forms: bare number (requires GitHub `origin` remote), `owner/repo#N`, or full URL; auth via `gh` CLI, then `GITHUB_TOKEN`, then unauthenticated (public repos, 60 req/hr). The worktree is never auto-deleted — a merge/discard/keep dialog appears at completion or abort.
+
+`--max-concurrent <n>` (0.11.0) caps simultaneous step containers for this run, overriding `AWMAN_MAX_CONCURRENT_AGENTS` and the `maxConcurrentAgents` config key. See `references/workflows.md` for parallel-group semantics.
+
+### `awman exec workflow --dynamic` (0.11.0)
+
+A leader agent reads the work item, designs a `workflow.toml`, and executes it.
+
+```sh
+awman exec workflow --dynamic --work-item 27
+awman exec workflow --dynamic --work-item 27 --leader claude::claude-opus-4-8
+awman exec workflow --dynamic --work-item 27 --model claude-sonnet-4-6   # default model for generated steps
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dynamic` | Enable dynamic mode; requires `--work-item`, rejects a workflow file path and `--plan` |
+| `--leader <agent::model>` | Override the leader agent and model (only valid with `--dynamic`) |
+| `--model <name>` | Default model for generated workflow steps |
+
+`--yolo`, `--worktree`, and the `context(workflow)` overlay are enforced automatically — passing them explicitly has no effect. Leader resolution order: `--leader` flag → `dynamicWorkflows.defaultLeader` config → `--model` on the project default agent → project default agent and model. If the generated `workflow.toml` is invalid, missing, or references unknown agents, a repair agent runs up to 3 times before the run errors with the file path.
+
+| Violation | Error |
+|-----------|-------|
+| `--dynamic` + workflow file path | `cannot specify a workflow file path with --dynamic...` |
+| `--dynamic` without `--work-item` | `--dynamic requires --work-item` |
+| `--leader` without `--dynamic` | `--leader is only valid with --dynamic` |
+| `--dynamic --plan` | `--dynamic cannot be used with --plan...` |
+| Malformed `--leader` | `invalid --leader value: expected agent::model...` |
+
+---
+
+## `awman clean` (0.11.0)
+
+Remove leftover awman resources.
+
+```sh
+awman clean --dry-run   # preview what would be removed
+awman clean             # interactive confirmation (y/N)
+awman clean --yes       # no prompt; required in non-TTY contexts
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | List removable items without deleting; no confirmation needed |
+| `--yes` / `-y` | Skip the confirmation prompt |
+
+**Removes:** stopped awman containers; completed workflow state files in `GITROOT/.awman/workflows/`; completed workflow context directories under `~/.awman/context/workflows/`; dangling awman-labeled Docker images.
+
+**Preserves:** in-progress workflows, active containers and images, and `~/.awman/logs/` (failure logs are never auto-cleaned).
+
+**Exit codes:** `0` success / nothing to clean / dry-run; `1` one or more deletions failed; `2` interactive input required but unavailable (non-TTY without `--yes`). If Docker is unavailable, container/image cleanup is skipped with a warning and filesystem cleanup proceeds. In the TUI, a confirmation modal replaces the text prompt.
 
 ---
 
@@ -223,6 +285,7 @@ awman api kill                                               # Graceful shutdown
 | `--background` | Run the server detached |
 | `--refresh-key` | Generate a new API key (prints plaintext once) |
 | `--dangerously-skip-tls` | Serve plain HTTP instead of self-signed HTTPS |
+| `--dangerously-skip-auth` | Disable auth for this process lifetime only; `api_key.hash` is untouched and the next normal start re-enables auth |
 
 See `references/api.md` for the full REST endpoint table and auth model.
 
@@ -291,6 +354,9 @@ awman remote session kill "$SESSION"
 | `unsupported workflow format` | Markdown (`.md`) workflow; convert to TOML or YAML |
 | `worktree already exists` | Previous `--worktree` run left a tree; resolve with `git worktree list` / `git worktree remove` |
 | `no agent Dockerfile found` | Run `awman ready --refresh` after `awman init` or after editing `.awman/Dockerfile.*` |
+| `--dynamic requires --work-item` | Dynamic mode needs a work item; add `--work-item <N>` |
+| `invalid --leader value` | `--leader` expects `agent::model` (e.g. `claude::claude-opus-4-8`) |
+| Value `0` rejected for `maxConcurrentAgents` | Use `1` to disable parallelism or unset for unlimited |
 
 ---
 

--- a/plugins/tools/awman/skills/awman/references/config.md
+++ b/plugins/tools/awman/skills/awman/references/config.md
@@ -1,8 +1,8 @@
 # awman Configuration Reference
 
-Reference for awman configuration files and keys as of v0.10.0.
+Reference for awman configuration files and keys as of v0.11.0.
 
-Source: https://github.com/prettysmartdev/awman/blob/main/docs/07-configuration.md and docs/08-overlays.md — accessed 2026-06-11.
+Source: https://github.com/prettysmartdev/awman/blob/main/docs/07-configuration.md, docs/08-overlays.md, docs/13-dynamic-workflows.md, and docs/15-parallel-workflows.md — accessed 2026-07-13.
 
 **Never hand-edit the JSON files.** Use `awman config set` to write values and `awman config show` to inspect the merged effective configuration. Keys marked "edit file" below are the exception — they are not settable via the CLI.
 
@@ -24,7 +24,7 @@ The per-repo `.awman/` directory also holds per-agent Dockerfiles (`Dockerfile.c
 
 XDG base-directory environment variables are honored as of 0.10.0.
 
-> **Migrating from amux:** the old split between `aspec/.amux.json` and `.amux/config.json` is gone. awman uses a single per-repo `GITROOT/.awman/config.json`, and config migrates automatically on first run. No migration is required from 0.9.1 to 0.10.0.
+> **Migrating from amux:** the old split between `aspec/.amux.json` and `.amux/config.json` is gone. awman uses a single per-repo `GITROOT/.awman/config.json`, and config migrates automatically on first run. No migration is required from 0.9.1 to 0.10.0, nor from 0.10.0 to 0.11.0 (new settings are optional).
 
 If you are unsure which value awman is using, run `awman config show` — it displays the merged effective config. As of 0.10.0, `awman config` works even when the configured runtime is not installed.
 
@@ -81,10 +81,55 @@ Per-repo overrides global on scalar conflicts; `overlays` merges additively.
 | `yoloDisallowedTools` | array of strings | `[]` | Yes |
 | `overlays` | array of overlay specs | `[]` | Yes |
 | `agentStuckTimeout` | integer | `30` (seconds) | Yes |
+| `maxConcurrentAgents` | integer ≥ 1 | unset (unlimited) | Yes |
+| `dynamicWorkflows.agentsToModels` | map of agent → model list | `{}` | Yes (dotted path) |
+| `dynamicWorkflows.defaultLeader` | `agent::model` string | unset | Yes |
+| `dynamicWorkflows.maxConcurrentSteps` | integer ≥ 1 | unset | Yes |
+| `dynamicWorkflows.guidance` | array of strings | `[]` | Yes (indexed path) |
 | `baseImage` | string | unset | No (edit file) |
 | `remote.defaultAddr` | string | unset | Yes |
 | `remote.defaultAPIKey` | string | unset | Yes |
 | `remote.savedDirs` | array of strings | `[]` | No (edit file) |
+
+### `maxConcurrentAgents` (0.11.0)
+
+Caps simultaneous workflow step containers. Precedence (highest wins): `--max-concurrent` flag → `AWMAN_MAX_CONCURRENT_AGENTS` env var → repo config → global config → **unlimited**. `1` disables parallel execution entirely; `0` is rejected.
+
+```sh
+awman config set maxConcurrentAgents 3            # current repo
+awman config set --global maxConcurrentAgents 2   # all projects
+awman exec workflow workflow.toml --max-concurrent 4   # single run
+```
+
+### `dynamicWorkflows.*` (0.11.0)
+
+Constrains the leader agent used by `awman exec workflow --dynamic`. All fields are optional.
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `agentsToModels` | map | Restricts the leader to approved agents/models; falls back to Dockerfile discovery when empty |
+| `maxConcurrentSteps` | integer ≥ 1 | Advisory concurrency cap the leader uses for planning — **not enforced at runtime** |
+| `defaultLeader` | `agent::model` | Repo-wide default leader; overridden by the `--leader` flag |
+| `guidance` | string array | Project-specific instructions injected into the leader prompt; max 50 entries of 1,000 chars each |
+
+```json
+{
+  "dynamicWorkflows": {
+    "agentsToModels": {
+      "claude": ["claude-opus-4-8", "claude-sonnet-4-6"],
+      "codex": ["codex-mini-latest"]
+    },
+    "maxConcurrentSteps": 3,
+    "defaultLeader": "claude::claude-opus-4-8",
+    "guidance": [
+      "Never spawn more than two agents in parallel.",
+      "Always include a validation step after each implementation step."
+    ]
+  }
+}
+```
+
+Set via dotted CLI paths (`awman config set dynamicWorkflows.defaultLeader claude::claude-opus-4-8`, `awman config set dynamicWorkflows.guidance.0 "..."`) or in the TUI config dialog (`Ctrl-,`; `Ctrl+N` adds `agentsToModels` and `guidance` entries, saving an empty value removes one).
 
 ---
 
@@ -143,6 +188,7 @@ awman reads several `AWMAN_*` environment variables (override config at runtime)
 | `AWMAN_REMOTE_ADDR` | `remote.defaultAddr` |
 | `AWMAN_API_KEY` | `remote.defaultAPIKey` / API auth key |
 | `AWMAN_REMOTE_SESSION` | Target session id for `awman remote` |
+| `AWMAN_MAX_CONCURRENT_AGENTS` | `maxConcurrentAgents` (both scopes; beaten only by `--max-concurrent`) |
 
 > **Migrating from amux:** rename all `AMUX_*` variables to `AWMAN_*`.
 

--- a/plugins/tools/awman/skills/awman/references/workflows.md
+++ b/plugins/tools/awman/skills/awman/references/workflows.md
@@ -1,8 +1,8 @@
 # awman Workflow Authoring
 
-Reference for authoring awman workflow files as of v0.10.0. Two formats are supported: **TOML** and **YAML**.
+Reference for authoring awman workflow files as of v0.11.0. Two formats are supported: **TOML** and **YAML**.
 
-Source: https://github.com/prettysmartdev/awman/blob/main/docs/05-workflows.md — accessed 2026-06-11. (The docs tree was renumbered in 0.10.0; this page was previously `04-workflows.md`.)
+Source: https://github.com/prettysmartdev/awman/blob/main/docs/05-workflows.md and docs/15-parallel-workflows.md — accessed 2026-07-13.
 
 > **Migrating from amux:** Markdown workflow files (`.md`) are **no longer supported as of 0.9.1**. Any extension other than `.toml`, `.yml`, or `.yaml` is rejected. Convert Markdown workflows to TOML or YAML.
 
@@ -35,9 +35,30 @@ awman exec workflow <path> --issue owner/repo#84
 awman exec workflow <path> --yolo --worktree
 ```
 
-Execution flags: `--agent`, `--model`, `--non-interactive`, `--plan`, `--yolo`, `--worktree`, `--allow-docker`, `--mount-ssh`, `--work-item <N>`, `--issue <ref>` (0.10.0; fetches a GitHub issue and treats it as the work item — mutually exclusive with `--work-item`).
+Execution flags: `--agent`, `--model`, `--non-interactive`, `--plan`, `--yolo`, `--worktree`, `--allow-docker`, `--mount-ssh`, `--work-item <N>`, `--issue <ref>` (0.10.0; fetches a GitHub issue and treats it as the work item — mutually exclusive with `--work-item`), `--max-concurrent <n>` (0.11.0; caps parallel step containers for this run).
 
 The `--agent` flag sets the **default** for steps that do not name an agent; it does **not** override steps that explicitly specify one.
+
+For workflows designed on the fly by a leader agent (`--dynamic`), see `references/command-reference.md` — dynamic mode generates and executes a `workflow.toml` from a work item without a hand-authored file.
+
+---
+
+## Parallel execution (0.11.0)
+
+Steps with **identical `depends_on` sets** form a parallel group and launch concurrently — neither depends on the other, so the engine runs them at the same time:
+
+```
+implement → tests
+          → docs
+          → review (depends_on = ["tests", "docs"])
+```
+
+Once `implement` completes, `tests` and `docs` start immediately; `review` waits for both.
+
+- **Scheduling:** eligible steps launch in workflow file order up to the `maxConcurrentAgents` cap; when a slot frees, the next queued step starts. Unset cap = unlimited; `1` disables parallelism; `0` is rejected. Precedence: `--max-concurrent` → `AWMAN_MAX_CONCURRENT_AGENTS` → repo config → global config. See `references/config.md`.
+- **Failure:** a failed step without `abort_on_failure` lets siblings continue; `abort_on_failure = true` kills all active peers in the group instantly.
+- **Per-container tracking:** stuck detection (30 s silent) and yolo countdowns (60 s) apply to each container independently — one stuck or expired container does not affect its siblings.
+- **TUI:** `Ctrl-S` rotates focus between running containers (passes through to the PTY when only one runs). The Workflow Control Board (`Ctrl-W`) scopes actions to the focused container; "Restart current step", "Cancel to previous step", and "Finish workflow" are disabled while peers run, but "Pause" and "Abort" stay available.
 
 ---
 
@@ -64,6 +85,7 @@ Available in all workflow text fields (not in `type`). Substituted at execution 
 | `agent` | string | no | Overrides the default agent for this step |
 | `model` | string | no | Overrides the model for this step |
 | `overlays` | array of overlay specs | no | Per-step overlays, e.g. `["ssh()", "skill(search)"]`; workflow-level `overlays` under `[workflow]` apply to all steps |
+| `abort_on_failure` | boolean | no | On failure, kill all active parallel peers and stop the workflow (0.11.0); without it, siblings continue. With an `on_failure` block, the remediation loop runs first — abort triggers only after `max_attempts` is exhausted |
 
 ---
 
@@ -120,6 +142,19 @@ setup:
       prompt: Tests failed. Fix issues and verify.
       max_attempts: 2
 ```
+
+### Automatic failure output capture (0.11.0)
+
+When a **teardown** step's `on_failure` remediation agent launches, awman captures the failed command's stdout/stderr (capped at 100 KB per stream) and writes it to a file the agent can read; a note prepended to the remediation prompt says where:
+
+- With a writable `context(workflow)` overlay: `/awman/context/workflow/teardown-failure-<step-name>.txt`
+- Otherwise: a dedicated directory mounted read-only at `/awman/remediation/teardown-failure-<step-name>.txt`
+
+On retry the file is overwritten with the latest failure. **Setup steps get no automatic capture** — include failure context explicitly in the `prompt` field.
+
+### Failure logs (0.11.0)
+
+Failed step container output (~100 lines rolling, combined stdout/stderr) is saved to `~/.awman/logs/{workflow-id}-{step-name}-{container-name}.log`. Logs are written only when the container failed **on its own** — containers awman itself stops (yolo auto-advance, control-board Abort/Pause/Finish, stuck-step cancel, `abort_on_failure` killing siblings) exit as expected and produce no log. `docker-sbx-experimental` runtimes do not produce these logs. The directory is created on demand and **never auto-cleaned** — `awman clean` does not touch it.
 
 ---
 

--- a/plugins/tools/awman/skills/awman/templates/0.11.0/commands.md
+++ b/plugins/tools/awman/skills/awman/templates/0.11.0/commands.md
@@ -1,0 +1,376 @@
+# awman v0.11.0 — Command Reference
+
+Pinned to awman v0.11.0 (released 2026-07-13, accessed 2026-07-13).
+Newer versions get their own `templates/X.Y.Z/commands.md` per the `/claude-code:skill-update` convention.
+
+Source: https://github.com/prettysmartdev/awman (release notes + docs/, accessed 2026-07-13)
+
+---
+
+## What's new versus v0.10.0
+
+- **Dynamic workflows** — `awman exec workflow --dynamic --work-item <N>` launches a leader agent that designs a custom workflow for the work item, then executes it. `--leader <agent::model>` overrides the leader; `dynamicWorkflows` config section (`agentsToModels`, `defaultLeader`, `maxConcurrentSteps`, `guidance`) constrains the plan. `--dynamic` auto-enforces `--yolo`, `--worktree`, and the `context(workflow)` overlay.
+- **True parallel execution** — independent DAG steps (identical `depends_on` sets) run concurrently. Cap with `maxConcurrentAgents` config (repo or global), `AWMAN_MAX_CONCURRENT_AGENTS`, or `--max-concurrent <n>` per run. Unset = unlimited; `1` disables parallelism; `0` is rejected. TUI: `Ctrl-S` rotates focus between parallel containers.
+- **Git sidebar** — `Ctrl-G` toggles a sidebar of changed files with per-file `+/-` counts (~2 s refresh); compact `+X -Y` summary in the status bar when closed.
+- **`awman clean`** — removes stopped containers, dangling awman-labeled images, and completed-workflow data. `--dry-run` previews; `--yes` skips confirmation.
+- **Container failure logging** — failed step output (~100 lines) saved to `~/.awman/logs/{workflow-id}-{step-name}-{container-name}.log`; teardown `on_failure` agents receive the failed command output as a readable file.
+- Fixes: credentials injected via environment (not command line); workflow filenames sanitized against path traversal; OpenCode interactive prompt handling. Codex Dockerfiles updated for newer GPT models.
+- No config migration required from 0.10.0; new settings are optional.
+
+---
+
+## `awman` (no args)
+
+Open the TUI. Scrollback defaults to 10,000 lines (configurable via `terminal_scrollback_lines`). `Ctrl-G` toggles the git sidebar; `Ctrl-S` switches between parallel containers; `Ctrl-,` opens the config dialog (`Ctrl+N` adds nested `dynamicWorkflows` entries); `Ctrl-W` opens the Workflow Control Board.
+
+---
+
+## `awman init`
+
+```sh
+awman init [--agent <name>] [--aspec]
+```
+
+Interactive project setup. Creates `GITROOT/.awman/config.json` (commit this) and per-agent Dockerfiles in `.awman/`. `--aspec` also downloads spec/workflow templates.
+
+---
+
+## `awman ready`
+
+```sh
+awman ready [--refresh]
+```
+
+Verify runtime, Dockerfiles, agent auth, and built images. `--refresh` re-audits and rebuilds the agent image. Run after switching `runtime`.
+
+---
+
+## `awman chat`
+
+```sh
+awman chat [--agent <name>] [--model <name>] [--plan] [--auto] [--yolo] [--worktree] [--non-interactive] [--overlay <spec>] [--allow-docker] [--mount-ssh]
+```
+
+| Flag | Effect |
+|------|--------|
+| `--agent <name>` | Override the default agent |
+| `--model <name>` | Override the model for this session |
+| `--plan` | Read-only analysis/planning mode |
+| `--auto` | Auto-approve file edits; prompt for shell commands |
+| `--yolo` | Fully autonomous (no prompts) |
+| `--worktree` | Run in a dedicated Git worktree |
+| `--non-interactive` / `-n` | Print/batch (headless) mode |
+| `--overlay <spec>` | Add an overlay spec: `dir()`, `ssh()`, `env()`, `skill()`, `context()` |
+| `--allow-docker` | Mount the Docker socket |
+| `--mount-ssh` | Mount `~/.ssh` read-only |
+
+---
+
+## `awman exec`
+
+```sh
+awman exec prompt "<text>" [--issue <ref>] [--agent <name>] [--non-interactive] [--auto] [--yolo]
+awman exec workflow <path> [--work-item <nnnn> | --issue <ref>] [--yolo] [--worktree] [--agent <name>] [--model <name>] [--max-concurrent <n>]
+awman exec workflow --dynamic --work-item <N> [--leader <agent::model>] [--model <name>]
+```
+
+Both subcommands accept `--agent`, `--model`, `--non-interactive`/`-n`, `--plan`, `--auto`, `--yolo`, `--overlay`, `--allow-docker`, `--mount-ssh`. `exec workflow` adds `--worktree`, `--work-item <N>`, and `--max-concurrent <n>`.
+
+`--issue <ref>`: for `exec workflow`, the issue is fetched and treated as if passed via `--work-item` (template variables populate from issue content). For `exec prompt`, the prompt text appears first, followed by the issue content. `--issue` and `--work-item` are mutually exclusive.
+
+### Dynamic mode (`--dynamic`, 0.11.0)
+
+A leader agent reads the work item, designs a `workflow.toml`, and executes it. `--yolo`, `--worktree`, and `context(workflow)` are enforced automatically — passing them explicitly is a no-op. Leader resolution order: `--leader <agent::model>` flag → `dynamicWorkflows.defaultLeader` config → `--model` applied to the project default agent → project default agent and model. An invalid generated workflow triggers a repair agent up to 3 times before erroring with the file path.
+
+| Violation | Error |
+|-----------|-------|
+| `--dynamic` + workflow file path | `cannot specify a workflow file path with --dynamic...` |
+| `--dynamic` without `--work-item` | `--dynamic requires --work-item` |
+| `--leader` without `--dynamic` | `--leader is only valid with --dynamic` |
+| `--dynamic --plan` | `--dynamic cannot be used with --plan...` |
+| Malformed `--leader` | `invalid --leader value: expected agent::model...` |
+
+---
+
+## `awman clean` (0.11.0)
+
+```sh
+awman clean [--dry-run] [--yes]
+```
+
+| Flag | Effect |
+|------|--------|
+| `--dry-run` | Preview removable items without deleting; no confirmation needed |
+| `--yes` / `-y` | Skip the confirmation prompt; required in non-TTY contexts |
+
+Removes: stopped awman containers, completed repo workflow state files (`GITROOT/.awman/workflows/`), completed workflow context directories (`~/.awman/context/workflows/`), and dangling awman-labeled Docker images. Preserves in-progress workflows and active containers. Does **not** clean `~/.awman/logs/`. If Docker is unavailable, container/image cleanup is skipped with a warning and filesystem cleanup proceeds.
+
+Exit codes: `0` success / nothing to clean / dry-run; `1` one or more deletions failed; `2` interactive input required but unavailable (non-TTY without `--yes`).
+
+---
+
+## `awman new`
+
+```sh
+awman new spec [--interview] [--issue <ref>]
+awman new workflow [--interview] [--global] [--format <toml|yaml>]
+awman new skill [--interview]
+```
+
+`new spec --issue` uses the fetched issue as input for spec generation; with `--interview`, the issue content pre-populates the interview text box.
+
+---
+
+## `awman specs`
+
+```sh
+awman specs amend <nnnn>   # Update work item <nnnn>
+```
+
+---
+
+## `awman status`
+
+```sh
+awman status [--watch]
+```
+
+---
+
+## `awman config`
+
+```sh
+awman config show                              # Merged effective config
+awman config get <field>                       # One field
+awman config set [--global] <field> <value>    # Write a key
+```
+
+`--global` writes to `~/.awman/config.json`; without it, writes to the per-repo `GITROOT/.awman/config.json`. Works even when the configured runtime is not installed. Nested `dynamicWorkflows` keys are settable via dotted paths:
+
+```sh
+awman config set dynamicWorkflows.defaultLeader claude::claude-opus-4-8
+awman config set dynamicWorkflows.maxConcurrentSteps 3
+awman config set dynamicWorkflows.agentsToModels.claude "claude-opus-4-8, claude-sonnet-4-6"
+awman config set dynamicWorkflows.guidance.0 "Never spawn more than two agents in parallel."
+awman config set maxConcurrentAgents 3
+awman config set --global maxConcurrentAgents 2
+```
+
+---
+
+## `awman api`
+
+Manage the REST API server (default port 9876, HTTPS self-signed by default).
+
+```sh
+awman api start --port 9876 --workdirs /repo          # foreground
+awman api start --background --port 9876 --workdirs /repo
+awman api start --refresh-key --port 9876 --workdirs /repo
+awman api status
+awman api logs                                        # background server only
+awman api kill
+```
+
+Add `--dangerously-skip-tls` for plain HTTP, `--dangerously-skip-auth` to disable auth for this process lifetime only (the `api_key.hash` file is untouched; the next normal start re-enables auth). Default port configurable via the `api.port` global key. See `references/api.md` for the REST surface.
+
+---
+
+## `awman remote`
+
+```sh
+awman remote run "<cmd>" [--session <ID>] [--follow] [--remote-addr <URL>]
+awman remote session start [dir] [--remote-addr <URL>] [--api-key <KEY>]
+awman remote session kill <id> [--remote-addr <URL>] [--api-key <KEY>]
+```
+
+Reads `remote.defaultAddr` / `remote.defaultAPIKey` from `~/.awman/config.json`; `AWMAN_REMOTE_ADDR`, `AWMAN_API_KEY`, and `AWMAN_REMOTE_SESSION` override at runtime. `--session` is required in CLI mode.
+
+---
+
+## Runtimes (v0.11.0)
+
+| `runtime` value | Platforms | Requirements |
+|-----------------|-----------|--------------|
+| `docker` (default) | Linux, macOS, Windows | Docker daemon |
+| `apple-containers` | macOS 26+ | native `container` CLI |
+| `docker-sbx-experimental` | macOS arm64, Windows x86_64 | `sbx` CLI + Docker account (`sbx login`) |
+
+`runtime` is global-only. Switch with `awman config set --global runtime <value>`, then run `awman ready`. Each runtime keeps separate state; switching does not delete the others' data. sbx requires Apple Silicon on macOS; Linux x86_64 is blocked by a virtiofs bug and returns an error if configured.
+
+---
+
+## Agents Supported in v0.11.0
+
+`claude` | `codex` | `opencode` | `maki` | `gemini` (deprecated) | `antigravity` | `copilot` | `crush` | `cline`
+
+Each has a corresponding `Dockerfile.<agent>` in `.awman/`. The project base image path is configurable via the per-repo `dockerfile` key (default `Dockerfile.dev`). Codex Dockerfiles were updated in 0.11.0 for newer GPT models.
+
+---
+
+## Workflow File Formats
+
+Two formats — **TOML and YAML**. Fields are lowercase only. Main steps: `name`, `prompt` (required), `depends_on`, `agent`, `model`, `overlays` (optional).
+
+### Parallel execution (0.11.0)
+
+Steps with identical `depends_on` sets form a parallel group and launch concurrently, in workflow file order, up to the `maxConcurrentAgents` cap. A failed step without `abort_on_failure` lets siblings continue; `abort_on_failure = true` kills all active peers in the group. Stuck detection (30 s) and yolo countdowns (60 s) track per container.
+
+### Main steps (TOML)
+
+```toml
+title = "Implement Feature Workflow"
+
+[[step]]
+name = "plan"
+prompt = "Read the work item and produce an implementation plan.\n\n{{work_item_content}}"
+
+[[step]]
+name = "implement"
+depends_on = ["plan"]
+agent = "codex"
+model = "claude-haiku-4-5"
+prompt = "Implement work item {{work_item_number}} according to the plan."
+```
+
+### Setup phase steps
+
+| Type | Required | Optional |
+|------|----------|----------|
+| `clone_repo` | `url` | `branch`, `into` |
+| `checkout_create_branch` | `branch` | `base` |
+| `pull_branch` | — | `remote`, `branch` |
+| `run_shell` | `command` | `env` |
+| `run_script` | `path` | `env` |
+| `poll_ci` | — | `interval_secs` (default 30), `max_retries` (default 10) |
+
+### Teardown phase steps
+
+| Type | Required | Optional |
+|------|----------|----------|
+| `run_shell` | `command` | `env` |
+| `run_script` | `path` | `env` |
+| `commit_changes` | `message` | `add_all` |
+| `push_branch` | — | `remote`, `branch` |
+| `create_pull_request` | — | `title`, `body`, `base` |
+| `poll_ci` | — | `interval_secs`, `max_retries` |
+
+Top-level `teardown_on_failure = true` runs teardown even when main steps fail (default `false`). Failed teardown steps log and continue (best-effort cleanup).
+
+### on_failure remediation
+
+```toml
+[[setup]]
+type = "run_shell"
+command = "npm test"
+[setup.on_failure]
+prompt = "Tests failed. Fix issues and verify."
+agent = "claude"              # optional; inherits if omitted
+model = "claude-opus-4-6"     # optional; inherits if omitted
+max_attempts = 2              # required; must be >= 1
+```
+
+On step failure, a remediation agent runs the prompt, then the step retries — up to `max_attempts` cycles. New in 0.11.0: teardown `on_failure` agents receive the failed command's stdout/stderr as a readable file (see failure logging below); setup `on_failure` agents get no automatic capture.
+
+### Failure logging (0.11.0)
+
+Failed step container output (~100 lines, combined stdout/stderr) is saved to `~/.awman/logs/{workflow-id}-{step-name}-{container-name}.log`. The directory is created on demand and never auto-cleaned (`awman clean` does not touch it).
+
+### Template Variables
+
+| Variable | Resolves to |
+|----------|-------------|
+| `{{work_item_number}}` | Zero-padded 4-digit number (e.g. `0027`) |
+| `{{work_item}}` | The bare number |
+| `{{work_item_content}}` | Full text of the work item (or fetched GitHub issue via `--issue`) |
+| `{{work_item_section:[Name]}}` | Named section within the work item (case-insensitive) |
+
+---
+
+## Overlays (v0.11.0 syntax)
+
+`overlays` is a string array (config, `AWMAN_OVERLAYS`, `--overlay`, or workflow/step `overlays = [...]`):
+
+| Spec | Effect |
+|------|--------|
+| `dir(HOST:CONTAINER[:ro\|rw])` | Mount a host directory (default read-only) |
+| `ssh()` | Mount `~/.ssh` read-only |
+| `env(VAR)` | Forward one env var (one call per var; unset vars skip silently) |
+| `skill(*)` / `skill(NAME)` | Mount all or one skill from `~/.awman/skills/` |
+| `context(global\|repo\|workflow[:ro])` | Durable context dir + system-prompt injection (default `rw`) |
+
+Context locations: `~/.awman/context/global/`, `~/.awman/context/repo/{owner}/{repo}/`, `~/.awman/context/workflow/` (per invocation). All sources merge additively; on host-path conflicts higher priority wins, but `:ro` always overrides `:rw`. Setup/teardown steps support `dir()`, `ssh()`, `env()` only — not `skill()`.
+
+---
+
+## Configuration Keys (v0.11.0)
+
+| Key | Type | Default | Scope | Settable via CLI |
+|-----|------|---------|-------|------------------|
+| `default_agent` | string | unset | Global only | Yes |
+| `runtime` | string | `"docker"` | Global only | Yes |
+| `workers` | integer | `2` | Global only | No (edit file) |
+| `baseImage` | string | unset | Global / repo | No (edit file) |
+| `api.workDirs` | array | `[]` | Global only | Yes |
+| `api.alwaysNonInteractive` | boolean | `false` | Global only | No (edit file) |
+| `api.port` | integer | `9876` | Global only | Yes |
+| `remote.defaultAddr` | string | unset | Both | Yes |
+| `remote.defaultAPIKey` | string | unset | Both | Yes |
+| `remote.savedDirs` | array | `[]` | Both | No (edit file) |
+| `agent` | string | unset | Both | Yes |
+| `auto_agent_auth_accepted` | bool | unset | Global only | No (managed) |
+| `terminal_scrollback_lines` | integer | `10000` | Both | Yes |
+| `yoloDisallowedTools` | array | `[]` | Both | Yes |
+| `overlays` | string array | `[]` | Both (additive) | Yes |
+| `agentStuckTimeout` | integer | `30` (seconds) | Both | Yes |
+| `maxConcurrentAgents` | integer ≥1 | unset (unlimited) | Both | Yes |
+| `dynamicWorkflows.agentsToModels` | map | `{}` (Dockerfile discovery) | Both | Yes (dotted path) |
+| `dynamicWorkflows.defaultLeader` | `agent::model` string | unset | Both | Yes |
+| `dynamicWorkflows.maxConcurrentSteps` | integer ≥1 | unset | Both | Yes |
+| `dynamicWorkflows.guidance` | string array (max 50 × 1,000 chars) | `[]` | Both | Yes (indexed path) |
+| `workItems.dir` | string | `aspec/work-items` | Repo only | Yes |
+| `workItems.template` | string | `<workItems.dir>/0000-template.md` | Repo only | Yes |
+| `dockerfile` | string | `Dockerfile.dev` | Repo only | No (edit file) |
+
+Overlays merge additively across sources; other list fields replace (repo overrides global). `maxConcurrentAgents` precedence: `--max-concurrent` flag → `AWMAN_MAX_CONCURRENT_AGENTS` env → repo config → global config → unlimited.
+
+---
+
+## REST API (v0.11.0)
+
+Default port `9876` (configurable via `api.port`), HTTPS self-signed by default. Auth: `Authorization: Bearer <api-key>` (or `--dangerously-skip-auth` at start).
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/v1/status` | Server health (no auth) |
+| `GET` | `/v1/workdirs` | List allowlisted directories |
+| `POST` | `/v1/sessions` | Create session (`{"workdir": "..."}`) |
+| `GET` | `/v1/sessions` | List sessions (`?status=active`) |
+| `GET` | `/v1/sessions/:id` | Session details |
+| `GET` | `/v1/sessions/:id/queue` | Queue status |
+| `DELETE` | `/v1/sessions/:id` | Close session |
+| `POST` | `/v1/commands` | Submit subcommand (`x-awman-session: <id>` header) |
+| `GET` | `/v1/commands/:id` | Command status (`queued`/`running`/`done`/`error`/`cancelled`) |
+| `GET` | `/v1/commands/:id/logs` | Captured output |
+| `GET` | `/v1/commands/:id/logs/stream` | Live output (SSE) |
+| `GET` | `/v1/workflows/:id` | Workflow state for a command |
+
+Commands queue FIFO per session — submission never blocks (returns `command_id`, HTTP 202). A workdir outside the allowlist → HTTP 403; a closing session → HTTP 409; missing/bad key → HTTP 401.
+
+---
+
+## Known Sharp Edges in v0.11.0
+
+1. Not a tmux wrapper — ships its own TUI.
+2. Single per-repo config `GITROOT/.awman/config.json` (same filename as the global `~/.awman/config.json`). Use `awman config show`.
+3. Worktrees are never auto-deleted.
+4. API server is HTTPS self-signed by default — local curl needs `--dangerously-skip-tls` or cert trust.
+5. `runtime` is global-only — no per-repo runtime selection.
+6. Markdown workflows removed (since 0.9.1) — TOML/YAML only.
+7. Lowercase keys only in workflow files.
+8. `--issue` and `--work-item` are mutually exclusive; bare `--issue <N>` requires a GitHub `origin` remote.
+9. `docker-sbx-experimental` does not honor `dir()`, skills, or context overlays; networking is proxy-only (raw TCP/UDP blocked); sandboxes persist between sessions; port mappings are lost when a sandbox stops.
+10. Context overlays default to `rw` — use `context(SCOPE:ro)` to prevent agents modifying accumulated knowledge.
+11. `--dynamic` force-enables `--yolo`, `--worktree`, and `context(workflow)` — there is no supervised dynamic mode.
+12. `maxConcurrentAgents` unset means **unlimited** parallelism; `1` disables it; `0` is rejected.
+13. `~/.awman/logs/` grows unbounded — `awman clean` does not remove failure logs.
+14. Setup-step `on_failure` agents get no automatic failure-output capture (teardown steps do).

--- a/plugins/tools/awman/skills/awman/templates/0.11.0/mise.toml
+++ b/plugins/tools/awman/skills/awman/templates/0.11.0/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+"github:prettysmartdev/awman" = "0.11.0"

--- a/plugins/tools/awman/skills/sources.md
+++ b/plugins/tools/awman/skills/sources.md
@@ -6,6 +6,12 @@ awman was previously named **amux** (repo `prettysmartdev/amux`). The skill was 
 
 ## Release History
 
+### v0.11.0 (2026-07-13, skill updated 2026-07-13)
+- **URL**: https://github.com/prettysmartdev/awman/releases/tag/v0.11.0
+- **Summary**: Additive release, no config migration required. **Dynamic workflows**: `awman exec workflow --dynamic --work-item <N>` launches a leader agent that designs and executes a workflow; `--leader <agent::model>` override; new `dynamicWorkflows` config section (`agentsToModels`, `defaultLeader`, `maxConcurrentSteps`, `guidance`); `--dynamic` force-enables `--yolo`/`--worktree`/`context(workflow)`. **True parallel execution**: steps with identical `depends_on` sets run concurrently; `maxConcurrentAgents` config / `AWMAN_MAX_CONCURRENT_AGENTS` / `--max-concurrent` cap (unset = unlimited, 1 disables, 0 rejected); per-step `abort_on_failure` kills active peers. **Git sidebar** (`Ctrl-G`), parallel-container switching (`Ctrl-S`), config-dialog nested-key editing (`Ctrl-,` + `Ctrl+N`). **`awman clean`** (`--dry-run`, `--yes`; exit codes 0/1/2). **Container failure logging** to `~/.awman/logs/{workflow-id}-{step-name}-{container-name}.log` (never auto-cleaned); teardown `on_failure` agents receive failed output as a file, setup steps get no capture. Fixes: credentials injected via environment; workflow filename path-traversal sanitization; OpenCode prompt handling; Codex Dockerfiles updated for newer GPT models. Docs tree additive: new `13-dynamic-workflows.md`, `14-cleaning-up.md`, `15-parallel-workflows.md` (no renumbering).
+- **Skill changes**: `templates/0.11.0/` snapshot added; SKILL.md gained Dynamic Workflows / Parallel Execution / Cleanup and Failure Logs sections + 4 sharp edges; references/config.md gained `dynamicWorkflows.*` and `maxConcurrentAgents`; references/workflows.md gained parallel-group semantics, `abort_on_failure`, failure-log and teardown-capture contracts; references/api.md re-verified against current `docs/09-api-mode.md` and updated where our 0.10.0-era snapshot had drifted (session `type: local|remote` with remote git-clone sessions, `POST /v1/commands` → `{command_id, flags_applied}` with `non_interactive`/`yolo` API-profile defaults, command status enum `queued/running/done/error/cancelled` with `queue_position`/`worker_id`, `--dangerously-skip-auth`).
+- **Discrepancy noted**: the end-to-end example in upstream `docs/09-api-mode.md` uses `[[steps]]` in a TOML workflow; `docs/05-workflows.md` uses `[[step]]` exclusively (16 occurrences). The skill documents `[[step]]` per the authoritative workflows page.
+
 ### skill update 0.2.1 → 0.2.2 (2026-06-12)
 - **Source verified**: `docs/08-overlays.md` (https://github.com/prettysmartdev/awman/blob/main/docs/08-overlays.md, accessed 2026-06-12) and `docs/03-agent-sessions.md` (accessed 2026-06-12)
 - **Changes**: Added `envPassthrough` removal notice + `env()` overlay migration example to SKILL.md and references/config.md. Added `gemini` deprecation note with `antigravity` migration guidance. Added env-passthrough worked example (ANTHROPIC_BASE_URL pattern) to SKILL.md Overlays section. Updated example global config in references/config.md to show env passthrough via `overlays` array. Added two items to Known Sharp Edges.
@@ -74,8 +80,9 @@ awman was previously named **amux** (repo `prettysmartdev/amux`). The skill was 
 ## Plugin Information
 
 - **Name**: awman
-- **Version**: 0.2.1
+- **Version**: 0.2.4
 - **Description**: awman: parallel AI code agent sessions with container isolation, worktrees, and a REST API
 - **Skills**: 1 skill (awman)
 - **Renamed from amux**: 2026-06-02 (upstream renamed amux → awman; refreshed to v0.9.1)
 - **Refreshed to v0.10.0**: 2026-06-11
+- **Refreshed to v0.11.0**: 2026-07-13

--- a/plugins/tools/awman/skills/sources.toml
+++ b/plugins/tools/awman/skills/sources.toml
@@ -3,7 +3,7 @@
 
 [meta]
 plugin = "awman"
-last_full_check = "2026-06-11"
+last_full_check = "2026-07-13"
 
 # ----------------------------------------------------------------------------
 # awman CLI/TUI — tracked via GitHub releases.
@@ -16,9 +16,9 @@ url = "https://github.com/prettysmartdev/awman"
 releases_url = "https://github.com/prettysmartdev/awman/releases"
 check_method = "github-releases"
 github_repo = "prettysmartdev/awman"
-current_version = "0.10.0"
+current_version = "0.11.0"
 version_constraint = "pre-1.0"
-last_checked = "2026-06-11"
+last_checked = "2026-07-13"
 update_priority = "medium"
 breaking_changes_likely = true
-notes = "Pre-1.0 CLI; minor bumps carry breaking changes (e.g. 0.9.1 dropped Markdown workflows, renamed headless→api). 0.10.0 was additive (no config migration). Create a versioned templates/X.Y.Z/commands.md on each update. Renamed from amux as of 0.9.x. Docs tree renumbered in 0.10.0 (workflows now 05, new 11-github-integration.md, 12-runtimes.md)."
+notes = "Pre-1.0 CLI; minor bumps carry breaking changes (e.g. 0.9.1 dropped Markdown workflows, renamed headless→api). 0.10.0 and 0.11.0 were additive (no config migration). 0.11.0 added dynamic workflows, parallel DAG execution, awman clean, git sidebar, failure logs; docs tree grew 13-dynamic-workflows.md, 14-cleaning-up.md, 15-parallel-workflows.md (no renumbering). Create a versioned templates/X.Y.Z/commands.md on each update. Renamed from amux as of 0.9.x."


### PR DESCRIPTION
- Add `templates/0.11.0/` immutable command snapshot + mise pin (0.9.1 and 0.10.0 retained)
- SKILL.md: refresh pins to 0.11.0; add Dynamic Workflows, Parallel Execution, and Cleanup/Failure Logs sections; add `awman clean` and `--dynamic`/`--max-concurrent` to the command tree; 4 new sharp edges
- references/command-reference.md: `awman clean`, dynamic-mode flags + validation errors, `--max-concurrent`, `--dangerously-skip-auth`, dotted `dynamicWorkflows.*` config-set examples
- references/config.md: `dynamicWorkflows.*` key schema, `maxConcurrentAgents` precedence chain, `AWMAN_MAX_CONCURRENT_AGENTS`
- references/workflows.md: parallel-group semantics, `abort_on_failure`, failure-log path, teardown `on_failure` output-capture contract
- references/api.md: re-verified against current upstream docs; fix drift (session `type: local|remote`, `{command_id, flags_applied}` submit response, `queued/running/done/error/cancelled` status enum, queue fields)
- sources.toml/sources.md: 0.11.0 entry, last-checked dates, upstream `[[steps]]` vs `[[step]]` discrepancy note; fix stale plugin-version line
- Bump awman plugin 0.2.3 → 0.2.4, all-skills 0.4.43 → 0.4.44 (plugin.json + marketplace.json)
- Verified against installed binary: `awman 0.11.0`, `clean --help` flags, `--dynamic requires --work-item` error