### PR TITLE
refactor(core): point tier references at the canonical list instead of copying it

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.59",
+      "version": "0.4.60",
       "category": "meta",
       "keywords": [
         "all",
@@ -114,7 +114,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.2.28",
+      "version": "0.2.29",
       "category": "development",
       "keywords": [
         "git",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.59",
+  "version": "0.4.60",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/agent-loop/references/agent-worker.md
+++ b/plugins/core/skills/agent-loop/references/agent-worker.md
@@ -4,13 +4,7 @@ You are an agent working a single task within an issue. You report to your sub-t
 
 ## Phase 1: Pre-flight
 
-1. Load core skills (MANDATORY, load first):
-   ```
-   /core:anti-fabrication, /core:git, /core:tdd, /core:twelve-factor,
-   /core:restraint, /core:security, /core:mise, /core:nushell,
-   /core:agent-loop, /core:bees
-   ```
-   Canonical list: `/core:agent-loop` "Core Skills (Mandatory)"; drift-checked in CI.
+1. Load core skills (MANDATORY, load first): invoke `/core:agent-loop` and load every name in its "Core Skills (Mandatory)" block — the canonical list, drift-checked in CI.
 2. Load task-specific skills from your assignment
    - If a skill you need is missing, check `/claude-code:plugin-marketplace` for available skills, then report to sub-lead. Never fabricate the missing knowledge.
 3. Initialize tracking with your task items

--- a/plugins/core/skills/agent-loop/references/sub-team-leader.md
+++ b/plugins/core/skills/agent-loop/references/sub-team-leader.md
@@ -4,13 +4,7 @@ You lead the sub-team for a single issue within a larger epic. You report to the
 
 ## Phase 1: Pre-flight
 
-1. Load core skills:
-   ```
-   /core:anti-fabrication, /core:git, /core:tdd, /core:twelve-factor,
-   /core:restraint, /core:security, /core:mise, /core:nushell,
-   /core:agent-loop, /core:bees
-   ```
-   Canonical list: `/core:agent-loop` "Core Skills (Mandatory)"; drift-checked in CI.
+1. Load core skills: invoke `/core:agent-loop` and load every name in its "Core Skills (Mandatory)" block — the canonical list, drift-checked in CI.
 2. Load issue-specific skills based on issue labels
 3. Decompose the issue into discrete tasks
 4. For each task:

--- a/plugins/core/skills/agent-loop/references/team-leader.md
+++ b/plugins/core/skills/agent-loop/references/team-leader.md
@@ -10,13 +10,7 @@ You are the Team Leader for an epic. You receive the epic assignment and are res
 
 ## Phase 1: Pre-flight
 
-1. Load core skills:
-   ```
-   /core:anti-fabrication, /core:git, /core:tdd, /core:twelve-factor,
-   /core:restraint, /core:security, /core:mise, /core:nushell,
-   /core:agent-loop, /core:bees
-   ```
-   Canonical list: `/core:agent-loop` "Core Skills (Mandatory)"; drift-checked in CI.
+1. Load core skills: invoke `/core:agent-loop` and load every name in its "Core Skills (Mandatory)" block — the canonical list, drift-checked in CI.
 2. Create a bees epic that mirrors the upstream epic (same title, objective, slug)
 3. **If the epic carries a `spec:` field** (e.g., `spec: docs/specs/<slug>.allium`): confirm the spec file exists at that path. If the epic is a refactor and no `spec:` is set, run `/allium:distill` to capture a behavioral baseline before decomposition. Skip this step entirely if neither condition applies.
 4. **Decomposition gate** — probe two deterministic signals (no file searching):

--- a/test/validate-core-list.nu
+++ b/test/validate-core-list.nu
@@ -75,9 +75,11 @@
 #   - Divergent names scattered as single-name fenced mentions escape the
 #     every-run rule, since each run falls under the 2-name threshold. Same
 #     class as prose mentions; not a plausible reader-followed idiom.
-#   - Anchors are semantics-blind regex substrings: a lead-in that NEGATES
-#     the instruction ("Do NOT ... invoke each of these by exact name")
-#     still anchors. Inherent to a grammar check.
+#   - Anchors and pointers are semantics-blind regex substrings: a lead-in
+#     that NEGATES the instruction ("Do NOT ... invoke each of these by exact
+#     name") still anchors, and a pointer sentence is equally negatable
+#     ("you need not invoke /core:agent-loop ..."). Inherent to a grammar
+#     check, and identical for both satellite shapes.
 #   - Fence indentation is judged against the LINE, not its container: a
 #     future satellite nesting a fence 4+ spaces deep inside a sub-list
 #     would have its delimiters misread as indented-code content, because

--- a/test/validate-core-list.nu
+++ b/test/validate-core-list.nu
@@ -37,6 +37,21 @@
 #      fenced worked example that quotes the lead-in must not be able to
 #      steal the anchor from a deleted operative block.
 #
+#   3b. POINTER SHAPE — a satellite whose entry carries a `pointer` regex
+#      replaces its enumerated copy with an imperative pointer at the
+#      canonical block ("invoke /core:agent-loop and load every name ...").
+#      Used by the tier references, which are reached from agent-loop's
+#      SKILL.md — the file that carries the canonical block and is itself
+#      mandatory, so the list is already in the reader's context. The anchor
+#      rules are identical; additionally the anchor line itself, or the
+#      first non-blank/non-fence line after it, must match the pointer.
+#      Adjacency is what stops the pointer drifting into unrelated prose
+#      lower in the file — a `Canonical list:` citation surviving elsewhere
+#      cannot green a deleted load step (the string-presence-anywhere bug
+#      the satellite model exists to prevent). Rule 2 still applies: any run
+#      that DOES appear in a pointer satellite must match canonical, so a
+#      helpfully re-pasted partial list fails.
+#
 #   4. SWEEP — every git-tracked .md/.sh file NOT registered as a satellite
 #      fails if the UNION of its runs carries EXPECTED_COUNT - 2 or more
 #      CANONICAL names. A file carrying (nearly) the full stack is a
@@ -94,6 +109,13 @@ const SKILL_NAME = '^/[a-z][a-z0-9-]*:[a-z][a-z0-9-]*$'
 # lead-in inside a fence would re-anchor onto the example and go green with
 # no operative list — an innocent-looking doc restructure, not a contrived
 # attack.
+#
+# A `pointer` field selects the pointer shape (doc item 3b above): the file
+# carries an imperative pointer at the canonical block instead of an
+# enumerated copy. One shared regex — drift between the three pointer
+# satellites would recreate the copy-drift the shape removes.
+const POINTER_REGEX = 'invoke `/core:agent-loop` and load every name in its "Core Skills \(Mandatory\)" block'
+
 const SATELLITES = [
   # The canonical block lives in this file and parses as a load list, so the
   # missing-name direction is vacuous here (canonical is always a subset of
@@ -101,11 +123,14 @@ const SATELLITES = [
   { path: "plugins/core/skills/agent-loop/SKILL.md"
     anchor: "Every agent at every tier loads these before any work" }
   { path: "plugins/core/skills/agent-loop/references/team-leader.md"
-    anchor: "Load core skills" }
+    anchor: "Load core skills"
+    pointer: $POINTER_REGEX }
   { path: "plugins/core/skills/agent-loop/references/sub-team-leader.md"
-    anchor: "Load core skills" }
+    anchor: "Load core skills"
+    pointer: $POINTER_REGEX }
   { path: "plugins/core/skills/agent-loop/references/agent-worker.md"
-    anchor: "Load core skills" }
+    anchor: "Load core skills"
+    pointer: $POINTER_REGEX }
   # This satellite IS a worked example: its operative list sits inside the
   # example prompt's fence, so the anchor must be allowed to match in-fence.
   { path: "plugins/core/skills/agent-loop/references/leader-spawn-example.md"
@@ -148,7 +173,8 @@ def main [--self-test] {
     }
 
     let in_fence_ok = ($satellite | get -o anchor_in_fence | default false)
-    let result = (check-satellite (open --raw $path | lines) $satellite.anchor $canonical_names $in_fence_ok)
+    let pointer = ($satellite | get -o pointer | default "")
+    let result = (check-satellite (open --raw $path | lines) $satellite.anchor $canonical_names $in_fence_ok $pointer)
 
     if (($result.errors | is-not-empty) or ($result.missing | is-not-empty) or ($result.extra | is-not-empty)) {
       $failures = ($failures | append ($result | insert file $satellite.path))
@@ -239,15 +265,18 @@ def extract-canonical-names [file: string] {
   $names
 }
 
-# Validate one satellite's content: anchor uniqueness, run adjacency to the
-# anchor, and every-run-must-match. Returns
+# Validate one satellite's content: anchor uniqueness, run (or pointer)
+# adjacency to the anchor, and every-run-must-match. Returns
 # { errors: [...], missing: [...], extra: [...], lists: [...] }.
 # `errors` carries the anchor/adjacency hard failures; missing/extra carry the
 # per-run drift, aggregated. Unless anchor_in_fence is set, lines inside
 # fenced code blocks cannot match the anchor — a fenced worked example
 # quoting the lead-in must not steal the anchor from a deleted operative
 # block (demonstrated live on team-leader.md before this filter existed).
-def check-satellite [lines: list<string>, anchor: string, canonical: list<string>, anchor_in_fence: bool = false] {
+# A non-empty `pointer` selects the pointer shape: instead of a run, the
+# anchor line itself or the first non-blank/non-fence line after it must
+# match the pointer regex. Every-run still applies either way.
+def check-satellite [lines: list<string>, anchor: string, canonical: list<string>, anchor_in_fence: bool = false, pointer: string = ""] {
   let runs = (find-load-list-runs $lines)
 
   mut errors = []
@@ -265,9 +294,11 @@ def check-satellite [lines: list<string>, anchor: string, canonical: list<string
   } else {
     let anchor_idx = ($anchor_hits | get 0.index)
     # Adjacency: skip ONLY blank lines and fence delimiters after the anchor;
-    # the first remaining line must begin a qualifying run. "Somewhere after"
-    # would relocate the gap — an em-dash-annotated operative list plus a
-    # distant canonical fence would pass.
+    # the first remaining line must begin a qualifying run (enumerated shape)
+    # or match the pointer (pointer shape, which may also sit on the anchor
+    # line itself). "Somewhere after" would relocate the gap — an
+    # em-dash-annotated operative list plus a distant canonical fence, or a
+    # pointer drifted into unrelated prose, would pass.
     let adjacent = ($lines
       | enumerate
       | skip ($anchor_idx + 1)
@@ -276,8 +307,16 @@ def check-satellite [lines: list<string>, anchor: string, canonical: list<string
         }
       | get -o 0.index)
 
-    if ($adjacent == null) or (not ($runs | any { |r| $r.start == $adjacent })) {
-      $errors = ($errors | append $"no load list directly after the anchor '($anchor)' — the first non-blank, non-fence line after it must begin a names-only load list \(annotated bullets do not parse as one\)")
+    if ($pointer | is-empty) {
+      if ($adjacent == null) or (not ($runs | any { |r| $r.start == $adjacent })) {
+        $errors = ($errors | append $"no load list directly after the anchor '($anchor)' — the first non-blank, non-fence line after it must begin a names-only load list \(annotated bullets do not parse as one\)")
+      }
+    } else {
+      let on_anchor = (($lines | get $anchor_idx) =~ $pointer)
+      let on_adjacent = (($adjacent != null) and (($lines | get $adjacent) =~ $pointer))
+      if not ($on_anchor or $on_adjacent) {
+        $errors = ($errors | append $"no pointer instruction adjacent to the anchor '($anchor)' — the anchor line or the first non-blank, non-fence line after it must instruct loading the canonical block \(regex '($pointer)'\); a citation elsewhere in the file does not count")
+      }
     }
   }
 
@@ -653,10 +692,80 @@ def self-test [] {
       missing: []
       extra: []
     }
+    {
+      name: "pointer_on_anchor_line_passes"
+      why: "pointer shape (claude-skills-122): tier references replace the enumerated copy with an imperative pointer on the load-step line itself"
+      content: "1. Load these first: invoke `/core:agent-loop` and load every name in its block.\n2. Next step.\n"
+      anchor: "Load these first"
+      pointer: "invoke `/core:agent-loop` and load every name"
+      error: ""
+      missing: []
+      extra: []
+    }
+    {
+      name: "pointer_on_adjacent_line_passes"
+      why: "the pointer may sit on the first non-blank, non-fence line after the anchor — same skip rules as the enumerated adjacency scan"
+      content: "Load these first:\n\ninvoke `/core:agent-loop` and load every name in its block.\n"
+      anchor: "Load these first"
+      pointer: "invoke `/core:agent-loop` and load every name"
+      error: ""
+      missing: []
+      extra: []
+    }
+    {
+      name: "pointer_deleted_is_error"
+      why: "an anchor surviving without its pointer instruction is a gutted load step — the reader is no longer told what to load"
+      content: "1. Load these first:\n2. Next step.\n"
+      anchor: "Load these first"
+      pointer: "invoke `/core:agent-loop` and load every name"
+      error: "no pointer instruction"
+      missing: []
+      extra: []
+    }
+    {
+      name: "pointer_far_from_anchor_is_error"
+      why: "adjacency stops the pointer drifting into unrelated prose lower in the file"
+      content: "Load these first:\nDo the other steps.\n\nSee also: invoke `/core:agent-loop` and load every name in its block.\n"
+      anchor: "Load these first"
+      pointer: "invoke `/core:agent-loop` and load every name"
+      error: "no pointer instruction"
+      missing: []
+      extra: []
+    }
+    {
+      name: "pointer_step_deleted_citation_survives_is_error"
+      why: "the F3-class mutation: the whole load step is deleted while a pointer-ish citation survives elsewhere — string presence anywhere must not green the check"
+      content: "1. Do the work.\n\nCanonical list: invoke `/core:agent-loop` and load every name in its block.\n"
+      anchor: "Load these first"
+      pointer: "invoke `/core:agent-loop` and load every name"
+      error: "anchor not found"
+      missing: []
+      extra: []
+    }
+    {
+      name: "pointer_with_divergent_partial_list_fails"
+      why: "every-run still applies to pointer satellites: a helpfully re-pasted partial list must not ride under a valid pointer"
+      content: "Load these first: invoke `/core:agent-loop` and load every name in its block.\n\nExample:\n\n```\n/core:aa\n/core:bb\n```\n"
+      anchor: "Load these first"
+      pointer: "invoke `/core:agent-loop` and load every name"
+      error: ""
+      missing: [/core:cc]
+      extra: []
+    }
+    {
+      name: "pointer_anchor_matched_twice_is_error"
+      why: "anchor uniqueness applies to the pointer shape identically — a copied lead-in must not steal the anchor"
+      content: "Load these first: invoke `/core:agent-loop` and load every name in its block.\n\nLoad these first, again.\n"
+      anchor: "Load these first"
+      pointer: "invoke `/core:agent-loop` and load every name"
+      error: "matched 2 lines"
+      missing: []
+      extra: []
+    }
   ]
 
   for c in $satellite_cases {
-    let got = (check-satellite ($c.content | lines) $c.anchor $canonical ($c | get -o in_fence | default false))
+    let got = (check-satellite ($c.content | lines) $c.anchor $canonical ($c | get -o in_fence | default false) ($c | get -o pointer | default ""))
     let error_ok = (if ($c.error | is-empty) {
       $got.errors | is-empty
     } else {


### PR DESCRIPTION
Closes claude-skills-122.

The mandatory core-skill list was enumerated in 8 places kept in sync by a drift check. Anthropic's Claude-5 context-engineering guidance argues for single statements over repetition — the implied fix is fewer copies, not a better synchroniser.

**Three of the eight are converted to a pointer. Five keep their enumeration deliberately.** The split is by consumer, not by file type:

| Site | Kept? | Why |
|---|---|---|
| `agent-loop/SKILL.md` | enumerated | the source of truth |
| `references/team-leader.md` | **pointer** | reached from SKILL.md, so the block is already in context |
| `references/sub-team-leader.md` | **pointer** | same |
| `references/agent-worker.md` | **pointer** | same |
| `references/leader-spawn-example.md` | enumerated | a worked example whose value is the literal shape |
| `commands/work.md` | enumerated | read on invocation; the list is what the command does |
| `hooks/session-start.sh` | enumerated | turn-1 injection, when nothing is loaded yet |
| `templates/CLAUDE.md` | enumerated | copied into a different repo, where the pointer may not resolve |

The three converted references are reached *from* `agent-loop/SKILL.md`, which carries the canonical block and is itself mandatory — so their enumeration was a verbatim restatement of something four screens up, which is precisely what the repetition rule targets.

## The pointer is an instruction, not a citation

These files are standalone second-person briefs, and nothing forbids a spawner handing one to a worker directly. So the surviving line tells the reader what to do:

```
1. Load core skills (MANDATORY, load first): invoke `/core:agent-loop` and load
   every name in its "Core Skills (Mandatory)" block — the canonical list,
   drift-checked in CI.
```

A bare `Canonical list:` footnote would have been a dead end for that reader. This way the failure is bounded: the pointer names a mandatory skill, so a standalone reader recovers the full list in one hop.

## The check gained a second shape rather than a weaker rule

The obvious implementation — drop the three from `SATELLITES` and assert the pointer string appears somewhere — was rejected in review, and rightly: that is **string-presence-anywhere**, the exact guarantee-weaker-than-the-claim bug PR #139 spent four adversarial rounds eliminating. An edit could delete the whole load step while a pointer line survived lower in the file, and the check would stay green on a reference that no longer instructs loading. Dropping them from `SATELLITES` would also have pushed them under the sweep, whose threshold is `EXPECTED_COUNT - 2` = 8, letting a re-pasted list that drifted to ≤7 names escape both.

Instead the three stay satellites under a **pointer shape** that reuses the hardened machinery: the anchor must still match exactly once outside fences; the pointer must be **adjacent** to the anchor under the same blank-and-fence skipping rule; and the every-run rule still applies, so a partial list pasted back in fails.

## Verified independently, in a scratchpad clone

| Mutation | Result |
|---|---|
| Delete the load step, keep a **full** pointer line elsewhere in the file | **FAILS** — anchor not found |
| Keep the anchor, gut the pointer from it | **FAILS** — "a citation elsewhere in the file does not count" |
| Remove a name from each of the 5 enumerated satellites in turn | **FAILS**, named, every time |

The first row is the specific regression this design exists to prevent.

32 self-test fixtures (25 existing + 7 new), covering both pass directions plus pointer-deleted, pointer-non-adjacent, step-deleted-citation-survives, divergent-partial-list, and anchor-matched-twice.

## What this does not do

**No part of #139's machinery retires.** Anchors, adjacency, the fence state machine, the `anchor_in_fence` opt-in, every-run, and the sweep all remain load-bearing for the five enumerated satellites — and the check is now slightly larger, not smaller. The honest trade is three fewer hand-edit sites on every future list change, which is a real recurring cost (#131 found `validator.md` and `fix-agent.md` carrying stale subsets), in exchange for a modest check extension.

**The bolder 8 → 3 cut is deliberately not attempted.** Converting the bootstrap sites would trade a mechanism observed working all session for one with no evidence behind it. This repo's "listed ≠ loaded" doctrine and quote-proof convention exist because agents were seen skipping loads *even when fully enumerated* — so pointer-following reliability is strictly less known, at the moments with the least context. Measuring one site first is the honest path, and belongs in its own issue.

Two deliberate behaviours: a full canonical enumeration re-pasted into a pointer file alongside a valid pointer passes (redundant but correct — a *partial* re-paste fails), and replacing a pointer file's step with the old enumerated shape fails loudly on the pointer rule rather than being silently accepted.
