### PR TITLE
docs(claude-code): add Claude-5 context-engineering reference and sources

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.55",
+      "version": "0.4.56",
       "category": "meta",
       "keywords": [
         "all",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -95,7 +95,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills: plugin marketplace management and validation",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "category": "tools",
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.55",
+  "version": "0.4.56",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/claude-skills/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-skills/SKILL.md
@@ -413,7 +413,7 @@ claude-skills/
 │   ├── design-patterns.md    # Degree of freedom, validation loops, conditional workflows
 │   ├── evaluation-guide.md   # Eval-driven development, A/B testing, multi-model testing
 │   ├── anti-fabrication.md   # Skill-creation-specific anti-fab guidance
-│   ├── context-engineering-claude-5.md  # What changed for Opus 5 / Sonnet 5 / Fable 5
+│   ├── context-engineering-claude-5.md  # What changed for Claude 5 generation models
 │   └── examples.md           # Annotated skill examples and common pitfalls
 └── templates/
     ├── evaluation-checklist.md  # Copyable eval checklist

--- a/plugins/tools/claude-code/skills/claude-skills/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-skills/SKILL.md
@@ -413,6 +413,7 @@ claude-skills/
 │   ├── design-patterns.md    # Degree of freedom, validation loops, conditional workflows
 │   ├── evaluation-guide.md   # Eval-driven development, A/B testing, multi-model testing
 │   ├── anti-fabrication.md   # Skill-creation-specific anti-fab guidance
+│   ├── context-engineering-claude-5.md  # What changed for Opus 5 / Sonnet 5 / Fable 5
 │   └── examples.md           # Annotated skill examples and common pitfalls
 └── templates/
     ├── evaluation-checklist.md  # Copyable eval checklist

--- a/plugins/tools/claude-code/skills/claude-skills/references/context-engineering-claude-5.md
+++ b/plugins/tools/claude-code/skills/claude-skills/references/context-engineering-claude-5.md
@@ -8,8 +8,8 @@ Anthropic reports: "We removed over 80% of Claude Code's system prompt for model
 and Claude Fable 5 with no measurable loss on our coding evaluations."
 
 The article describes six shifts. Five of them govern skill authoring and are covered below. The
-sixth — moving memory out of CLAUDE.md and into auto-memory — is product behaviour rather than
-authoring guidance, so it is not covered here.
+remaining one — moving memory out of CLAUDE.md and into auto-memory — is product behaviour rather
+than authoring guidance, so it is not covered here.
 
 ## 1. Judgment over rules
 
@@ -88,7 +88,7 @@ rely on an agent recognising a need it does not yet have, keep it prescriptive.
 Verified verbatim against `github.com/anthropics/claude-code/CHANGELOG.md`:
 
 - "`/doctor` is now a full setup checkup that can diagnose and fix issues; `/checkup` is its alias"
-- "Added a `/doctor` check that proposes trimming checked-in CLAUDE.md files by cutting content
+- "Added a `/doctor` check that proposes trimming checked-in `CLAUDE.md` files by cutting content
   Claude could derive from the codebase" — rule 3 applied to project instructions.
 - "raised the listing cap from 250 to 1,536 characters and added a startup warning when descriptions
   are truncated". Note this repo's own validator enforces a stricter 1024-character cap on

--- a/plugins/tools/claude-code/skills/claude-skills/references/context-engineering-claude-5.md
+++ b/plugins/tools/claude-code/skills/claude-skills/references/context-engineering-claude-5.md
@@ -1,0 +1,89 @@
+# Context engineering for Claude 5 generation models
+
+Source: https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models
+(Thariq Shihipar, Anthropic). Applies to Opus 5, Sonnet 5, and Fable 5.
+
+Anthropic reports removing **over 80% of Claude Code's system prompt** for Opus 5 and Fable 5
+with no measurable loss of quality. The five practices below are what replaced it.
+
+## 1. Judgment over rules
+
+Prefer contextual guidance to explicit prohibition lists. "Write code that reads like the
+surrounding code" outperforms "never write multi-line docstrings" — the model infers the
+specific rule from the general one, and the general one covers cases the list would miss.
+
+Applies to: style guidance, best-practice bullets, do/don't tables.
+
+## 2. Tool design over examples
+
+> "giving examples actually constrains them to a certain exploration space"
+
+Invest in parameter and enum design rather than walkthrough examples. A field table with valid
+values teaches more than a worked example, and does not narrow the model's approach to the one
+path the example took.
+
+Keep an example only when it carries information no schema can: a non-obvious composition, or
+a gotcha. Delete examples that merely restate a field table in annotated form.
+
+## 3. Progressive disclosure over upfront loading
+
+> a skill or CLAUDE.md should be "a tree that loads context at the right time, not a central
+> repository"
+
+Spend tokens on gotchas, not on patterns the model can observe directly in the code or in a
+tool schema. A body that summarises each of its own references — then links to them — pays for
+that content on every activation and again on the drill-down.
+
+In this repo, `/claude-code:claude-teams` (96 lines, 4 references) is the shape to imitate;
+`/claude-code:claude-workflows` (114 lines, 3 references) is the second example. A body that
+promises a reference which does not exist is worse than a long body: the detail is advertised
+and unavailable.
+
+## 4. Single statements over repetition
+
+State a rule once, where the thing it governs is defined. The article's example: put usage
+instructions in the tool description rather than restating them in the system prompt.
+
+The repo-level corollary: a number asserted in prose drifts from the number enforced in code.
+Cite the enforcing constant instead of restating its value.
+
+## 5. Prefer code and schema over prose specs
+
+> "a HTML mockup of a design will generally produce better results than a description"
+
+Where a format can be shown as a schema, a table, or runnable code, prefer that to prose.
+
+## The boundary — this repo's own conclusion, not the article's
+
+The article describes tuning a **product system prompt**. Rule 1 does not extend to rules that
+something else depends on:
+
+- **Rules a validator enforces.** Softening "skills never use `allowed-tools`" into guidance
+  breaks the check in `test/validate-plugin.nu` that assumes the rule holds.
+- **Facts a model will otherwise invent.** Valid hook event names, required frontmatter keys,
+  and enum values are not style. Softened, they get fabricated.
+- **Standing disciplines, which must be pushed rather than pulled.** A skill's `Use when`
+  description is a pull mechanism: the model decides it applies. That fails for a discipline
+  whose absence is the trigger condition. `/core:tdd` reads "Use when writing code test-first"
+  — it presupposes the test-first intent the skill exists to instill, so the agent that most
+  needs it is the one whose framing will not match. `/core:twelve-factor` names microservices
+  and Kubernetes while the everyday demand is env-var config discipline. Both under-fire under
+  description-driven activation, which is why they stay in the mandatory always-load set in
+  `/core:agent-loop` "Core Skills (Mandatory)" rather than activating on demand.
+
+Test for the boundary: if removing the prescription would break a check, permit a fabrication,
+or rely on an agent recognising a need it does not yet have, keep it prescriptive.
+
+## Related: the `/doctor` checkup
+
+Verified against `github.com/anthropics/claude-code/CHANGELOG.md`:
+
+- `claude doctor` (CLI, non-interactive) checks installation health only — settings, auth, MCP.
+- In-session `/doctor` (alias `/checkup`) is a full setup checkup that can diagnose and fix
+  issues, and includes a check that proposes trimming checked-in CLAUDE.md files by cutting
+  content Claude could derive from the codebase — rule 3 applied to project instructions.
+- The skill-description listing cap was raised from 250 to **1,536 characters**, with a startup
+  warning when descriptions truncate. Note this repo's own validator enforces a stricter 1024.
+
+Unverified: third-party claims that `/checkup` finds unused skills or duplicate CLAUDE.md
+content do not appear in the primary changelog.

--- a/plugins/tools/claude-code/skills/claude-skills/references/context-engineering-claude-5.md
+++ b/plugins/tools/claude-code/skills/claude-skills/references/context-engineering-claude-5.md
@@ -1,55 +1,64 @@
 # Context engineering for Claude 5 generation models
 
 Source: https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models
-(Thariq Shihipar, Anthropic). Applies to Opus 5, Sonnet 5, and Fable 5.
+(Thariq Shihipar, Anthropic). The article names Claude Opus 5 and Claude Fable 5; it is written for
+the Claude 5 generation broadly.
 
-Anthropic reports removing **over 80% of Claude Code's system prompt** for Opus 5 and Fable 5
-with no measurable loss of quality. The five practices below are what replaced it.
+Anthropic reports: "We removed over 80% of Claude Code's system prompt for models like Claude Opus 5
+and Claude Fable 5 with no measurable loss on our coding evaluations."
+
+The article describes six shifts. Five of them govern skill authoring and are covered below. The
+sixth — moving memory out of CLAUDE.md and into auto-memory — is product behaviour rather than
+authoring guidance, so it is not covered here.
 
 ## 1. Judgment over rules
 
-Prefer contextual guidance to explicit prohibition lists. "Write code that reads like the
-surrounding code" outperforms "never write multi-line docstrings" — the model infers the
-specific rule from the general one, and the general one covers cases the list would miss.
+Prefer contextual guidance to explicit prohibition lists. The article contrasts an old-style rule,
+"Never write multi-paragraph docstrings or multi-line comment blocks — one short line max," with
+the guidance that replaced it: "Write code that reads like the surrounding code: match its comment
+density, naming, and idiom." The general instruction covers cases the list would miss, and the model
+infers the specific rule from it.
 
 Applies to: style guidance, best-practice bullets, do/don't tables.
 
 ## 2. Tool design over examples
 
-> "giving examples actually constrains them to a certain exploration space"
+The article reports that "giving examples actually constrains them to a certain exploration space."
 
-Invest in parameter and enum design rather than walkthrough examples. A field table with valid
-values teaches more than a worked example, and does not narrow the model's approach to the one
-path the example took.
+Invest in parameter and enum design rather than walkthrough examples. A field table with valid values
+teaches more than a worked example, and does not narrow the model's approach to the one path the
+example took.
 
-Keep an example only when it carries information no schema can: a non-obvious composition, or
-a gotcha. Delete examples that merely restate a field table in annotated form.
+Keep an example only when it carries information no schema can: a non-obvious composition, or a
+gotcha. Delete examples that merely restate a field table in annotated form.
 
 ## 3. Progressive disclosure over upfront loading
 
-> a skill or CLAUDE.md should be "a tree that loads context at the right time, not a central
-> repository"
+The article's advice for CLAUDE.md is to "consider having a tree of files that can be loaded at the
+right time." Our restatement of the contrast: a skill is that tree, not a central repository holding
+everything at once.
 
-Spend tokens on gotchas, not on patterns the model can observe directly in the code or in a
-tool schema. A body that summarises each of its own references — then links to them — pays for
-that content on every activation and again on the drill-down.
+It also advises keeping CLAUDE.md lightweight and spending most of the tokens on gotchas — not on
+patterns the model can observe directly in the code or in a tool schema. A body that summarises each
+of its own references, then links to them, pays for that content on every activation and again on
+the drill-down.
 
 In this repo, `/claude-code:claude-teams` (96 lines, 4 references) is the shape to imitate;
-`/claude-code:claude-workflows` (114 lines, 3 references) is the second example. A body that
-promises a reference which does not exist is worse than a long body: the detail is advertised
-and unavailable.
+`/claude-code:claude-workflows` (114 lines, 3 references) is the second example. A body that promises
+a reference which does not exist is worse than a long body: the detail is advertised and unavailable.
 
 ## 4. Single statements over repetition
 
-State a rule once, where the thing it governs is defined. The article's example: put usage
-instructions in the tool description rather than restating them in the system prompt.
+State a rule once, where the thing it governs is defined. The article's example is to "put
+instructions on how to use tools in the tool descriptions rather than the system prompt."
 
-The repo-level corollary: a number asserted in prose drifts from the number enforced in code.
-Cite the enforcing constant instead of restating its value.
+The repo-level corollary: a number asserted in prose drifts from the number enforced in code. Cite
+the enforcing constant instead of restating its value.
 
 ## 5. Prefer code and schema over prose specs
 
-> "a HTML mockup of a design will generally produce better results than a description"
+The article observes that "a HTML mockup of a design will generally produce better results than a
+description of the design or a screenshot."
 
 Where a format can be shown as a schema, a table, or runnable code, prefer that to prose.
 
@@ -58,32 +67,35 @@ Where a format can be shown as a schema, a table, or runnable code, prefer that 
 The article describes tuning a **product system prompt**. Rule 1 does not extend to rules that
 something else depends on:
 
-- **Rules a validator enforces.** Softening "skills never use `allowed-tools`" into guidance
-  breaks the check in `test/validate-plugin.nu` that assumes the rule holds.
-- **Facts a model will otherwise invent.** Valid hook event names, required frontmatter keys,
-  and enum values are not style. Softened, they get fabricated.
-- **Standing disciplines, which must be pushed rather than pulled.** A skill's `Use when`
-  description is a pull mechanism: the model decides it applies. That fails for a discipline
-  whose absence is the trigger condition. `/core:tdd` reads "Use when writing code test-first"
-  — it presupposes the test-first intent the skill exists to instill, so the agent that most
-  needs it is the one whose framing will not match. `/core:twelve-factor` names microservices
-  and Kubernetes while the everyday demand is env-var config discipline. Both under-fire under
-  description-driven activation, which is why they stay in the mandatory always-load set in
-  `/core:agent-loop` "Core Skills (Mandatory)" rather than activating on demand.
+- **Rules a validator enforces.** Softening "skills never use `allowed-tools`" into guidance breaks
+  the check in `test/validate-plugin.nu` that assumes the rule holds.
+- **Facts a model will otherwise invent.** Valid hook event names, required frontmatter keys, and
+  enum values are not style. Softened, they get fabricated.
+- **Standing disciplines, which must be pushed rather than pulled.** A skill's `Use when` description
+  is a pull mechanism: the model decides it applies. That fails for a discipline whose absence is the
+  trigger condition. `/core:tdd` reads "Use when writing code test-first" — it presupposes the
+  test-first intent the skill exists to instill, so the agent that most needs it is the one whose
+  framing will not match. `/core:twelve-factor` names microservices and Kubernetes while the everyday
+  demand is env-var config discipline. Both under-fire under description-driven activation, which is
+  why they stay in the mandatory always-load set in `/core:agent-loop` "Core Skills (Mandatory)"
+  rather than activating on demand.
 
-Test for the boundary: if removing the prescription would break a check, permit a fabrication,
-or rely on an agent recognising a need it does not yet have, keep it prescriptive.
+Test for the boundary: if removing the prescription would break a check, permit a fabrication, or
+rely on an agent recognising a need it does not yet have, keep it prescriptive.
 
 ## Related: the `/doctor` checkup
 
-Verified against `github.com/anthropics/claude-code/CHANGELOG.md`:
+Verified verbatim against `github.com/anthropics/claude-code/CHANGELOG.md`:
 
-- `claude doctor` (CLI, non-interactive) checks installation health only — settings, auth, MCP.
-- In-session `/doctor` (alias `/checkup`) is a full setup checkup that can diagnose and fix
-  issues, and includes a check that proposes trimming checked-in CLAUDE.md files by cutting
-  content Claude could derive from the codebase — rule 3 applied to project instructions.
-- The skill-description listing cap was raised from 250 to **1,536 characters**, with a startup
-  warning when descriptions truncate. Note this repo's own validator enforces a stricter 1024.
+- "`/doctor` is now a full setup checkup that can diagnose and fix issues; `/checkup` is its alias"
+- "Added a `/doctor` check that proposes trimming checked-in CLAUDE.md files by cutting content
+  Claude could derive from the codebase" — rule 3 applied to project instructions.
+- "raised the listing cap from 250 to 1,536 characters and added a startup warning when descriptions
+  are truncated". Note this repo's own validator enforces a stricter 1024-character cap on
+  `description` (`test/validate-skills-quality.nu:389`).
 
-Unverified: third-party claims that `/checkup` finds unused skills or duplicate CLAUDE.md
-content do not appear in the primary changelog.
+Changelog entries show the non-interactive `claude doctor` CLI covering installation, settings, auth,
+and MCP diagnostics. No changelog line states that scope is exhaustive.
+
+Unverified: third-party claims that `/checkup` finds unused skills or duplicate CLAUDE.md content do
+not appear in the primary changelog.

--- a/plugins/tools/claude-code/skills/sources.md
+++ b/plugins/tools/claude-code/skills/sources.md
@@ -409,20 +409,21 @@ Create a modular Claude Code plugin marketplace that:
   - Schema compliance checking
   - Automated template generation
   - Nushell-based validation scripts
+
 ## Context Engineering for Claude 5 Models
 
 ### The New Rules of Context Engineering for Claude 5 Generation Models
 - **URL**: https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models
 - **Author**: Thariq Shihipar, Anthropic
-- **Purpose**: How prompt, skill, and CLAUDE.md authoring changes for Opus 5 / Sonnet 5 / Fable 5; basis for the skill-authoring conventions in claude-skills
+- **Purpose**: How prompt, skill, and CLAUDE.md authoring changes for Claude 5 generation models (the article names Opus 5 and Fable 5); basis for the skill-authoring conventions in claude-skills
 - **Date Accessed**: 2026-07-25
 - **Key Points**:
-  - Over 80% of Claude Code's system prompt was removed for Opus 5 and Fable 5 with no measurable loss
-  - Judgment over rules — contextual guidance beats explicit prohibition lists
+  - Over 80% of Claude Code's system prompt was removed for Opus 5 and Fable 5 "with no measurable loss on our coding evaluations"
+  - Judgment over rules — contextual guidance beats explicit prohibition lists (the article describes six shifts; the sixth, CLAUDE.md memory to auto-memory, is product behaviour and is not covered in the reference)
   - Tool design over examples — "giving examples actually constrains them to a certain exploration space"; invest in parameter and enum design
-  - Progressive disclosure over upfront loading — a skill or CLAUDE.md should be "a tree that loads context at the right time, not a central repository"
+  - Progressive disclosure over upfront loading — "consider having a tree of files that can be loaded at the right time"
   - Single statements over repetition — state a rule once, where the thing it governs is defined
-  - Prefer code and schema over prose specs — "a HTML mockup of a design will generally produce better results than a description"
+  - Prefer code and schema over prose specs — "a HTML mockup of a design will generally produce better results than a description of the design or a screenshot"
   - Keep CLAUDE.md lightweight; spend tokens on gotchas, not patterns Claude can observe in the code
 - **Boundary noted in the reference (this repo's conclusion, not the article's)**: rule 1 does not extend to rules a validator enforces, facts a model would otherwise fabricate, or standing disciplines that must be pushed rather than pulled — see the reference for the test
 - **Used In**: skills/claude-skills/references/context-engineering-claude-5.md, skills/claude-skills/SKILL.md
@@ -432,7 +433,7 @@ Create a modular Claude Code plugin marketplace that:
 - **Purpose**: Verifying what `claude doctor` and the in-session `/doctor` (alias `/checkup`) actually check, and the current skill-description listing cap
 - **Date Accessed**: 2026-07-25
 - **Key Points**:
-  - `claude doctor` (CLI) checks installation health only — settings, auth, MCP
+  - `claude doctor` (CLI) covers installation, settings, auth, and MCP diagnostics
   - In-session `/doctor` is a full setup checkup that can diagnose and fix issues
   - `/doctor` includes a check proposing to trim checked-in CLAUDE.md files by cutting content Claude could derive from the codebase
   - Skill-description listing cap raised from 250 to 1,536 characters, with a startup warning when descriptions truncate

--- a/plugins/tools/claude-code/skills/sources.md
+++ b/plugins/tools/claude-code/skills/sources.md
@@ -419,7 +419,7 @@ Create a modular Claude Code plugin marketplace that:
 - **Date Accessed**: 2026-07-25
 - **Key Points**:
   - Over 80% of Claude Code's system prompt was removed for Opus 5 and Fable 5 "with no measurable loss on our coding evaluations"
-  - Judgment over rules — contextual guidance beats explicit prohibition lists (the article describes six shifts; the sixth, CLAUDE.md memory to auto-memory, is product behaviour and is not covered in the reference)
+  - Judgment over rules — contextual guidance beats explicit prohibition lists (the article describes six shifts; the remaining one, CLAUDE.md memory to auto-memory, is product behaviour and is not covered in the reference)
   - Tool design over examples — "giving examples actually constrains them to a certain exploration space"; invest in parameter and enum design
   - Progressive disclosure over upfront loading — "consider having a tree of files that can be loaded at the right time"
   - Single statements over repetition — state a rule once, where the thing it governs is defined

--- a/plugins/tools/claude-code/skills/sources.md
+++ b/plugins/tools/claude-code/skills/sources.md
@@ -409,3 +409,32 @@ Create a modular Claude Code plugin marketplace that:
   - Schema compliance checking
   - Automated template generation
   - Nushell-based validation scripts
+## Context Engineering for Claude 5 Models
+
+### The New Rules of Context Engineering for Claude 5 Generation Models
+- **URL**: https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models
+- **Author**: Thariq Shihipar, Anthropic
+- **Purpose**: How prompt, skill, and CLAUDE.md authoring changes for Opus 5 / Sonnet 5 / Fable 5; basis for the skill-authoring conventions in claude-skills
+- **Date Accessed**: 2026-07-25
+- **Key Points**:
+  - Over 80% of Claude Code's system prompt was removed for Opus 5 and Fable 5 with no measurable loss
+  - Judgment over rules — contextual guidance beats explicit prohibition lists
+  - Tool design over examples — "giving examples actually constrains them to a certain exploration space"; invest in parameter and enum design
+  - Progressive disclosure over upfront loading — a skill or CLAUDE.md should be "a tree that loads context at the right time, not a central repository"
+  - Single statements over repetition — state a rule once, where the thing it governs is defined
+  - Prefer code and schema over prose specs — "a HTML mockup of a design will generally produce better results than a description"
+  - Keep CLAUDE.md lightweight; spend tokens on gotchas, not patterns Claude can observe in the code
+- **Boundary noted in the reference (this repo's conclusion, not the article's)**: rule 1 does not extend to rules a validator enforces, facts a model would otherwise fabricate, or standing disciplines that must be pushed rather than pulled — see the reference for the test
+- **Used In**: skills/claude-skills/references/context-engineering-claude-5.md, skills/claude-skills/SKILL.md
+
+### Claude Code CHANGELOG — `/doctor` and skill-description limits
+- **URL**: https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md
+- **Purpose**: Verifying what `claude doctor` and the in-session `/doctor` (alias `/checkup`) actually check, and the current skill-description listing cap
+- **Date Accessed**: 2026-07-25
+- **Key Points**:
+  - `claude doctor` (CLI) checks installation health only — settings, auth, MCP
+  - In-session `/doctor` is a full setup checkup that can diagnose and fix issues
+  - `/doctor` includes a check proposing to trim checked-in CLAUDE.md files by cutting content Claude could derive from the codebase
+  - Skill-description listing cap raised from 250 to 1,536 characters, with a startup warning when descriptions truncate
+- **Verification note**: third-party claims that `/checkup` finds unused skills or duplicate CLAUDE.md content were NOT found in the primary changelog and are excluded
+- **Used In**: skills/claude-skills/references/context-engineering-claude-5.md


### PR DESCRIPTION
Documents Anthropic's context-engineering guidance for Claude 5 generation models as a reference in the `claude-skills` skill, with full provenance in `sources.md`. Groundwork for claude-skills-123 (the skill-authoring pass), which needs a citable source rather than a conversation.

- `references/context-engineering-claude-5.md` (89 lines) — the five shifted practices with the article's own quotes: judgment over rules, tool design over examples, progressive disclosure over upfront loading, single statements over repetition, and code/schema over prose specs. Plus the headline: over 80% of Claude Code's system prompt was removed for Opus 5 and Fable 5 with no measurable loss.
- Two `sources.md` sections following the existing `URL / Purpose / Date Accessed / Key Points / Used In` format — one for the article, one for the Claude Code CHANGELOG entries covering `/doctor` and the skill-description listing cap.

Two things the reference is careful about:

**The boundary is marked as ours, not the article's.** Rule 1 (judgment over rules) does not extend to rules a validator enforces, facts a model would otherwise fabricate, or standing disciplines that must be pushed rather than pulled. That section is labelled as this repo's conclusion, because we derived it by getting it wrong — trimming `/core:tdd` and `/core:twelve-factor` out of the mandatory set in an earlier revision of #131 and having to reverse it. A future reader should not think Anthropic published the caveat.

It ends with a usable test rather than a principle: if removing a prescription would break a check, permit a fabrication, or depend on an agent recognising a need it does not yet have, keep it prescriptive.

**Unverified claims are recorded as unverified.** Third-party assertions that `/checkup` finds unused skills or duplicate CLAUDE.md content do not appear in the primary changelog, so they are named and excluded in both files rather than quietly dropped.

The reference is linked from the `claude-skills` References tree, so it is not an orphan.
