### PR TITLE
fix(skills): match frontmatter names to directories for the last 19 skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.63",
+      "version": "0.4.64",
       "category": "meta",
       "keywords": [
         "all",
@@ -114,7 +114,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.2.31",
+      "version": "0.2.32",
       "category": "development",
       "keywords": [
         "git",
@@ -135,7 +135,7 @@
       "source": "./plugins/tools/dagu",
       "strict": true,
       "description": "Dagu workflow orchestration: workflows, web UI, REST API",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "category": "tools",
       "keywords": [
         "dagu",
@@ -165,7 +165,7 @@
       "source": "./plugins/tools/github",
       "strict": true,
       "description": "GitHub Actions, Workflows, act local testing, community health files, Dependabot consolidation, and PR review",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "category": "tools",
       "keywords": [
         "github",
@@ -383,7 +383,7 @@
       "source": "./plugins/tools/slidev",
       "strict": true,
       "description": "Slidev presentation skills: strategy, branding, interactive demos, markdown slides, syntax, code blocks, export, and troubleshooting",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "category": "tools",
       "keywords": [
         "slidev",
@@ -467,7 +467,7 @@
       "source": "./plugins/languages/zig",
       "strict": true,
       "description": "Zig programming skills: build system, comptime, allocators, error handling, C interop, testing, and troubleshooting",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "category": "language",
       "keywords": [
         "zig",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.63",
+  "version": "0.4.64",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ Slidev markdown-based presentation development.
 
 **Skills:**
 - **slidev** - Overview, project setup, and routing to sub-skills
-- **slidev-syntax** - Slide separators, frontmatter, layouts, MDC, notes, transitions
-- **slidev-code** - Shiki highlighting, Monaco editor, Magic Move, TwoSlash, code groups
-- **slidev-export** - PDF, PPTX, PNG export, SPA build, CLI flags
-- **slidev-troubleshooting** - Export failures, font issues, configuration debugging
+- **syntax** - Slide separators, frontmatter, layouts, MDC, notes, transitions
+- **code** - Shiki highlighting, Monaco editor, Magic Move, TwoSlash, code groups
+- **export** - PDF, PPTX, PNG export, SPA build, CLI flags
+- **troubleshooting** - Export failures, font issues, configuration debugging
 
 **Keywords**: slidev, presentation, slides, markdown, vite
 

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.31",
+  "version": "0.2.32",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/beads/references/skill-catalog.md
+++ b/plugins/core/skills/beads/references/skill-catalog.md
@@ -64,9 +64,9 @@ Runtime discovery ensures that third-party or user-created skills can be suggest
 
 | Skill | Trigger Keywords |
 |-------|-----------------|
-| `dagu-workflows` | dagu, workflow definition, DAG, YAML workflow, scheduling |
-| `dagu-webui` | dagu UI, workflow monitoring, DAG browser |
-| `dagu-rest-api` | dagu API, workflow API, execution status API |
+| `workflows` | dagu, workflow definition, DAG, YAML workflow, scheduling |
+| `webui` | dagu UI, workflow monitoring, DAG browser |
+| `rest-api` | dagu API, workflow API, execution status API |
 
 ### elixir Plugin
 
@@ -98,10 +98,10 @@ Runtime discovery ensures that third-party or user-created skills can be suggest
 | Skill | Trigger Keywords |
 |-------|-----------------|
 | `slidev` | slidev, sli.dev, presentation, slides, deck |
-| `slidev-syntax` | slide syntax, slide layout, frontmatter, markdown slides, presenter notes |
-| `slidev-code` | code block, syntax highlighting, monaco, magic move, twoslash, code group |
-| `slidev-export` | export PDF, export PPTX, slidev build, static SPA, slidev export |
-| `slidev-troubleshooting` | slidev error, export failure, font issue, slidev debug |
+| `syntax` | slide syntax, slide layout, frontmatter, markdown slides, presenter notes |
+| `code` | code block, syntax highlighting, monaco, magic move, twoslash, code group |
+| `export` | export PDF, export PPTX, slidev build, static SPA, slidev export |
+| `troubleshooting` | slidev error, export failure, font issue, slidev debug |
 
 ### ui Plugin
 

--- a/plugins/languages/zig/.claude-plugin/plugin.json
+++ b/plugins/languages/zig/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zig",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Zig programming skills: build system, comptime, allocators, error handling, C interop, testing, and troubleshooting",
   "author": {
     "name": "vinnie357"

--- a/plugins/languages/zig/skills/allocators/SKILL.md
+++ b/plugins/languages/zig/skills/allocators/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: zig-allocators
+name: allocators
 description: Guide for Zig memory management and allocators. Use when choosing allocators, managing memory lifecycle, debugging leaks, or understanding arena vs page vs fixed-buffer allocation patterns.
 ---
 

--- a/plugins/languages/zig/skills/build/SKILL.md
+++ b/plugins/languages/zig/skills/build/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: zig-build
+name: build
 description: Guide for the Zig build system and CI integration. Use when configuring build.zig, adding build steps, cross-compiling, managing dependencies, or setting up CI pipelines.
 ---
 

--- a/plugins/languages/zig/skills/c-interop/SKILL.md
+++ b/plugins/languages/zig/skills/c-interop/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: zig-c-interop
+name: c-interop
 description: Guide for Zig and C interoperability. Use when importing C headers with @cImport, exporting Zig functions to C, mapping C types, using translate-c, or linking C libraries.
 ---
 

--- a/plugins/languages/zig/skills/language/SKILL.md
+++ b/plugins/languages/zig/skills/language/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: zig-language
+name: language
 description: Guide for Zig core language features. Use when writing Zig code with comptime, error handling, data types, slices, optionals, defer, or following Zig idioms.
 ---
 

--- a/plugins/languages/zig/skills/testing/SKILL.md
+++ b/plugins/languages/zig/skills/testing/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: zig-testing
+name: testing
 description: Guide for Zig built-in testing framework. Use when writing tests, using test allocator for leak detection, filtering tests, setting up build.zig test steps, or integrating tests into CI.
 ---
 

--- a/plugins/languages/zig/skills/troubleshooting/SKILL.md
+++ b/plugins/languages/zig/skills/troubleshooting/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: zig-troubleshooting
+name: troubleshooting
 description: Guide for debugging and troubleshooting Zig programs. Use when diagnosing compiler errors, runtime panics, memory issues, build failures, or common Zig pitfalls.
 ---
 

--- a/plugins/tools/dagu/.claude-plugin/plugin.json
+++ b/plugins/tools/dagu/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dagu",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Dagu workflow orchestration: workflow authoring, web UI, and REST API",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/dagu/skills/rest-api/SKILL.md
+++ b/plugins/tools/dagu/skills/rest-api/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dagu-rest-api
+name: rest-api
 description: Guide for using the Dagu REST API. Use when programmatically managing workflows, querying execution status, or integrating Dagu with external systems.
 ---
 

--- a/plugins/tools/dagu/skills/webui/SKILL.md
+++ b/plugins/tools/dagu/skills/webui/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dagu-webui
+name: webui
 description: Guide for using the Dagu Web UI. Use when monitoring workflow executions, managing DAGs through the browser, or troubleshooting workflow issues.
 ---
 

--- a/plugins/tools/dagu/skills/workflows/SKILL.md
+++ b/plugins/tools/dagu/skills/workflows/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dagu-workflows
+name: workflows
 description: Guide for authoring Dagu workflows with YAML syntax. Use when creating workflow definitions, configuring steps and executors, or setting up scheduling and dependencies.
 ---
 

--- a/plugins/tools/github/.claude-plugin/plugin.json
+++ b/plugins/tools/github/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "GitHub Actions, Workflows, act local testing, community health files, Dependabot consolidation, and PR review",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/github/skills/actions/SKILL.md
+++ b/plugins/tools/github/skills/actions/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: github-actions
+name: actions
 description: Create and configure GitHub Actions. Use when building custom actions, setting up runners, implementing security practices, or publishing to the marketplace.
 ---
 

--- a/plugins/tools/github/skills/community-health/SKILL.md
+++ b/plugins/tools/github/skills/community-health/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: github-community-health
+name: community-health
 description: Guide for setting up GitHub community health files for open source repositories. Use when preparing repos for public release, adding community standards files, or configuring issue/PR templates.
 ---
 

--- a/plugins/tools/github/skills/workflows/SKILL.md
+++ b/plugins/tools/github/skills/workflows/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: github-workflows
+name: workflows
 description: Write and optimize GitHub Actions workflows. Use when creating CI/CD pipelines, configuring workflow triggers, managing artifacts, or debugging workflow runs.
 ---
 

--- a/plugins/tools/slidev/.claude-plugin/plugin.json
+++ b/plugins/tools/slidev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slidev",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Slidev presentation skills: strategy, branding, interactive demos, markdown slides, syntax, code blocks, export, and troubleshooting",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/slidev/skills/code/SKILL.md
+++ b/plugins/tools/slidev/skills/code/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: slidev-code
+name: code
 description: Guide for Slidev code block features. Use when configuring syntax highlighting, line highlighting, Monaco editor, Magic Move animations, TwoSlash type annotations, or code groups.
 ---
 

--- a/plugins/tools/slidev/skills/export/SKILL.md
+++ b/plugins/tools/slidev/skills/export/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: slidev-export
+name: export
 description: Guide for exporting Slidev presentations. Use when exporting to PDF, PPTX, PNG, building static SPA sites, or configuring export CLI flags.
 ---
 

--- a/plugins/tools/slidev/skills/interactive/SKILL.md
+++ b/plugins/tools/slidev/skills/interactive/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: slidev-interactive
+name: interactive
 description: Guide for embedding interactive demos and mock UIs in Slidev presentations. Use when adding clickable prototypes, animated workflows, Vue components, or standalone HTML5 mock pages to slide decks.
 ---
 

--- a/plugins/tools/slidev/skills/presentations/SKILL.md
+++ b/plugins/tools/slidev/skills/presentations/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: slidev-presentations
+name: presentations
 description: Guide for presentation strategy and best practices. Use when planning slide decks, choosing audience-appropriate formats, structuring problem-first narratives, creating one-pagers, or following presentation design principles like rule of threes and assertion-evidence.
 ---
 

--- a/plugins/tools/slidev/skills/presentations/references/frameworks.md
+++ b/plugins/tools/slidev/skills/presentations/references/frameworks.md
@@ -1,6 +1,6 @@
 # Presentation Frameworks Reference
 
-Deep reference for the core presentation strategy frameworks used in the `slidev-presentations` skill.
+Deep reference for the core presentation strategy frameworks used in the `presentations` skill.
 
 ## Table of Contents
 

--- a/plugins/tools/slidev/skills/sources.md
+++ b/plugins/tools/slidev/skills/sources.md
@@ -187,7 +187,7 @@ This file documents the sources used to create the slidev plugin skills.
 - **Name**: slidev
 - **Version**: 0.2.0
 - **Description**: Slidev presentation skills: strategy, branding, interactive demos, markdown slides, syntax, code blocks, export, and troubleshooting
-- **Skills**: 8 (slidev, slidev-syntax, slidev-code, slidev-export, slidev-troubleshooting, slidev-presentations, slidev-styles, slidev-interactive)
+- **Skills**: 8 (slidev, syntax, code, export, troubleshooting, presentations, styles, interactive)
 - **Agents**: 3 (content-strategist, brand-discoverer, slide-builder)
 - **Created**: 2026-02-21
 - **Updated**: 2026-04-04

--- a/plugins/tools/slidev/skills/styles/SKILL.md
+++ b/plugins/tools/slidev/skills/styles/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: slidev-styles
+name: styles
 description: Guide for brand discovery, theme generation, and style validation for Slidev presentations. Use when extracting brand tokens from websites, creating Slidev themes from brand guidelines, validating slide compliance with brand standards, or configuring colors, fonts, and spacing.
 ---
 

--- a/plugins/tools/slidev/skills/syntax/SKILL.md
+++ b/plugins/tools/slidev/skills/syntax/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: slidev-syntax
+name: syntax
 description: Guide for Slidev slide syntax and structure. Use when working with slide separators, frontmatter, layouts, MDC syntax, presenter notes, click animations, or transitions.
 ---
 

--- a/plugins/tools/slidev/skills/troubleshooting/SKILL.md
+++ b/plugins/tools/slidev/skills/troubleshooting/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: slidev-troubleshooting
+name: troubleshooting
 description: Guide for debugging and troubleshooting Slidev presentations. Use when diagnosing export failures, missing content, font issues, build errors, or configuration mistakes.
 ---
 

--- a/test/quality-baseline.json
+++ b/test/quality-baseline.json
@@ -198,13 +198,6 @@
       "detail_count": null
     },
     {
-      "key": "dagu/rest-api:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
       "key": "dagu/rest-api:source",
       "class": "DEBT",
       "issue": "claude-skills-144",
@@ -215,13 +208,6 @@
       "key": "dagu/webui:anti_fab",
       "class": "DEBT",
       "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "dagu/webui:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
       "first_seen": "migrated",
       "detail_count": null
     },
@@ -245,13 +231,6 @@
       "issue": "claude-skills-143",
       "first_seen": "migrated",
       "detail_count": 833
-    },
-    {
-      "key": "dagu/workflows:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
-      "first_seen": "migrated",
-      "detail_count": null
     },
     {
       "key": "dupe/1182fd06:duplicate_block",
@@ -401,20 +380,6 @@
       "detail_count": 653
     },
     {
-      "key": "github/actions:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "github/community-health:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
       "key": "github/community-health:source",
       "class": "DEBT",
       "issue": "claude-skills-144",
@@ -427,13 +392,6 @@
       "issue": "claude-skills-143",
       "first_seen": "migrated",
       "detail_count": 887
-    },
-    {
-      "key": "github/workflows:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
-      "first_seen": "migrated",
-      "detail_count": null
     },
     {
       "key": "qa/qa:ref_depth",
@@ -464,23 +422,9 @@
       "detail_count": null
     },
     {
-      "key": "slidev/code:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
       "key": "slidev/export:anti_fab",
       "class": "DEBT",
       "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "slidev/export:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
       "first_seen": "migrated",
       "detail_count": null
     },
@@ -492,23 +436,9 @@
       "detail_count": null
     },
     {
-      "key": "slidev/interactive:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
       "key": "slidev/presentations:anti_fab",
       "class": "DEBT",
       "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "slidev/presentations:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
       "first_seen": "migrated",
       "detail_count": null
     },
@@ -527,13 +457,6 @@
       "detail_count": null
     },
     {
-      "key": "slidev/styles:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
       "key": "slidev/styles:ref_depth",
       "class": "DEBT",
       "issue": "claude-skills-145",
@@ -548,23 +471,9 @@
       "detail_count": null
     },
     {
-      "key": "slidev/syntax:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
       "key": "slidev/troubleshooting:anti_fab",
       "class": "DEBT",
       "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "slidev/troubleshooting:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
       "first_seen": "migrated",
       "detail_count": null
     },
@@ -611,13 +520,6 @@
       "detail_count": null
     },
     {
-      "key": "zig/allocators:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
       "key": "zig/build:anti_fab",
       "class": "DEBT",
       "issue": "claude-skills-144",
@@ -625,23 +527,9 @@
       "detail_count": null
     },
     {
-      "key": "zig/build:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
       "key": "zig/c-interop:anti_fab",
       "class": "DEBT",
       "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "zig/c-interop:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
       "first_seen": "migrated",
       "detail_count": null
     },
@@ -660,13 +548,6 @@
       "detail_count": null
     },
     {
-      "key": "zig/language:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
       "key": "zig/testing:anti_fab",
       "class": "DEBT",
       "issue": "claude-skills-144",
@@ -674,23 +555,9 @@
       "detail_count": null
     },
     {
-      "key": "zig/testing:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
       "key": "zig/troubleshooting:anti_fab",
       "class": "DEBT",
       "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "zig/troubleshooting:name_dir",
-      "class": "DEBT",
-      "issue": "claude-skills-139",
       "first_seen": "migrated",
       "detail_count": null
     },


### PR DESCRIPTION
- Strip the plugin prefix from 19 skill frontmatter name lines (dagu 3, github 3, slidev 7, zig 6) so name matches the directory per the Agent Skills spec; invocation is directory-driven, so no skill's invocation changes
- Update the four doc sites carrying the prefixed names to bare form: README slidev bullets, skill-catalog dagu/slidev rows, slidev sources.md summary line, presentations frameworks.md prose
- Remove the 19 name_dir waivers from test/quality-baseline.json via --update-baseline (101 -> 82)
- Bump dagu 0.1.4, github 0.3.4, slidev 0.2.1, zig 0.1.4, core 0.2.32, all-skills 0.4.64 in plugin.json and marketplace.json; mise update-all-skills reports no skill path changes
- Verified: quality validator green with 82 waivers and zero name_dir failures; source waivers unchanged at 8; slidev-exported default, the export-configuration TOC anchor, and github sources.md URLs byte-identical to main; mise test and mise run ci exit 0; gitleaks clean