### PR TITLE
docs(core): forbid review agents from mutating the shared working tree

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.58",
+      "version": "0.4.59",
       "category": "meta",
       "keywords": [
         "all",
@@ -114,7 +114,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.2.27",
+      "version": "0.2.28",
       "category": "development",
       "keywords": [
         "git",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.58",
+  "version": "0.4.59",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/agent-loop/SKILL.md
+++ b/plugins/core/skills/agent-loop/SKILL.md
@@ -337,7 +337,7 @@ Workflows are a research preview on paid plans. When disabled, the default Task-
 - `references/leader-spawn-example.md` -- Worked Phoenix-endpoint Team Leader spawn prompt with explicit `/core:*` + `/elixir:*` skill list
 - `references/dep-doc-introspection.md` — Staged-pipeline prompts name the runtime-introspection tools AND the specific deps touched, never abstract "use the introspection tools"
 - `references/no-todos.md` — Implementer prompts ban TODO/FIXME/XXX/HACK/KLUDGE/DEFERRED markers, enforced by pre-commit grep; tempted workers escalate-or-implement-now instead of punting scope via a comment
-- `references/dispatch-discipline.md` — Spawn-prompt rules: explicit model, specialized subagent types, lead delegates all execution, fresh-main branch creation, no polling, host-inspection over claims, ADR search before proposing architecture
+- `references/dispatch-discipline.md` — Spawn-prompt rules: explicit model, specialized subagent types, lead delegates all execution, fresh-main branch creation, read-only agents never mutate the shared tree (scratchpad clone instead), no polling, host-inspection over claims, ADR search before proposing architecture
 - `references/secret-provisioning.md` — Tier 1 plans include symmetric secret provisioning (generation, store creation, prod/dev deploy diffs); Tier 5 blocker check
 - `references/workflows-execution.md` — Optional workflow substrate for the five-tier pipeline: pipeline-as-script, stage gates, escalation ladder, teams-of-teams; decomposition/merge stay interactive
 - `templates/five-tier-issue.workflow.js` — Runnable `N=1` five-tier pipeline template: stage prompts, `skillProof` schemas, diff-boundary gate, escalation ladder, bounded fix loop

--- a/plugins/core/skills/agent-loop/references/dispatch-discipline.md
+++ b/plugins/core/skills/agent-loop/references/dispatch-discipline.md
@@ -38,6 +38,21 @@ git checkout -b <branch>
 
 Without this step, the spawned agent inherits the working tree's current branch — often a sibling PR's stale branch — and produces a PR that contains both the new work and the sibling's diff.
 
+## Read-only agents never touch the shared working tree
+
+Reviewers, auditors, and research agents get this verbatim in their spawn prompt:
+
+```
+Never run git checkout, switch, restore, stash, or reset against the shared
+working tree. To inspect another ref: git show <ref>:<path>, git diff a...b,
+git ls-tree. To test anything that requires mutation, copy the repo into your
+scratchpad and work there; state the scratchpad path in your report.
+```
+
+Name the commands. "No git state changes" is not enough — an agent given that wording checked out a PR branch, restored main afterward, and read the round trip as net-zero. Three other agents were writing to that tree at the time; all three had their work silently moved onto the wrong branch. It was recoverable only because the branch happened to sit at the same commit and the reviewer disclosed the checkout in its report.
+
+The scratchpad copy is the half that makes the prohibition workable. A read-only reviewer that cannot mutate anything also cannot verify a destructive scenario, so it either skips the check or does it live and hopes. Working in a clone removes the tradeoff: full freedom to break things, zero risk to in-flight work. Reviewers using this pattern have demonstrated exploits — deleting a file's operative content, injecting malformed fences, adding synthetic skills — that a read-only pass would have missed entirely.
+
 ## No timed polling loops in workers
 
 Spawned agents do not sustain timed polling loops. The `Monitor` tool is restricted; `sleep` longer than a few seconds is blocked. Polling work decomposes into one-shot snapshot agents the lead re-spawns at intervals OR external orchestration that pings on event.

--- a/plugins/core/skills/agent-loop/references/dispatch-discipline.md
+++ b/plugins/core/skills/agent-loop/references/dispatch-discipline.md
@@ -43,11 +43,21 @@ Without this step, the spawned agent inherits the working tree's current branch 
 Reviewers, auditors, and research agents get this verbatim in their spawn prompt:
 
 ```
-Never run git checkout, switch, restore, stash, or reset against the shared
-working tree. To inspect another ref: git show <ref>:<path>, git diff a...b,
-git ls-tree. To test anything that requires mutation, copy the repo into your
-scratchpad and work there; state the scratchpad path in your report.
+Never run git checkout, switch, restore, stash, reset, clean, rebase, merge,
+pull, cherry-pick, apply, am, or branch -f/-D against the shared working tree,
+or any other command that changes HEAD, the index, or tracked or untracked
+files. To inspect another ref: git show <ref>:<path>, git diff a...b,
+git ls-tree. To test anything that requires mutation:
+
+    git clone <repo> "$SCRATCHPAD/repo"
+    git -C "$SCRATCHPAD/repo" remote remove origin
+
+Work there and state the scratchpad path in your report.
 ```
+
+The catch-all clause matters as much as the names. A closed list recreates the failure it fixes one step over — an agent that reads literally enough to treat checkout-then-restore as net-zero will also read "rebase isn't on the list". `git clean -fd` is the worst omission a list can have: it destroys teammates' uncommitted work with no recovery, unlike the incident below, which was survivable.
+
+Removing `origin` in the clone is not optional. `git clone` from a local path sets origin to the shared repo, so a push from the scratchpad writes refs back into it; a `cp -R` that carries `.git` keeps the GitHub remote and pushes to the real one.
 
 Name the commands. "No git state changes" is not enough — an agent given that wording checked out a PR branch, restored main afterward, and read the round trip as net-zero. Three other agents were writing to that tree at the time; all three had their work silently moved onto the wrong branch. It was recoverable only because the branch happened to sit at the same commit and the reviewer disclosed the checkout in its report.
 

--- a/plugins/core/skills/agent-loop/references/dispatch-discipline.md
+++ b/plugins/core/skills/agent-loop/references/dispatch-discipline.md
@@ -52,12 +52,16 @@ git ls-tree. To test anything that requires mutation:
     git clone <repo> "$SCRATCHPAD/repo"
     git -C "$SCRATCHPAD/repo" remote remove origin
 
-Work there and state the scratchpad path in your report.
+Work there and state the scratchpad path in your report. Do not write under
+.git/ directly (config, hooks, refs); git fetch is the only sanctioned .git
+write.
 ```
 
 The catch-all clause matters as much as the names. A closed list recreates the failure it fixes one step over — an agent that reads literally enough to treat checkout-then-restore as net-zero will also read "rebase isn't on the list". `git clean -fd` is the worst omission a list can have: it destroys teammates' uncommitted work with no recovery, unlike the incident below, which was survivable.
 
 Removing `origin` in the clone is not optional. `git clone` from a local path sets origin to the shared repo, so a push from the scratchpad writes refs back into it; a `cp -R` that carries `.git` keeps the GitHub remote and pushes to the real one.
+
+`.git/` internals are not covered by "HEAD, the index, or tracked files" — `git status` never lists them — so the block adds: do not write under `.git/` directly (config, hooks, refs); `git fetch` is the only sanctioned `.git` write. The vector that earns the clause is `.git/hooks/*`: a hook written there executes on a teammate's next commit, which is mutation by proxy. The carve-out matters as much as the ban, since a flat "never write under `.git/`" would forbid `git fetch`, which reviewers legitimately need.
 
 Name the commands. "No git state changes" is not enough — an agent given that wording checked out a PR branch, restored main afterward, and read the round trip as net-zero. Three other agents were writing to that tree at the time; all three had their work silently moved onto the wrong branch. It was recoverable only because the branch happened to sit at the same commit and the reviewer disclosed the checkout in its report.
 

--- a/plugins/core/skills/agent-loop/templates/five-tier-issue.workflow.js
+++ b/plugins/core/skills/agent-loop/templates/five-tier-issue.workflow.js
@@ -140,6 +140,10 @@ function planPrompt(a) {
     `Tests will live in: ${a.testFiles.join(', ')}.`,
     'Read the existing code and test conventions in the repo before designing.',
     'STAY IN STAGE: design the test list only. Do NOT write test code,',
+    'Never run git checkout, switch, restore, stash, reset, clean, rebase,',
+    'merge, pull, cherry-pick, apply, am, or branch -f/-D against the shared',
+    'working tree, or any other command that changes HEAD, the index, or',
+    'tracked or untracked files — other agents may be writing to it.',
     'implementation code, run CI, or review work.',
     'Return one entry per test: its name and the acceptance criterion it covers.',
   ].join('\n')
@@ -188,6 +192,10 @@ function ciPrompt(a) {
     'Run mise run ci. Capture the verbatim output and report green or red.',
     'Require a clean working tree before reporting green — a dirty tree green is an illusion.',
     'STAY IN STAGE: run and report only. Do NOT fix failures, edit files,',
+    'Never run git checkout, switch, restore, stash, reset, clean, rebase,',
+    'merge, pull, cherry-pick, apply, am, or branch -f/-D against the shared',
+    'working tree, or any other command that changes HEAD, the index, or',
+    'tracked or untracked files — other agents may be writing to it.',
     'or commit anything.',
   ].join('\n')
 }

--- a/plugins/core/skills/agent-loop/templates/five-tier-issue.workflow.js
+++ b/plugins/core/skills/agent-loop/templates/five-tier-issue.workflow.js
@@ -217,7 +217,14 @@ function reviewPrompt(a) {
     ...a.acceptanceCriteria.map(c => `- ${c}`),
     'Check for overfit-to-tests and missed edge cases.',
     'STAY IN STAGE: read and judge only. Do NOT edit files, run fixes,',
-    'or commit anything.',
+    'or commit anything. Never run git checkout, switch, restore, stash,',
+    'reset, clean, rebase, merge, pull, cherry-pick, apply, am, or',
+    'branch -f/-D against the shared working tree, or any other command',
+    'that changes HEAD, the index, or tracked or untracked files —',
+    'other agents may be writing to it. Inspect other refs with',
+    'git show <ref>:<path> / git diff a...b / git ls-tree. To test',
+    'anything requiring mutation, git clone the repo into your scratchpad,',
+    'git remote remove origin there, and work in the copy.',
     'Return approved true/false plus a findings list (empty when approved).',
   ].join('\n')
 }

--- a/plugins/core/skills/agent-loop/templates/forge-issue.workflow.js
+++ b/plugins/core/skills/agent-loop/templates/forge-issue.workflow.js
@@ -199,6 +199,13 @@ function testReviewPrompt(a, plan, index) {
     JSON.stringify(plan.slices),
     '2. Are any tests redundant or duplicated? Flag them.',
     'STAY IN STAGE: read and judge only. Do NOT edit tests or write implementation.',
+    'Never run git checkout, switch, restore, stash, reset, clean, rebase,',
+    'merge, pull, cherry-pick, apply, am, or branch -f/-D against the shared',
+    'working tree, or any other command that changes HEAD, the index, or',
+    'tracked or untracked files — other agents may be writing to it. Inspect',
+    'other refs with git show <ref>:<path> / git diff a...b / git ls-tree.',
+    'To test anything requiring mutation, git clone the repo into your',
+    'scratchpad, git remote remove origin there, and work in the copy.',
     'Return approved true/false plus findings (empty when approved).',
   ].join('\n')
 }

--- a/plugins/core/skills/agent-loop/templates/forge-issue.workflow.js
+++ b/plugins/core/skills/agent-loop/templates/forge-issue.workflow.js
@@ -136,6 +136,8 @@ function startingIndex(index) {
 function handsPrompt(objective, vision) {
   return [
     'You are read-only research hands. Do NOT design, edit, write code, or commit.',
+    'Never run git commands that change HEAD, the index, or tracked or',
+    'untracked files in the shared working tree — other agents write there.',
     `Objective: ${objective}`,
     vision
       ? 'The objective requires vision: use the harness visual tools (WebFetch / Playwright / image reader).'
@@ -230,6 +232,13 @@ function ciPrompt(a, label) {
     'Run mise run ci. Capture verbatim output and report green or red.',
     'Require a clean working tree before reporting green — a dirty tree green is an illusion.',
     'STAY IN STAGE: run and report only. Do NOT fix, edit, or commit.',
+    'Never run git checkout, switch, restore, stash, reset, clean, rebase,',
+    'merge, pull, cherry-pick, apply, am, or branch -f/-D against the shared',
+    'working tree, or any other command that changes HEAD, the index, or',
+    'tracked or untracked files — other agents may be writing to it. Inspect',
+    'other refs with git show <ref>:<path> / git diff a...b / git ls-tree.',
+    'To test anything requiring mutation, git clone the repo into your',
+    'scratchpad, git remote remove origin there, and work in the copy.',
   ].join('\n')
 }
 
@@ -258,6 +267,13 @@ function reviewPrompt(a, index, role) {
     'Check for overfit-to-tests and missed edge cases. Use the starting index; spawn focused',
     'hands for anything more — do NOT sweep the tree yourself.',
     'STAY IN STAGE: read and judge only. Do NOT edit, fix, or commit.',
+    'Never run git checkout, switch, restore, stash, reset, clean, rebase,',
+    'merge, pull, cherry-pick, apply, am, or branch -f/-D against the shared',
+    'working tree, or any other command that changes HEAD, the index, or',
+    'tracked or untracked files — other agents may be writing to it. Inspect',
+    'other refs with git show <ref>:<path> / git diff a...b / git ls-tree.',
+    'To test anything requiring mutation, git clone the repo into your',
+    'scratchpad, git remote remove origin there, and work in the copy.',
     'Return approved true/false plus findings (empty when approved).',
   ].join('\n')
 }


### PR DESCRIPTION
Closes claude-skills-138.

A review agent spawned with "REVIEW ONLY — no edits, no commits, no git state changes" checked out a PR branch mid-review and restored main afterward, reading the round trip as net-zero. Three other agents were writing to that working tree at the time; all three had their work silently moved onto the wrong branch. It was recoverable only because the branch happened to sit at the same commit and the reviewer disclosed the checkout in its report — neither of which was by design.

Adds one section to `references/dispatch-discipline.md`, which already owns spawn-prompt rules including the related "Branch from fresh main, explicitly".

**Name the commands.** "No git state changes" was not specific enough — the agent read checkout-then-restore as leaving no trace. The rule now names the mutating commands explicitly and gives the read-only alternatives (`git show <ref>:<path>`, `git diff a...b`, `git ls-tree`).

**The scratchpad clone is the half that makes the prohibition workable**, and it is the more important half. A reviewer that cannot mutate anything also cannot verify a destructive scenario, so it either skips the check or does it live and hopes. Working in a copy removes the tradeoff.

That is not theoretical: reviewers using this pattern during PRs #138 and #139 demonstrated exploits a read-only pass would have missed entirely — deleting a satellite's operative content and replacing it with a worked example, injecting malformed and phantom fences, adding synthetic skills to test a name check. Four demonstrated silent false passes in the core-list check came out of scratchpad-clone attacks. (#137's review was also adversarial, but its body does not record a scratchpad clone, so it is not claimed here.)


**The ban is a category, not a list.** Review found that naming only `checkout/switch/restore/stash/reset` recreates the failure one step over — an agent literal enough to treat checkout-then-restore as net-zero will also reason that "rebase isn't on the list". The rule now names the siblings (`clean`, `rebase`, `merge`, `pull`, `cherry-pick`, `apply`, `am`, `branch -f/-D`) and closes with a catch-all covering anything that changes HEAD, the index, or tracked/untracked files. `git clean -fd` was the worst omission: it destroys teammates' uncommitted work with no recovery, unlike the incident, which was survivable.

**The clone recipe removes `origin`,** because both natural recipes carry a push hazard the prose was silent on: `git clone` from a local path sets origin to the shared repo, so a push writes refs back into it; a `cp -R` carrying `.git` keeps the GitHub remote and pushes to the real one.

**Both shipped reviewer prompt templates now carry the rule verbatim.** `five-tier-issue.workflow.js` said "read and judge only. Do NOT edit files, run fixes, or commit anything" and `forge-issue.workflow.js` said "Do NOT edit tests or write implementation" — a checkout is neither an edit nor a commit, so both were the exact wording the incident defeated, in files this repo calls executable specifications. A tools allowlist cannot close it, since git mutations ride through Bash; prompt text is the only lever.

The `SKILL.md` reference-list annotation is updated so the rule is visible to someone scanning the index rather than only to someone who opens the file.
