### PR TITLE
test(core): anchor satellite load lists and delete the annotated-bullet grammar

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.57",
+      "version": "0.4.58",
       "category": "meta",
       "keywords": [
         "all",
@@ -114,7 +114,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.2.26",
+      "version": "0.2.27",
       "category": "development",
       "keywords": [
         "git",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.57",
+  "version": "0.4.58",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/commands/work.md
+++ b/plugins/core/commands/work.md
@@ -17,10 +17,12 @@ Invoke the Skill tool for each by exact name before any other step:
 - `/core:security`
 - `/core:mise`
 - `/core:nushell`
-- `/core:agent-loop` (carries Forge: paired teams, the hands pattern, fan-out)
-- `/core:bees` (the tracker)
+- `/core:agent-loop`
+- `/core:bees`
 - `/claude-code:claude-agents` (always, before spawning) and `/claude-code:claude-teams` (when spawning ≥2 parallel workers)
 - Domain skills for the target's labels, by exact name.
+
+`/core:agent-loop` carries Forge (paired teams, the hands pattern, fan-out); `/core:bees` is the tracker.
 
 Canonical list: `/core:agent-loop` "Core Skills (Mandatory)"; drift-checked in CI.
 

--- a/test/README.md
+++ b/test/README.md
@@ -17,7 +17,7 @@ mise test
 
 `mise run ci` is the canonical CI gate (matches the workspace-wide convention);
 it depends on `test`, which depends on `test:claude`, `test:marketplace`,
-`test:plugins`, and `test:skills-quality`.
+`test:plugins`, `test:skills-quality`, `test:core-list`, and `test:disclosure`.
 
 `test:version-bumps` is deliberately **not** a dependency of `test` — it
 needs a real base ref to diff against, which is only meaningful with the
@@ -60,6 +60,21 @@ mise test:claude
 
 Locally, a missing mise-managed `claude` binary is a warning (skip). Under
 CI (`$env.CI` set), a missing binary is a hard failure.
+
+### Test Core Skill List
+
+Checks that the mandatory core skill list has not drifted: every satellite
+file's operative load list (located via a per-file anchor line) matches the
+canonical block in `agent-loop/SKILL.md`, every other list in those files
+agrees too, and no unregistered `.md`/`.sh` file carries a near-complete
+copy of the list. Runs its own fixture suite first:
+
+```bash
+mise test:core-list
+# or directly
+nu test/validate-core-list.nu --self-test
+nu test/validate-core-list.nu
+```
 
 ### Test Version Bumps
 
@@ -191,6 +206,7 @@ Use `/benchmark-skills` for a more detailed analysis with category classificatio
 
 - **validate-plugin.nu** — Validates a specific plugin (name, kebab-case, invalid fields, skill paths)
 - **validate-skills-quality.nu** — Skill quality scorecard plus agents/commands/hooks surface pass, both ratchet-baseline enforced (`--update-baseline` to regenerate, shrink-only)
+- **validate-core-list.nu** — Verifies the mandatory core skill list is identical across the canonical block and all anchored satellite load lists, and sweeps for unregistered files carrying a near-complete copy (`--self-test` runs its fixtures)
 - **check-version-bumps.nu** — Verifies every plugin with changed files bumped `plugin.json` and `marketplace.json` versions against a base ref; hard-fails on a missing/invalid base ref
 
 `quality-baseline.json` is the ratchet baseline data file consumed by `validate-skills-quality.nu` — not a script, but tracked here since it gates CI.

--- a/test/validate-core-list.nu
+++ b/test/validate-core-list.nu
@@ -63,6 +63,10 @@
 #   - Anchors are semantics-blind regex substrings: a lead-in that NEGATES
 #     the instruction ("Do NOT ... invoke each of these by exact name")
 #     still anchors. Inherent to a grammar check.
+#   - Fence indentation is judged against the LINE, not its container: a
+#     future satellite nesting a fence 4+ spaces deep inside a sub-list
+#     would have its delimiters misread as indented-code content, because
+#     container-relative indentation is out of scope for a line-based lint.
 #
 # Usage:
 #   nu test/validate-core-list.nu
@@ -349,26 +353,43 @@ def file-canonical-overlap [lines: list<string>, canonical: list<string>] {
 # the delimiter lines themselves. Used to keep satellite anchors from
 # matching inside worked examples.
 #
-# CommonMark-faithful where it matters: an opener is a backtick or tilde
-# delimiter of length 3+, recorded with its CHARACTER and LENGTH; while
-# in-fence, only a bare delimiter of the SAME character with AT LEAST the
-# opener's length closes it (a closing fence carries no info string). Naive
-# parity-flipping on any ``` prefix reopened the anchor theft two ways: a
-# bare ``` inside a ```` block flipped state off and classified the rest of
-# the block out-of-fence, and ~~~ fences were not recognised at all — both
-# are live shapes in this repo (four-backtick outer fences exist precisely
-# because references documents show fenced examples).
+# CommonMark-faithful where it matters, on both sides of the state machine.
+#
+# OPENERS: a backtick or tilde delimiter of length 3+, indented at most 3
+# spaces, recorded with its CHARACTER and LENGTH. Two phantom shapes the
+# raw prefix regex admitted are rejected because each desyncs the state so
+# the NEXT REAL opener is consumed as a closer (classifying a genuine
+# example's interior as out-of-fence and reopening anchor theft):
+#   - a backtick "opener" whose info string contains a backtick — per
+#     CommonMark that is a paragraph with an inline code span (```nu```
+#     prose), since a backtick fence's info string may not contain
+#     backticks; tilde info strings may contain anything.
+#   - a delimiter indented 4+ spaces — at top level that is indented-code
+#     CONTENT, which is exactly how docs show fence syntax literally.
+#
+# CLOSERS: only a bare delimiter (no info string) of the SAME character
+# with AT LEAST the opener's length, indented at most 3 spaces. Naive
+# parity-flipping failed both ways: a bare ``` inside a ```` block flipped
+# state off, and ~~~ fences were not recognised at all — live shapes in
+# this repo.
 def fence-flags [lines: list<string>] {
   mut flags = []
   mut fence_char = null   # "`" or "~" while inside a fence, else null
   mut fence_len = 0
 
   for line in $lines {
+    let delim = ($line | parse -r '^ {0,3}(?<d>`{3,}|~{3,})' | get -o 0.d)
     let t = ($line | str trim)
-    let delim = ($t | parse -r '^(?<d>`{3,}|~{3,})' | get -o 0.d)
 
     if $fence_char == null {
-      if $delim != null {
+      let opens = (if $delim == null {
+        false
+      } else if ($delim | str starts-with "`") {
+        $line =~ '^ {0,3}`{3,}[^`]*$'
+      } else {
+        true
+      })
+      if $opens {
         $flags = ($flags | append true)
         $fence_char = ($delim | str substring 0..0)
         $fence_len = ($delim | str length)
@@ -377,8 +398,6 @@ def fence-flags [lines: list<string>] {
       }
     } else {
       $flags = ($flags | append true)
-      # A closer is ONLY the delimiter (no info string), same character,
-      # at least the opener's length.
       let closes = (($delim != null)
         and ($t == $delim)
         and (($delim | str substring 0..0) == $fence_char)
@@ -393,11 +412,12 @@ def fence-flags [lines: list<string>] {
   $flags
 }
 
-# A line that is a fence delimiter of either CommonMark kind. Shared by the
-# adjacency scan and the run-finder so they cannot disagree with fence-flags
-# about what counts as fence syntax.
+# A line that is a fence delimiter of either CommonMark kind, mirroring
+# fence-flags' opener rules (≤3-space indent; backtick-free info string for
+# backtick fences). Shared by the adjacency scan and the run-finder so they
+# cannot disagree with fence-flags about what counts as fence syntax.
 def is-fence-delimiter [line: string] {
-  ($line | str trim) =~ '^(`{3,}|~{3,})'
+  ($line =~ '^ {0,3}`{3,}[^`]*$') or ($line =~ '^ {0,3}~{3,}')
 }
 
 # Find the load LISTS in the given lines, as contiguous runs of names-only
@@ -666,6 +686,18 @@ def self-test [] {
       why: "reviewer PoC 7b: ~~~ is a valid CommonMark fence; unrecognised, its whole block was classified out-of-fence"
       content: "~~~\ncontent line\n~~~\nafter\n"
       expect: [true true true false]
+    }
+    {
+      name: "backtick_opener_with_backtick_info_string_is_prose"
+      why: "reviewer PoC 8a: ```nu``` at line start is a paragraph with an inline code span, not a fence — a backtick info string may not contain backticks; a phantom open here consumes the next real opener as a closer"
+      content: "```nu``` is the fence form used throughout these references.\nafter\n"
+      expect: [false false]
+    }
+    {
+      name: "indented_delimiter_is_content"
+      why: "reviewer PoC 8b: a delimiter indented 4+ spaces is indented-code CONTENT at top level — how docs show fence syntax literally; a phantom open here desyncs the same way"
+      content: "    ```\nafter\n"
+      expect: [false false]
     }
   ]
 

--- a/test/validate-core-list.nu
+++ b/test/validate-core-list.nu
@@ -5,99 +5,94 @@
 # The canonical copy lives in plugins/core/skills/agent-loop/SKILL.md under
 # the "## Core Skills (Mandatory)" heading. Every satellite file must carry
 # the same set of names in an actual LOAD LIST, not merely somewhere in its
-# prose.
+# prose. (Substring presence over the whole file was the original check; when
+# the list was trimmed from 10 names to 8, five satellites passed while their
+# real load lists were stale, because the removed names lingered in prose.)
 #
-# Why structural, not substring: an earlier version checked
-# `$content | str contains $name` over the whole file. When the mandatory
-# list was trimmed from 10 names to 8, five satellites passed that check
-# while their real load lists were stale, because the removed names still
-# appeared in explanatory prose. Substring presence is not list membership.
+# Structure of the check, per satellite:
 #
-# Two load-list grammars are recognised:
+#   1. GRAMMAR — a load-list line is a names-only line: after stripping list
+#      markers, whitespace and backticks, the line is one or more skill-shaped
+#      names separated by commas. A contiguous RUN of such lines carrying 2+
+#      /core: names is a load list; anything else (prose, annotated bullets,
+#      fence delimiters) is not.
 #
-#   G1  names-only line — the whole line, after stripping list markers,
-#       whitespace and backticks, is one or more skill-shaped names
-#       separated by commas. Covers the canonical fenced block, the
-#       comma-separated fences in the tier references, the mixed
-#       /core: + /elixir: block in leader-spawn-example.md, the indented
-#       bullets in the operator CLAUDE.md template, and the session-start
-#       hook's one-name-per-line list.
+#   2. EVERY RUN MUST MATCH — each run is compared to the canonical set
+#      independently, both directions (missing canonical name / extra /core:
+#      name). A file-wide union admitted silent false passes: a stale worked
+#      example or a prose bullet elsewhere in the file patched a deleted name
+#      back into the union. leader-spawn-example.md exists to carry worked
+#      examples, so this is a live risk, not hypothetical.
 #
-#   G2  bullet whose FIRST token is a /core: name — covers commands/work.md,
-#       whose bullets carry trailing annotations. The first-token rule is
-#       what stops prose bullets (e.g. "- **Tracker state:** a repo tracked
-#       by beads loads `/core:beads` ...") from being read as load lists.
+#   3. ANCHOR — each satellite registers a regex for the lead-in line that
+#      sits directly above its operative load list. The anchor must match
+#      exactly once, and the first line after it that is neither blank nor a
+#      fence delimiter must BEGIN a qualifying run. Without this, the check
+#      only proved "at least one canonical run exists and no visible run
+#      disagrees" — the operative list could be deleted outright, or
+#      annotated into invisibility (em-dash bullets fail the grammar), and
+#      CI stayed green. Anchoring is ADDITIVE: rule 2 still applies to every
+#      run, anchored or not.
 #
-# Lists are compared per contiguous RUN of list lines, and EVERY run must
-# match the canonical set. A file-wide union of names was the original design
-# and it admitted silent false passes: with a name deleted from the real list,
-# a paren-annotated prose bullet or a fenced worked example elsewhere in the
-# file put the name back into the union and the file passed green. Checking
-# each run independently closes that, while still permitting a satellite to
-# carry more than one correct list (leader-spawn-example.md exists to hold a
-# worked example).
+#   4. SWEEP — every git-tracked .md/.sh file NOT registered as a satellite
+#      fails if it carries a run with EXPECTED_COUNT - 2 or more CANONICAL
+#      names. A file carrying (nearly) the full stack is a de-facto ninth
+#      satellite and must be registered, or it drifts unchecked. Overlap with
+#      the canonical set is the discriminator — several files legitimately
+#      list 5 non-canonical or partial /core: stacks and must stay silent.
 #
-# A run carrying fewer than 2 /core: names is ignored — that is what lets a
-# lone prose mention exist without being read as a list.
-#
-# Both drift directions are checked against every run: a canonical name
-# MISSING from it, and an EXTRA /core: name present in it but absent from the
-# canonical block.
-#
-# What this still cannot see:
-#   - A load list written in a form neither grammar recognises. validator.md:7
-#     is such a case (inline numbered item), acceptable only because it is an
-#     excluded partial — see EXCLUDED_PARTIAL.
-#   - A paren-annotated bullet inside a run counts as an entry regardless of
-#     what the annotation SAYS. "- `/core:tdd` (NOT loaded by default)" passes.
-#     This is a real gap, not a property: the fix is deleting G2 and requiring
-#     names-only lines. Tracked in claude-skills-134, fixture in --self-test.
-#   - A real list annotated with em-dashes is invisible to both grammars, so a
-#     satellite can pass with no operative list at all. The fix is anchoring to
-#     a marker rather than searching for a list. Also claude-skills-134.
-#   - Prose mentions, by design, so restraint/SKILL.md and restraint/README.md
-#     may discuss /core:tdd freely.
-#
-# Known false FAIL, accepted because it is loud: a blank line inside a single
-# logical list splits it into two runs, and a partial list (2+ names but not
-# the full set) is rejected even when deliberate. Both surface as an explicit
-# failure naming the parsed runs, never as a silent pass.
+# Known limits, all loud or deliberate:
+#   - A blank line inside one logical list splits it into two runs and the
+#     partial runs are rejected — a false FAIL that surfaces explicitly,
+#     never a silent pass.
+#   - Prose mentions are ignored by design; restraint/SKILL.md may discuss
+#     /core:tdd freely.
+#   - Files carrying a deliberate SUBSET of the stack (fewer than
+#     EXPECTED_COUNT - 2 canonical names) are invisible to the sweep.
+#     Whether per-tier subsets are legitimate at all is claude-skills-125;
+#     today references/fix-agent.md (4 names) relies on this, and
+#     references/validator.md's inline numbered list (3 names) is a form the
+#     grammar does not parse at all.
 #
 # Usage:
 #   nu test/validate-core-list.nu
+#   nu test/validate-core-list.nu --self-test
 
 const CANONICAL_FILE = "plugins/core/skills/agent-loop/SKILL.md"
 const CANONICAL_HEADING = "## Core Skills (Mandatory)"
 const EXPECTED_COUNT = 10
 
 # One definition of each name shape, shared by the canonical extractor and
-# both grammars. Keeping these separate previously let them disagree on case
+# the grammar. Keeping these separate previously let them disagree on case
 # and digits, so a name like /core:s3-tools parsed in a satellite but was
 # dropped from the canonical block, surfacing as a confusing count mismatch.
 const CORE_NAME = '^/core:[a-z][a-z0-9-]*$'
 const SKILL_NAME = '^/[a-z][a-z0-9-]*:[a-z][a-z0-9-]*$'
 
+# Each satellite pairs the file with the anchor regex for the line DIRECTLY
+# above its operative load list (blank lines and fence delimiters may sit
+# between). If a lead-in is reworded, the check fails naming the expected
+# regex — update the wording here in the same change.
 const SATELLITES = [
   # The canonical block lives in this file and parses as a load list, so the
   # missing-name direction is vacuous here (canonical is always a subset of
-  # itself). Its entry earns its place on the EXTRA direction.
-  "plugins/core/skills/agent-loop/SKILL.md"
-  "plugins/core/skills/agent-loop/references/team-leader.md"
-  "plugins/core/skills/agent-loop/references/sub-team-leader.md"
-  "plugins/core/skills/agent-loop/references/agent-worker.md"
-  "plugins/core/skills/agent-loop/references/leader-spawn-example.md"
-  "plugins/core/commands/work.md"
-  "plugins/core/hooks/session-start.sh"
-  "plugins/tools/claude-code/templates/CLAUDE.md"
-]
-
-# Files that carry a deliberate SUBSET of the core stack, so the
-# missing-name direction does not apply to them. Whether per-tier subsets
-# are legitimate at all is claude-skills-125; until that lands, list them
-# here with the reason rather than silently omitting them.
-const EXCLUDED_PARTIAL = [
-  "plugins/core/skills/agent-loop/references/validator.md"   # 3 names, inline numbered item
-  "plugins/core/skills/agent-loop/references/fix-agent.md"   # 4 names
+  # itself). Its entry earns its place on the EXTRA direction and the anchor.
+  { path: "plugins/core/skills/agent-loop/SKILL.md"
+    anchor: "Every agent at every tier loads these before any work" }
+  { path: "plugins/core/skills/agent-loop/references/team-leader.md"
+    anchor: "Load core skills" }
+  { path: "plugins/core/skills/agent-loop/references/sub-team-leader.md"
+    anchor: "Load core skills" }
+  { path: "plugins/core/skills/agent-loop/references/agent-worker.md"
+    anchor: "Load core skills" }
+  { path: "plugins/core/skills/agent-loop/references/leader-spawn-example.md"
+    anchor: "## Load skills" }
+  { path: "plugins/core/commands/work.md"
+    anchor: "Invoke the Skill tool for each by exact name" }
+  { path: "plugins/core/hooks/session-start.sh"
+    anchor: "invoke each of these by exact name" }
+  { path: "plugins/tools/claude-code/templates/CLAUDE.md"
+    anchor: "instruct team members/tasks to always load these core skills first" }
 ]
 
 def main [--self-test] {
@@ -122,60 +117,47 @@ def main [--self-test] {
   mut failures = []
 
   for satellite in $SATELLITES {
-    let path = ($repo_root | path join $satellite)
+    let path = ($repo_root | path join $satellite.path)
     if not ($path | path exists) {
-      $failures = ($failures | append { file: $satellite, missing: ["<file not found>"], extra: [], lists: [] })
+      $failures = ($failures | append { file: $satellite.path, errors: ["file not found"], missing: [], extra: [], lists: [] })
       continue
     }
 
-    let runs = (find-load-list-runs $path)
+    let result = (check-satellite (open --raw $path | lines) $satellite.anchor $canonical_names)
 
-    if ($runs | is-empty) {
-      $failures = ($failures | append { file: $satellite, missing: ["<no load list recognised>"], extra: [], lists: [] })
-      continue
-    }
-
-    # EVERY qualifying run must match the canonical set. A satellite may hold
-    # more than one list — leader-spawn-example.md exists to carry worked
-    # examples — and a second correct list is not a defect. What the union
-    # design allowed was a run that DISAGREES with canonical hiding behind one
-    # that agrees; checking each run independently closes that without
-    # forbidding legitimate duplicates.
-    mut file_missing = []
-    mut file_extra = []
-
-    for run in $runs {
-      $file_missing = ($file_missing | append ($canonical_names | where { |name| $name not-in $run }))
-      $file_extra = ($file_extra | append ($run | where { |name| $name not-in $canonical_names }))
-    }
-
-    let missing = ($file_missing | uniq | sort)
-    let extra = ($file_extra | uniq | sort)
-
-    if (($missing | length) > 0) or (($extra | length) > 0) {
-      $failures = ($failures | append {
-        file: $satellite,
-        missing: $missing,
-        extra: $extra,
-        lists: (if ($runs | length) > 1 { $runs | each { |r| $"[($r | str join ', ')]" } } else { [] })
-      })
+    if (($result.errors | is-not-empty) or ($result.missing | is-not-empty) or ($result.extra | is-not-empty)) {
+      $failures = ($failures | append ($result | insert file $satellite.path))
     } else {
-      print $"  ✓ ($satellite)"
+      print $"  ✓ ($satellite.path)"
     }
   }
 
-  if ($failures | length) > 0 {
-    print $"\n(ansi red_bold)❌ Core list drift detected:(ansi reset)\n"
-    for failure in $failures {
-      if ($failure.missing | is-not-empty) {
-        print $"  • ($failure.file): missing from load list — ($failure.missing | str join ', ')"
+  let sweep_violations = (sweep-unregistered $canonical_names)
+
+  if (($failures | length) > 0) or (($sweep_violations | length) > 0) {
+    if ($failures | length) > 0 {
+      print $"\n(ansi red_bold)❌ Core list drift detected:(ansi reset)\n"
+      for failure in $failures {
+        for err in $failure.errors {
+          print $"  • ($failure.file): ($err)"
+        }
+        if ($failure.missing | is-not-empty) {
+          print $"  • ($failure.file): missing from load list — ($failure.missing | str join ', ')"
+        }
+        if ($failure.extra | is-not-empty) {
+          print $"  • ($failure.file): extra in load list — ($failure.extra | str join ', ')"
+        }
+        if ($failure.lists | is-not-empty) {
+          print $"    ($failure.lists | length) separate lists parsed in this file; every one must match canonical — ($failure.lists | str join ' and ')"
+        }
       }
-      if ($failure.extra | is-not-empty) {
-        print $"  • ($failure.file): extra in load list — ($failure.extra | str join ', ')"
+    }
+    if ($sweep_violations | length) > 0 {
+      print $"\n(ansi red_bold)❌ Unregistered file\(s\) carry a near-complete core load list:(ansi reset)\n"
+      for v in $sweep_violations {
+        print $"  • ($v.file): ($v.names | str join ', ')"
       }
-      if ($failure.lists | is-not-empty) {
-        print $"    ($failure.lists | length) separate lists parsed in this file; every one must match canonical — ($failure.lists | str join ' and ')"
-      }
+      print $"\nRegister the file in SATELLITES \(with an anchor\) in test/validate-core-list.nu, or trim the list."
     }
     print $"\nThe canonical block is ($CANONICAL_FILE) under \"($CANONICAL_HEADING)\"."
     exit 1
@@ -186,7 +168,10 @@ def main [--self-test] {
 }
 
 # Extract the /core:* names listed in the canonical block of the given file,
-# between the canonical heading and the next level-2 (## ) heading.
+# between the canonical heading and the closing fence of the first fenced
+# block after it. (Terminating at the next "## " heading was wrong: "### ..."
+# subheadings do not match it, and the parsed block absorbed bare names from
+# the following subsection.)
 def extract-canonical-names [file: string] {
   let lines = (open --raw $file | lines)
   let heading_idx = ($lines | enumerate | where { |it| $it.item == $CANONICAL_HEADING } | get -o 0.index)
@@ -196,10 +181,6 @@ def extract-canonical-names [file: string] {
     exit 1
   }
 
-  # Terminate at the closing fence of the first fenced block after the heading.
-  # Terminating at the next "## " heading was wrong: "### Skills to load before
-  # spawning" does not match it, so the parsed block ran 35 lines past the fence
-  # and absorbed any bare skill name in that subsection into the canonical set.
   let rest = ($lines | skip ($heading_idx + 1))
   let fence_open = ($rest | enumerate | where { |it| ($it.item | str trim) | str starts-with "```" } | get -o 0.index)
 
@@ -233,50 +214,140 @@ def extract-canonical-names [file: string] {
   $names
 }
 
-# Find the load LISTS in a file, as contiguous runs of list lines.
-#
-# Comparing a file-wide UNION of names was the original design and it admitted
-# silent false passes: with a name deleted from the real list, any second
-# occurrence elsewhere in the file restored it to the union and the file
-# passed. Both a paren-annotated prose bullet and a fenced worked example are
-# natural idioms that did this. Runs fix it — a name has to appear in the list
-# itself, not merely somewhere in the file.
-#
-# A run is a maximal sequence of consecutive lines that each parse as a list
-# line under G1 or G2. Runs carrying fewer than 2 /core: names are ignored:
-# that is what keeps a lone prose bullet or a one-name example from counting
-# as a list.
-#
-# Returns a list of runs, each a sorted list of /core: names.
-def find-load-list-runs [file: string] {
-  let lines = (open --raw $file | lines)
+# Validate one satellite's content: anchor uniqueness, run adjacency to the
+# anchor, and every-run-must-match. Returns
+# { errors: [...], missing: [...], extra: [...], lists: [...] }.
+# `errors` carries the anchor/adjacency hard failures; missing/extra carry the
+# per-run drift, aggregated.
+def check-satellite [lines: list<string>, anchor: string, canonical: list<string>] {
+  let runs = (find-load-list-runs $lines)
 
+  mut errors = []
+
+  let anchor_hits = ($lines | enumerate | where { |it| $it.item =~ $anchor })
+
+  if ($anchor_hits | is-empty) {
+    $errors = ($errors | append $"anchor not found — no line matches '($anchor)'. The operative load list is anchored to that lead-in; if it was reworded, update SATELLITES in test/validate-core-list.nu in the same change")
+  } else if ($anchor_hits | length) > 1 {
+    let at = ($anchor_hits | each { |it| $it.index + 1 } | str join ', ')
+    $errors = ($errors | append $"anchor '($anchor)' matched ($anchor_hits | length) lines \(($at)\); it must match exactly one so a copied lead-in cannot steal the anchor")
+  } else {
+    let anchor_idx = ($anchor_hits | get 0.index)
+    # Adjacency: skip ONLY blank lines and fence delimiters after the anchor;
+    # the first remaining line must begin a qualifying run. "Somewhere after"
+    # would relocate the gap — an em-dash-annotated operative list plus a
+    # distant canonical fence would pass.
+    let adjacent = ($lines
+      | enumerate
+      | skip ($anchor_idx + 1)
+      | where { |it|
+          let t = ($it.item | str trim)
+          not (($t | is-empty) or ($t | str starts-with "```"))
+        }
+      | get -o 0.index)
+
+    if ($adjacent == null) or (not ($runs | any { |r| $r.start == $adjacent })) {
+      $errors = ($errors | append $"no load list directly after the anchor '($anchor)' — the first non-blank, non-fence line after it must begin a names-only load list \(annotated bullets do not parse as one\)")
+    }
+  }
+
+  # EVERY qualifying run must match the canonical set, anchored or not. A
+  # satellite may hold more than one list — leader-spawn-example.md exists to
+  # carry worked examples — and a second correct list is not a defect. What
+  # this forbids is a run that DISAGREES with canonical hiding behind one
+  # that agrees.
+  mut missing = []
+  mut extra = []
+
+  for run in $runs {
+    $missing = ($missing | append ($canonical | where { |name| $name not-in $run.names }))
+    $extra = ($extra | append ($run.names | where { |name| $name not-in $canonical }))
+  }
+
+  {
+    errors: $errors
+    missing: ($missing | uniq | sort)
+    extra: ($extra | uniq | sort)
+    lists: (if ($runs | length) > 1 { $runs | each { |r| $"[($r.names | str join ', ')]" } } else { [] })
+  }
+}
+
+# Coverage sweep: a git-tracked .md/.sh file that is not a registered
+# satellite must not carry a run with EXPECTED_COUNT - 2 or more CANONICAL
+# names — that is a de-facto satellite drifting unchecked. Overlap with the
+# canonical set is the discriminator: a threshold on any /core: names would
+# false-positive on files listing 5 non-canonical names today.
+def sweep-unregistered [canonical: list<string>] {
+  let threshold = $EXPECTED_COUNT - 2
+  let registered = ($SATELLITES | get path)
+  let tracked = (git ls-files
+    | lines
+    | where { |f| ($f | str ends-with ".md") or ($f | str ends-with ".sh") }
+    | where { |f| $f not-in $registered })
+
+  mut violations = []
+
+  for file in $tracked {
+    let raw = (open --raw $file)
+    if not ($raw | str contains "/core:") { continue }
+
+    for run in (find-load-list-runs ($raw | lines)) {
+      let overlap = ($run.names | where { |name| $name in $canonical })
+      if ($overlap | length) >= $threshold {
+        $violations = ($violations | append { file: $file, names: $overlap })
+      }
+    }
+  }
+
+  $violations
+}
+
+# Find the load LISTS in the given lines, as contiguous runs of names-only
+# list lines. A run is a maximal sequence of consecutive lines that each
+# parse under the grammar; runs carrying fewer than 2 /core: names are
+# ignored — that is what keeps a lone prose bullet or a one-name example
+# from counting as a list.
+#
+# Returns a list of { start: <0-based line index>, names: <sorted /core: names> }.
+def find-load-list-runs [lines: list<string>] {
   mut runs = []
   mut current = []
+  mut start = 0
 
-  for line in $lines {
-    let hits = ([...(names-only-line $line) ...(bullet-leading-name $line)] | uniq)
+  for it in ($lines | enumerate) {
+    # Fence delimiters are excluded from the grammar explicitly rather than
+    # relying on "```" happening to fail the name shape; like any other
+    # non-list line, they end the current run. (claude-skills-134)
+    let is_fence = (($it.item | str trim) | str starts-with "```")
+    let hits = (if $is_fence { [] } else { names-only-line $it.item })
 
     if ($hits | is-empty) {
       # Run ended. Keep it only if it looks like a list rather than a mention.
       if ($current | length) >= 2 {
-        $runs = ($runs | append [($current | uniq | sort)])
+        $runs = ($runs | append { start: $start, names: ($current | uniq | sort) })
       }
       $current = []
     } else {
+      if ($current | is-empty) { $start = $it.index }
       $current = ($current | append $hits)
     }
   }
 
   if ($current | length) >= 2 {
-    $runs = ($runs | append [($current | uniq | sort)])
+    $runs = ($runs | append { start: $start, names: ($current | uniq | sort) })
   }
 
   $runs
 }
 
-# G1: the entire line is one or more skill-shaped names, comma-separated.
-# Returns the /core: subset, or [] when the line is not a names-only line.
+# The grammar: the entire line, after stripping list markers, whitespace and
+# backticks, is one or more skill-shaped names separated by commas. Covers
+# the canonical fenced block, the comma-separated fences in the tier
+# references, the mixed /core: + /elixir: block in leader-spawn-example.md,
+# the bullets in commands/work.md and the operator CLAUDE.md template, and
+# the session-start hook's one-name-per-line list. Annotated bullets do NOT
+# parse — a load-list entry is a name, and annotations live in prose below
+# the list. Returns the /core: subset, or [] when the line does not parse.
 def names-only-line [line: string] {
   let bare = ($line
     | str trim
@@ -303,46 +374,11 @@ def names-only-line [line: string] {
   $tokens | where { |t| $t | str starts-with "/core:" }
 }
 
-# G2: a bullet whose FIRST token is a /core: name, allowing a parenthesised
-# annotation after it. Returns that single name, or [].
-#
-# The remainder after the name must be empty or start with "(" — that is what
-# separates a load-list entry from a prose bullet ABOUT a skill. Real
-# annotated entries in commands/work.md are paren-shaped ("- `/core:bees`
-# (the tracker)"), while documentation bullets use an em-dash ("- `/core:tdd`
-# — standing discipline, not pulled"). Without this test, any future prose
-# bullet in that idiom would be counted as a load-list entry, which could
-# MASK a genuinely missing name — the same false-pass class this check exists
-# to remove.
-def bullet-leading-name [line: string] {
-  let trimmed = ($line | str trim)
-
-  if not ($trimmed =~ '^[-*]\s') { return [] }
-
-  let after_marker = ($trimmed | str replace -r '^[-*]\s+' '' | str trim | str replace -a '`' '' | str trim)
-  let tokens = ($after_marker | split row " ")
-  let first_token = ($tokens | get -o 0 | default "" | str trim | str replace -r '[,.]$' '')
-
-  if not ($first_token =~ $CORE_NAME) { return [] }
-
-  let remainder = ($tokens | skip 1 | str join " " | str trim)
-
-  if ($remainder | is-empty) or ($remainder | str starts-with "(") {
-    [$first_token]
-  } else {
-    []
-  }
-}
-
-# Regression fixtures for the run-finder. Every case below is a real defect or
-# a real idiom found by review — three separate reviewers each found one silent
-# false pass in this parser, and every round was fixed by editing the parser
-# with no test added, which is why the next round found another. These are that
-# test. Two cases are CHARACTERISATION tests: they assert current behaviour on
-# known gaps (tracked in claude-skills-134) so that fixing the gap fails here
-# and forces the expectation to be updated deliberately.
+# Regression fixtures. Every run-finder case is a real defect or a real idiom
+# found by review — three separate reviewers each found one silent false pass
+# in this parser, and every round was fixed by editing the parser with no test
+# added, which is why the next round found another. These are that test.
 def self-test [] {
-  let dir = (mktemp -d | str trim)
   mut failures = []
 
   let cases = [
@@ -359,10 +395,16 @@ def self-test [] {
       expect: [[/core:aa /core:bb /core:cc]]
     }
     {
-      name: "paren_annotated_bullets"
-      why: "commands/work.md idiom: bullet, backticked name, paren annotation"
-      content: "- `/core:aa`\n- `/core:bb` (the tracker)\n- `/core:cc` (carries Forge)\n"
-      expect: [[/core:aa /core:bb /core:cc]]
+      name: "annotated_bullets_do_not_parse"
+      why: "a paren-annotated bullet is not a load-list entry; the annotation could NEGATE the instruction. Names-only lines are the grammar; annotations live in prose below the list (was gap F1, claude-skills-135)"
+      content: "- `/core:aa`\n- `/core:bb`\n- `/core:cc` (NOT loaded by default; skip for doc-only work)\n"
+      expect: [[/core:aa /core:bb]]
+    }
+    {
+      name: "all_bullets_annotated_no_run"
+      why: "annotated entries never join a run, so a list of them yields nothing — the anchor check is what makes that loud at the satellite level"
+      content: "- `/core:aa` (always)\n- `/core:bb` (the tracker)\n- `/core:cc` (carries Forge)\n"
+      expect: []
     }
     {
       name: "lone_em_dash_prose_bullet_ignored"
@@ -383,8 +425,8 @@ def self-test [] {
       expect: [[/core:aa /core:bb /core:cc] [/core:aa /core:bb /core:cc]]
     }
     {
-      name: "masking_paren_bullet_separate_run"
-      why: "PoC A: name deleted from the list, re-added as a detached paren bullet"
+      name: "masking_paren_bullet_invisible"
+      why: "PoC A: name deleted from the list, re-added as a detached annotated bullet — the bullet no longer parses at all, so it cannot patch anything"
       content: "- `/core:aa`\n- `/core:bb`\n\nLater, unrelated:\n\n- `/core:cc` (standing discipline)\n"
       expect: [[/core:aa /core:bb]]
     }
@@ -401,30 +443,101 @@ def self-test [] {
       expect: []
     }
     {
-      name: "KNOWN GAP F1 adjacent paren bullet joins the run"
-      why: "characterisation: a paren annotation that NEGATES the instruction still counts, because it sits in the run. Fix is deleting G2 — claude-skills-134"
-      content: "- `/core:aa`\n- `/core:bb`\n- `/core:cc` (NOT loaded by default; skip for doc-only work)\n"
-      expect: [[/core:aa /core:bb /core:cc]]
-    }
-    {
-      name: "KNOWN GAP F3 em-dash annotated operative list is invisible"
-      why: "characterisation: annotate a REAL list with em-dashes and no run is found, so a file can pass with no list at all. Fix is anchoring to a marker — claude-skills-134"
+      name: "em_dash_annotated_list_invisible_to_grammar"
+      why: "an operative list annotated with em-dashes parses as nothing — by design the grammar cannot see it; the ANCHOR check (was gap F3, claude-skills-135) is what makes this loud"
       content: "- `/core:aa` — always\n- `/core:bb` — the tracker\n- `/core:cc` — carries Forge\n"
       expect: []
     }
   ]
 
   for c in $cases {
-    let f = ($dir | path join "fixture.md")
-    $c.content | save -f $f
-    let got = (find-load-list-runs $f)
+    let got = (find-load-list-runs ($c.content | lines) | each { |r| $r.names })
     if $got != $c.expect {
       $failures = ($failures | append $"($c.name): expected ($c.expect | to nuon), got ($got | to nuon)")
     }
-    rm -f $f
   }
 
-  rm -rf $dir
+  # Satellite-level fixtures: anchor + adjacency + every-run-must-match, the
+  # composition main runs per file. `error` is a substring the errors list
+  # must contain (empty = errors must be empty).
+  let canonical = [/core:aa /core:bb /core:cc]
+
+  let satellite_cases = [
+    {
+      name: "anchored_canonical_run_passes"
+      why: "the healthy shape: anchor, blank, fence, canonical names"
+      content: "Load these first:\n\n```\n/core:aa\n/core:bb\n/core:cc\n```\n"
+      anchor: "Load these first"
+      error: ""
+      missing: []
+      extra: []
+    }
+    {
+      name: "anchor_missing_is_error"
+      why: "was gap F3: delete the operative list (and its lead-in) and the file passed; now the absent anchor is loud"
+      content: "Prose only.\n\n```\n/core:aa\n/core:bb\n/core:cc\n```\n"
+      anchor: "Load these first"
+      error: "anchor not found"
+      missing: []
+      extra: []
+    }
+    {
+      name: "em_dash_adjacent_list_is_error"
+      why: "was gap F3: annotate the operative list into grammar-invisibility; adjacency now fails because no run begins after the anchor"
+      content: "Load these first:\n- `/core:aa` — always\n- `/core:bb` — the tracker\n- `/core:cc` — carries Forge\n"
+      anchor: "Load these first"
+      error: "no load list directly after the anchor"
+      missing: []
+      extra: []
+    }
+    {
+      name: "divergent_later_run_still_fails"
+      why: "anchoring is ADDITIVE: a canonical anchored run does not excuse a divergent run elsewhere — every run must match"
+      content: "Load these first:\n\n```\n/core:aa\n/core:bb\n/core:cc\n```\n\nExample:\n\n```\n/core:aa\n/core:bb\n```\n"
+      anchor: "Load these first"
+      error: ""
+      missing: [/core:cc]
+      extra: []
+    }
+    {
+      name: "anchor_matched_twice_is_error"
+      why: "first-match-silently-wins would let a copied lead-in in an earlier example steal the anchor"
+      content: "Load these first:\n\n```\n/core:aa\n/core:bb\n/core:cc\n```\n\nLoad these first, again:\n"
+      anchor: "Load these first"
+      error: "matched 2 lines"
+      missing: []
+      extra: []
+    }
+    {
+      name: "anchored_run_missing_name_reported"
+      why: "teeth: the anchored run itself dropping a name surfaces through the existing missing direction"
+      content: "Load these first:\n\n```\n/core:aa\n/core:bb\n```\n"
+      anchor: "Load these first"
+      error: ""
+      missing: [/core:cc]
+      extra: []
+    }
+  ]
+
+  for c in $satellite_cases {
+    let got = (check-satellite ($c.content | lines) $c.anchor $canonical)
+    let error_ok = (if ($c.error | is-empty) {
+      $got.errors | is-empty
+    } else {
+      $got.errors | any { |e| $e | str contains $c.error }
+    })
+    if not $error_ok {
+      $failures = ($failures | append $"($c.name): expected errors matching '($c.error)', got ($got.errors | to nuon)")
+    }
+    if $got.missing != $c.missing {
+      $failures = ($failures | append $"($c.name): expected missing ($c.missing | to nuon), got ($got.missing | to nuon)")
+    }
+    if $got.extra != $c.extra {
+      $failures = ($failures | append $"($c.name): expected extra ($c.extra | to nuon), got ($got.extra | to nuon)")
+    }
+  }
+
+  let total = (($cases | length) + ($satellite_cases | length))
 
   if ($failures | is-not-empty) {
     print $"(ansi red_bold)❌ Core-list self-test failed:(ansi reset)"
@@ -432,5 +545,5 @@ def self-test [] {
     exit 1
   }
 
-  print $"(ansi green_bold)✅ Core-list self-test passed \(($cases | length) cases\)(ansi reset)"
+  print $"(ansi green_bold)✅ Core-list self-test passed \(($total) cases\)(ansi reset)"
 }

--- a/test/validate-core-list.nu
+++ b/test/validate-core-list.nu
@@ -32,14 +32,18 @@
 #      disagrees" — the operative list could be deleted outright, or
 #      annotated into invisibility (em-dash bullets fail the grammar), and
 #      CI stayed green. Anchoring is ADDITIVE: rule 2 still applies to every
-#      run, anchored or not.
+#      run, anchored or not. Lines inside fenced code blocks do not match
+#      the anchor unless the satellite opts in with anchor_in_fence — a
+#      fenced worked example that quotes the lead-in must not be able to
+#      steal the anchor from a deleted operative block.
 #
 #   4. SWEEP — every git-tracked .md/.sh file NOT registered as a satellite
-#      fails if it carries a run with EXPECTED_COUNT - 2 or more CANONICAL
-#      names. A file carrying (nearly) the full stack is a de-facto ninth
-#      satellite and must be registered, or it drifts unchecked. Overlap with
-#      the canonical set is the discriminator — several files legitimately
-#      list 5 non-canonical or partial /core: stacks and must stay silent.
+#      fails if the UNION of its runs carries EXPECTED_COUNT - 2 or more
+#      CANONICAL names. A file carrying (nearly) the full stack is a
+#      de-facto ninth satellite and must be registered, or it drifts
+#      unchecked. Overlap with the canonical set is the discriminator —
+#      several files legitimately list 5 non-canonical or partial /core:
+#      stacks and must stay silent.
 #
 # Known limits, all loud or deliberate:
 #   - A blank line inside one logical list splits it into two runs and the
@@ -53,6 +57,12 @@
 #     today references/fix-agent.md (4 names) relies on this, and
 #     references/validator.md's inline numbered list (3 names) is a form the
 #     grammar does not parse at all.
+#   - Divergent names scattered as single-name fenced mentions escape the
+#     every-run rule, since each run falls under the 2-name threshold. Same
+#     class as prose mentions; not a plausible reader-followed idiom.
+#   - Anchors are semantics-blind regex substrings: a lead-in that NEGATES
+#     the instruction ("Do NOT ... invoke each of these by exact name")
+#     still anchors. Inherent to a grammar check.
 #
 # Usage:
 #   nu test/validate-core-list.nu
@@ -73,6 +83,13 @@ const SKILL_NAME = '^/[a-z][a-z0-9-]*:[a-z][a-z0-9-]*$'
 # above its operative load list (blank lines and fence delimiters may sit
 # between). If a lead-in is reworded, the check fails naming the expected
 # regex — update the wording here in the same change.
+#
+# Anchors only match OUTSIDE fenced code blocks unless the satellite sets
+# anchor_in_fence: true. Otherwise a single edit that deletes the operative
+# block and "moves the load list into a worked example" quoting the same
+# lead-in inside a fence would re-anchor onto the example and go green with
+# no operative list — an innocent-looking doc restructure, not a contrived
+# attack.
 const SATELLITES = [
   # The canonical block lives in this file and parses as a load list, so the
   # missing-name direction is vacuous here (canonical is always a subset of
@@ -85,8 +102,11 @@ const SATELLITES = [
     anchor: "Load core skills" }
   { path: "plugins/core/skills/agent-loop/references/agent-worker.md"
     anchor: "Load core skills" }
+  # This satellite IS a worked example: its operative list sits inside the
+  # example prompt's fence, so the anchor must be allowed to match in-fence.
   { path: "plugins/core/skills/agent-loop/references/leader-spawn-example.md"
-    anchor: "## Load skills" }
+    anchor: "## Load skills"
+    anchor_in_fence: true }
   { path: "plugins/core/commands/work.md"
     anchor: "Invoke the Skill tool for each by exact name" }
   { path: "plugins/core/hooks/session-start.sh"
@@ -123,7 +143,8 @@ def main [--self-test] {
       continue
     }
 
-    let result = (check-satellite (open --raw $path | lines) $satellite.anchor $canonical_names)
+    let in_fence_ok = ($satellite | get -o anchor_in_fence | default false)
+    let result = (check-satellite (open --raw $path | lines) $satellite.anchor $canonical_names $in_fence_ok)
 
     if (($result.errors | is-not-empty) or ($result.missing | is-not-empty) or ($result.extra | is-not-empty)) {
       $failures = ($failures | append ($result | insert file $satellite.path))
@@ -218,16 +239,22 @@ def extract-canonical-names [file: string] {
 # anchor, and every-run-must-match. Returns
 # { errors: [...], missing: [...], extra: [...], lists: [...] }.
 # `errors` carries the anchor/adjacency hard failures; missing/extra carry the
-# per-run drift, aggregated.
-def check-satellite [lines: list<string>, anchor: string, canonical: list<string>] {
+# per-run drift, aggregated. Unless anchor_in_fence is set, lines inside
+# fenced code blocks cannot match the anchor — a fenced worked example
+# quoting the lead-in must not steal the anchor from a deleted operative
+# block (demonstrated live on team-leader.md before this filter existed).
+def check-satellite [lines: list<string>, anchor: string, canonical: list<string>, anchor_in_fence: bool = false] {
   let runs = (find-load-list-runs $lines)
 
   mut errors = []
 
-  let anchor_hits = ($lines | enumerate | where { |it| $it.item =~ $anchor })
+  let flags = (fence-flags $lines)
+  let anchor_hits = ($lines | enumerate | where { |it|
+    ($it.item =~ $anchor) and ($anchor_in_fence or (not ($flags | get $it.index)))
+  })
 
   if ($anchor_hits | is-empty) {
-    $errors = ($errors | append $"anchor not found — no line matches '($anchor)'. The operative load list is anchored to that lead-in; if it was reworded, update SATELLITES in test/validate-core-list.nu in the same change")
+    $errors = ($errors | append $"anchor not found — no line outside a fenced code block matches '($anchor)'. The operative load list is anchored to that lead-in; if it was reworded, update SATELLITES in test/validate-core-list.nu in the same change")
   } else if ($anchor_hits | length) > 1 {
     let at = ($anchor_hits | each { |it| $it.index + 1 } | str join ', ')
     $errors = ($errors | append $"anchor '($anchor)' matched ($anchor_hits | length) lines \(($at)\); it must match exactly one so a copied lead-in cannot steal the anchor")
@@ -273,10 +300,10 @@ def check-satellite [lines: list<string>, anchor: string, canonical: list<string
 }
 
 # Coverage sweep: a git-tracked .md/.sh file that is not a registered
-# satellite must not carry a run with EXPECTED_COUNT - 2 or more CANONICAL
-# names — that is a de-facto satellite drifting unchecked. Overlap with the
-# canonical set is the discriminator: a threshold on any /core: names would
-# false-positive on files listing 5 non-canonical names today.
+# satellite must not carry EXPECTED_COUNT - 2 or more CANONICAL names across
+# its load lists — that is a de-facto satellite drifting unchecked. Overlap
+# with the canonical set is the discriminator: a threshold on any /core:
+# names would false-positive on files listing 5 non-canonical names today.
 def sweep-unregistered [canonical: list<string>] {
   let threshold = $EXPECTED_COUNT - 2
   let registered = ($SATELLITES | get path)
@@ -291,15 +318,51 @@ def sweep-unregistered [canonical: list<string>] {
     let raw = (open --raw $file)
     if not ($raw | str contains "/core:") { continue }
 
-    for run in (find-load-list-runs ($raw | lines)) {
-      let overlap = ($run.names | where { |name| $name in $canonical })
-      if ($overlap | length) >= $threshold {
-        $violations = ($violations | append { file: $file, names: $overlap })
-      }
+    let overlap = (file-canonical-overlap ($raw | lines) $canonical)
+    if ($overlap | length) >= $threshold {
+      $violations = ($violations | append { file: $file, names: $overlap })
     }
   }
 
   $violations
+}
+
+# The sweep's measure: the UNION of run names across the whole file,
+# intersected with the canonical set. Union is safe HERE and only here — the
+# sweep detects PRESENCE (register-or-trim), not correctness, so the masking
+# argument that forced per-run comparison for satellites does not apply:
+# there is no canonical set being vouched for, only the question "does this
+# unregistered file carry a near-complete list". Per-RUN overlap was the
+# original design and it was bypassed by one blank line splitting the full
+# 10-name list 5+5, each fragment under the threshold. Do not "fix" this
+# back to per-run. Measured union overlap across all real unregistered files
+# is 5 (threshold 8), so the union costs no false positives.
+def file-canonical-overlap [lines: list<string>, canonical: list<string>] {
+  find-load-list-runs $lines
+    | each { |r| $r.names }
+    | flatten
+    | uniq
+    | where { |name| $name in $canonical }
+    | sort
+}
+
+# Per-line fence parity: true for lines inside a fenced code block, and for
+# the delimiter lines themselves. Used to keep satellite anchors from
+# matching inside worked examples.
+def fence-flags [lines: list<string>] {
+  mut flags = []
+  mut in_fence = false
+
+  for line in $lines {
+    if (($line | str trim) | str starts-with "```") {
+      $flags = ($flags | append true)
+      $in_fence = (not $in_fence)
+    } else {
+      $flags = ($flags | append $in_fence)
+    }
+  }
+
+  $flags
 }
 
 # Find the load LISTS in the given lines, as contiguous runs of names-only
@@ -517,10 +580,29 @@ def self-test [] {
       missing: [/core:cc]
       extra: []
     }
+    {
+      name: "fenced_leadin_cannot_steal_anchor"
+      why: "reviewer PoC: operative block replaced with an opt-out, load list 'moved into a worked example' whose fence quotes the lead-in — the in-fence match must not anchor, so this fails loudly instead of going green with no operative list"
+      content: "1. Skip skill loading; workers handle it themselves.\n\nExample:\n\n```\n1. Load these first:\n/core:aa, /core:bb, /core:cc\n```\n"
+      anchor: "Load these first"
+      error: "anchor not found"
+      missing: []
+      extra: []
+    }
+    {
+      name: "anchor_in_fence_opt_in_matches"
+      why: "leader-spawn-example.md's operative list deliberately sits inside its example fence; the opt-in lets its anchor match there"
+      content: "An example prompt:\n\n```\n## Load these\n/core:aa\n/core:bb\n/core:cc\n```\n"
+      anchor: "## Load these"
+      in_fence: true
+      error: ""
+      missing: []
+      extra: []
+    }
   ]
 
   for c in $satellite_cases {
-    let got = (check-satellite ($c.content | lines) $c.anchor $canonical)
+    let got = (check-satellite ($c.content | lines) $c.anchor $canonical ($c | get -o in_fence | default false))
     let error_ok = (if ($c.error | is-empty) {
       $got.errors | is-empty
     } else {
@@ -537,7 +619,30 @@ def self-test [] {
     }
   }
 
-  let total = (($cases | length) + ($satellite_cases | length))
+  # Sweep-measure fixtures: union overlap per FILE, not per run.
+  let sweep_cases = [
+    {
+      name: "sweep_union_defeats_blank_line_split"
+      why: "reviewer PoC: the full canonical list split by one blank line left each fragment under the per-run threshold; the file-wide union sees all names"
+      content: "```\n/core:aa\n/core:bb\n```\n\n```\n/core:cc\n/core:aa\n```\n"
+      expect: [/core:aa /core:bb /core:cc]
+    }
+    {
+      name: "sweep_union_counts_canonical_only"
+      why: "non-canonical names must not inflate the overlap — the threshold discriminates on the canonical set"
+      content: "```\n/core:aa\n/core:zz\n```\n"
+      expect: [/core:aa]
+    }
+  ]
+
+  for c in $sweep_cases {
+    let got = (file-canonical-overlap ($c.content | lines) $canonical)
+    if $got != $c.expect {
+      $failures = ($failures | append $"($c.name): expected ($c.expect | to nuon), got ($got | to nuon)")
+    }
+  }
+
+  let total = (($cases | length) + ($satellite_cases | length) + ($sweep_cases | length))
 
   if ($failures | is-not-empty) {
     print $"(ansi red_bold)❌ Core-list self-test failed:(ansi reset)"

--- a/test/validate-core-list.nu
+++ b/test/validate-core-list.nu
@@ -268,8 +268,7 @@ def check-satellite [lines: list<string>, anchor: string, canonical: list<string
       | enumerate
       | skip ($anchor_idx + 1)
       | where { |it|
-          let t = ($it.item | str trim)
-          not (($t | is-empty) or ($t | str starts-with "```"))
+          not ((($it.item | str trim) | is-empty) or (is-fence-delimiter $it.item))
         }
       | get -o 0.index)
 
@@ -346,23 +345,59 @@ def file-canonical-overlap [lines: list<string>, canonical: list<string>] {
     | sort
 }
 
-# Per-line fence parity: true for lines inside a fenced code block, and for
+# Per-line fence state: true for lines inside a fenced code block, and for
 # the delimiter lines themselves. Used to keep satellite anchors from
 # matching inside worked examples.
+#
+# CommonMark-faithful where it matters: an opener is a backtick or tilde
+# delimiter of length 3+, recorded with its CHARACTER and LENGTH; while
+# in-fence, only a bare delimiter of the SAME character with AT LEAST the
+# opener's length closes it (a closing fence carries no info string). Naive
+# parity-flipping on any ``` prefix reopened the anchor theft two ways: a
+# bare ``` inside a ```` block flipped state off and classified the rest of
+# the block out-of-fence, and ~~~ fences were not recognised at all — both
+# are live shapes in this repo (four-backtick outer fences exist precisely
+# because references documents show fenced examples).
 def fence-flags [lines: list<string>] {
   mut flags = []
-  mut in_fence = false
+  mut fence_char = null   # "`" or "~" while inside a fence, else null
+  mut fence_len = 0
 
   for line in $lines {
-    if (($line | str trim) | str starts-with "```") {
-      $flags = ($flags | append true)
-      $in_fence = (not $in_fence)
+    let t = ($line | str trim)
+    let delim = ($t | parse -r '^(?<d>`{3,}|~{3,})' | get -o 0.d)
+
+    if $fence_char == null {
+      if $delim != null {
+        $flags = ($flags | append true)
+        $fence_char = ($delim | str substring 0..0)
+        $fence_len = ($delim | str length)
+      } else {
+        $flags = ($flags | append false)
+      }
     } else {
-      $flags = ($flags | append $in_fence)
+      $flags = ($flags | append true)
+      # A closer is ONLY the delimiter (no info string), same character,
+      # at least the opener's length.
+      let closes = (($delim != null)
+        and ($t == $delim)
+        and (($delim | str substring 0..0) == $fence_char)
+        and (($delim | str length) >= $fence_len))
+      if $closes {
+        $fence_char = null
+        $fence_len = 0
+      }
     }
   }
 
   $flags
+}
+
+# A line that is a fence delimiter of either CommonMark kind. Shared by the
+# adjacency scan and the run-finder so they cannot disagree with fence-flags
+# about what counts as fence syntax.
+def is-fence-delimiter [line: string] {
+  ($line | str trim) =~ '^(`{3,}|~{3,})'
 }
 
 # Find the load LISTS in the given lines, as contiguous runs of names-only
@@ -381,8 +416,7 @@ def find-load-list-runs [lines: list<string>] {
     # Fence delimiters are excluded from the grammar explicitly rather than
     # relying on "```" happening to fail the name shape; like any other
     # non-list line, they end the current run. (claude-skills-134)
-    let is_fence = (($it.item | str trim) | str starts-with "```")
-    let hits = (if $is_fence { [] } else { names-only-line $it.item })
+    let hits = (if (is-fence-delimiter $it.item) { [] } else { names-only-line $it.item })
 
     if ($hits | is-empty) {
       # Run ended. Keep it only if it looks like a list rather than a mention.
@@ -619,6 +653,29 @@ def self-test [] {
     }
   }
 
+  # Fence-state fixtures: CommonMark closer rules, not naive parity.
+  let fence_cases = [
+    {
+      name: "four_backtick_block_inner_triple_stays_in_fence"
+      why: "reviewer PoC 7a: a bare ``` inside a ```` block is content, not a closer — parity-flipping classified everything after it out-of-fence and reopened anchor theft"
+      content: "````markdown\n```\ncontent line\n```\n````\nafter\n"
+      expect: [true true true true true false]
+    }
+    {
+      name: "tilde_fence_recognised"
+      why: "reviewer PoC 7b: ~~~ is a valid CommonMark fence; unrecognised, its whole block was classified out-of-fence"
+      content: "~~~\ncontent line\n~~~\nafter\n"
+      expect: [true true true false]
+    }
+  ]
+
+  for c in $fence_cases {
+    let got = (fence-flags ($c.content | lines))
+    if $got != $c.expect {
+      $failures = ($failures | append $"($c.name): expected ($c.expect | to nuon), got ($got | to nuon)")
+    }
+  }
+
   # Sweep-measure fixtures: union overlap per FILE, not per run.
   let sweep_cases = [
     {
@@ -642,7 +699,7 @@ def self-test [] {
     }
   }
 
-  let total = (($cases | length) + ($satellite_cases | length) + ($sweep_cases | length))
+  let total = (($cases | length) + ($satellite_cases | length) + ($fence_cases | length) + ($sweep_cases | length))
 
   if ($failures | is-not-empty) {
     print $"(ansi red_bold)❌ Core-list self-test failed:(ansi reset)"


### PR DESCRIPTION
Closes claude-skills-135 and claude-skills-134.

The core-list drift check had two documented SILENT false passes, both covered by characterisation fixtures asserting the broken behaviour. Both are now closed.

**F1 — the paren blessing.** `G2` accepted any bullet whose remainder started with `(`, regardless of what the annotation said. `- /core:tdd (NOT loaded by default; skip for doc-only work)` counted as a load-list entry, so a command file could tell the model tdd is not loaded while CI reported the list canonical. That rule was itself introduced as a "fix" for an over-broad match — it converted the match into a *blessed idiom*, which is worse.

**F3 — the guarantee was weaker than the claim.** The check proved "at least one canonical run exists and no visible run disagrees", not "the operative list is canonical". The operative list could be deleted **entirely** from the operator template and CI stayed green.

## The change

**`G2` is deleted** (~30 lines). Load-list lines are names-only. `commands/work.md` was the only file depending on it; its two annotated entries are now bare names with the annotations moved to a single prose line *below* the complete list. They could not move to the line between entries — any non-list line splits a run, which would have left 9 names plus an orphan and failed this PR's own check.

**Each satellite declares an anchor** — a regex matching the line that directly precedes its operative list — and the check validates *that* list. Six of the eight satellites already had a natural lead-in, so no file needed a new marker. Markers could not have been uniform anyway: `session-start.sh` is a heredoc where any marker is emitted into turn-1 context, and `leader-spawn-example.md`'s list sits inside a fence where a marker would leak into the rendered example.

Anchoring is **additive, not substitutive** — this is the part that matters. The earlier design in the plan would have replaced "every qualifying run must match canonical" with "check only the anchored run", which silently drops the guarantee that killed two previously-verified false passes: a stale worked example inside a satellite would have gone invisible again, and `leader-spawn-example.md` exists to carry worked examples. Both rules now hold together.

Adjacency is enforced: after the anchor, only blank lines and fence delimiters may intervene. Without it, the fix merely relocates F3 — em-dash-annotate the real list, leave a canonical fenced block later, and that distant block becomes "the run after the anchor".

Anchor matching **ignores lines inside fenced blocks**, with a per-satellite `anchor_in_fence` opt-in for `leader-spawn-example.md`, whose operative list deliberately sits inside its example fence. Without that, a fenced worked example quoting the lead-in could steal the anchor: an adversarial review demonstrated replacing a satellite's real block with "Skip skill loading; workers handle it themselves", appending an example containing the old lead-in plus a canonical list, and getting **full green**. That is F3 re-materialized one step narrower, and "move the load list into a worked example" is what an innocent doc restructure looks like.

Three loud failure modes, each naming the satellite: anchor not found (printing the expected regex, since an anchor is a tripwire on prose wording), anchor matched more than once (first-match-wins would let a copied lead-in steal it), and no parseable list directly after the anchor.

**A coverage sweep** fails when an unregistered tracked file carries names overlapping the canonical set by ≥ `EXPECTED_COUNT - 2`, computed as a **union across the whole file**. Per-run was bypassed by a single blank line: the complete 10-name list split 5+5 left each fragment under threshold and the file invisible — demonstrated by review. A union is correct *here specifically*, and the code says why so nobody reverts it on pattern-matching grounds: the sweep detects **presence** (register-or-trim), not correctness, so no canonical set is being vouched for and the masking argument that forced per-run comparison for satellites does not apply. Deliberately *not* a count of any `/core:` names at any threshold: `qa/commands/qa.md` and `qa/agents/qa-lead.md` both carry exactly 5, so a ≥6 any-name rule would be one added skill from a false positive. Canonical overlap is the right discriminator, and tying it to `EXPECTED_COUNT` makes it move with the list.

## Attacks verified independently in a scratchpad clone

| Attack | Result |
|---|---|
| Delete a name, re-add it as a paren-annotated bullet | **FAILS** — `missing from load list` |
| Delete the operative list entirely | **FAILS** — no list after the anchor |
| Em-dash-annotate the adjacent list | **FAILS** — all 10 reported missing |
| Canonical adjacent list **plus a divergent fenced run later** | **FAILS** — "2 separate lists parsed; every one must match" |
| Remove one name from each of the 8 anchored lists in turn | **FAILS** with the skill named, every time |
| A synthetic unregistered file with 8 canonical names | **FAILS** with register-or-trim guidance |
| A fenced example quoting the lead-in, real block deleted | **FAILS** — no anchor outside a fence |
| 10 canonical names in an unregistered file, split 5+5 by a blank line | **FAILS** — union sees all 10 |
| The 25 real unregistered partial files (max overlap 5) | silent |
| A ````markdown block whose inner bare fence flips parity | **FAILS** — CommonMark-faithful fence tracking |
| A `~~~` tilde-fenced example quoting the lead-in | **FAILS** — tilde fences recognised |
| Prose ```nu``` before a real fenced example (phantom opener) | **FAILS** — backtick info strings may not contain backticks |
| A 4-space-indented ``` delimiter before a real example | **FAILS** — 4+ spaces is indented content, not a fence |

The fourth row is the additive guarantee holding alongside anchoring rather than instead of it.

## Fixtures

25 cases. Three existing run-finder fixtures changed with `G2`'s deletion, and the `KNOWN GAP F3` fixture's expectation is **unchanged** — anchoring lives outside `find-load-list-runs`, so flipping it would have proved nothing while looking like verification. Per-satellite validation was factored into its own function so six new cases can exercise the anchored path directly, including the divergent-later-run guard and fail-on-duplicate-anchor.

## claude-skills-134

Closed here: fence delimiters are now explicitly excluded from the grammar rather than relying on backticks accidentally failing the name shape; `EXCLUDED_PARTIAL` is demoted from documentation-shaped-as-config to a header comment naming claude-skills-125 as the owner of the per-tier-subset question; and the G1/G2 punctuation asymmetry dissolved with `G2`.

## Honest note on size

The file went **436 → 743 lines**. Deleting `G2` removed parser, but the anchor mechanism, the sweep, and six fixtures add more than that — so the plan's framing of "less parser, not more" holds only for the `G2` part. The growth buys two closed silent false passes and a coverage guard against a satellite nobody registered.

Fence tracking is CommonMark-faithful: a fence closes only on a bare delimiter of the same character with length ≥ the opener. Parity-toggle tracking was defeated two ways — a ````markdown block whose first inner line is a bare fence flipped parity off, and `~~~` fences were unrecognised entirely. Both reopened anchor theft, and both are live shapes here: 10 tracked files already use four-backtick or tilde fences. One of them, `claude-skills/references/examples.md`, was converted to four backticks by #138 to repair a different malformation — so an earlier fix created this vector. A single shared `is-fence-delimiter` predicate now serves all three fence consumers so they cannot disagree.

Opener acceptance also had to match the spec, not just closers. Two line shapes matched the naive opener regex without being fences — prose containing an inline code span (````nu````, since a backtick info string may not contain backticks) and a 4+-space-indented delimiter (indented content at top level). Each desynced the state machine so the NEXT REAL opener was consumed as a closer, reopening theft. Openers are now gated on ≤3-space indent, 3+ delimiter, and a backtick-free info string for backtick fences; tilde info strings may contain anything. Measured: the deepest fence indent across all 8 satellites is exactly 3, so the indent rule is a corpus no-op.

Three residuals documented in Known limits: fence indentation is judged against the LINE, not its container, so a future satellite nesting a fence 4+ spaces inside a sub-list would be misread — container-relative indentation is out of scope for a line-based lint. Divergent names split into single-name fences escape the every-run rule (each falls under the 2-name threshold, same class as prose mentions), and anchors are semantics-blind regex substrings, so a negated lead-in ("Do NOT invoke each of these") still anchors.

One deliberate interpretation, flagged: fence delimiters still **end** a run rather than being transparent within one. Transparency would merge two back-to-back fenced lists separated only by delimiters into a single run — a union-shaped masking vector. Adjacency skips fences separately when locating the anchored run.
