### PR TITLE
fix(bees): correct twelve documented behaviours against bees 0.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.65",
+      "version": "0.4.66",
       "category": "meta",
       "keywords": [
         "all",
@@ -114,7 +114,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, accessibility, security",
-      "version": "0.2.33",
+      "version": "0.2.34",
       "category": "development",
       "keywords": [
         "git",
@@ -261,7 +261,7 @@
       "source": "./plugins/pm",
       "strict": true,
       "description": "Product management toolkit: harvest implementation-agnostic feature specs from prototypes with SDLC guardrails and author PRDs as implementation contracts",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "tools",
       "keywords": [
         "pm",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.65",
+  "version": "0.4.66",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/mise.toml
+++ b/mise.toml
@@ -682,29 +682,32 @@ def main [issue_id: string] {
 description = "Create a new issue"
 run = '''
 #!/usr/bin/env nu
+# bees create has NO label flag and NO parent flag; its -p is PRIORITY.
+# Add labels after creation with `bees label add <id> <label>` (one per call);
+# add parent links with `bees dep add <child> <parent> -t parent-child`.
 def main [
     title: string
     --description (-d): string  # Issue description
-    --labels (-l): string       # Comma-separated labels
+    --type (-t): string         # Issue type (task, bug, feature, epic, story)
+    --priority (-p): int        # Priority (1=critical .. 4=low)
     --assignee (-a): string     # Assignee name
     --owner (-o): string        # Owner name
-    --parent (-p): string       # Parent issue ID
 ] {
     mut args = ["create", $title]
     if ($description | is-not-empty) {
         $args = ($args | append ["-d", $description])
     }
-    if ($labels | is-not-empty) {
-        $args = ($args | append ["-l", $labels])
+    if ($type | is-not-empty) {
+        $args = ($args | append ["-t", $type])
+    }
+    if ($priority | is-not-empty) {
+        $args = ($args | append ["-p", ($priority | into string)])
     }
     if ($assignee | is-not-empty) {
         $args = ($args | append ["-a", $assignee])
     }
     if ($owner | is-not-empty) {
         $args = ($args | append ["-o", $owner])
-    }
-    if ($parent | is-not-empty) {
-        $args = ($args | append ["-p", $parent])
     }
     ^bees ...$args
 }
@@ -756,37 +759,27 @@ def main [
 description = "Export issues to JSONL format"
 run = "bees sync"
 
-[tasks."bees:prime"]
-description = "Generate markdown output for LLM context"
-run = '''
-#!/usr/bin/env nu
-def main [
-    --status (-s): string   # Filter by status
-    --labels (-l): string   # Filter by labels
-] {
-    mut args = ["prime"]
-    if ($status | is-not-empty) {
-        $args = ($args | append ["--status", $status])
-    }
-    if ($labels | is-not-empty) {
-        $args = ($args | append ["--labels", $labels])
-    }
-    ^bees ...$args
-}
-'''
+[tasks."bees:import"]
+description = "Rebuild the database from issues.jsonl (drops and re-creates bees.db)"
+run = "bees import"
 
+# bees prime takes no flags and outputs a static workflow cheatsheet (no issue
+# data). For issue context use bees:list / bees:show, which wrap --json.
+[tasks."bees:prime"]
+description = "Dump the static agent workflow cheatsheet"
+run = "bees prime"
+
+# bees config requires a get/set subcommand; a bare `bees config` exits 1.
 [tasks."bees:config"]
-description = "Show or set bees configuration"
+description = "Get or set a bees configuration value"
 run = '''
 #!/usr/bin/env nu
 def main [
-    action?: string  # "set" or "get" (omit to show all)
-    key?: string     # Config key
+    action: string   # "set" or "get"
+    key: string      # Config key
     value?: string   # Config value (for set)
 ] {
-    if ($action | is-empty) {
-        bees config
-    } else if $action == "set" {
+    if $action == "set" {
         bees config set $key $value
         print $"(ansi green)Set ($key) = ($value)(ansi reset)"
     } else if $action == "get" {
@@ -859,29 +852,31 @@ def main [issue_id: string] {
 }
 '''
 
+# bees label takes ONE label per invocation — a comma-separated string is
+# stored verbatim as a single literal label (e.g. "a,b").
 [tasks."bees:label:add"]
-description = "Add labels to an issue"
+description = "Add a label to an issue (one label per call)"
 run = '''
 #!/usr/bin/env nu
 def main [
     issue_id: string # Issue ID
-    labels: string   # Comma-separated labels to add
+    label: string    # Single label to add
 ] {
-    bees label add $issue_id $labels
-    print $"(ansi cyan)Added labels to ($issue_id): ($labels)(ansi reset)"
+    bees label add $issue_id $label
+    print $"(ansi cyan)Added label to ($issue_id): ($label)(ansi reset)"
 }
 '''
 
 [tasks."bees:label:remove"]
-description = "Remove labels from an issue"
+description = "Remove a label from an issue (one label per call)"
 run = '''
 #!/usr/bin/env nu
 def main [
     issue_id: string # Issue ID
-    labels: string   # Comma-separated labels to remove
+    label: string    # Single label to remove
 ] {
-    bees label remove $issue_id $labels
-    print $"(ansi yellow)Removed labels from ($issue_id): ($labels)(ansi reset)"
+    bees label remove $issue_id $label
+    print $"(ansi yellow)Removed label from ($issue_id): ($label)(ansi reset)"
 }
 '''
 

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "description": "Essential development skills: Git, documentation, code review, accessibility",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/bees/SKILL.md
+++ b/plugins/core/skills/bees/SKILL.md
@@ -12,7 +12,7 @@ This skill activates when working with Bees for issue tracking, dependency manag
 
 Activate when:
 - Managing issues with dependencies in a local repository
-- Exporting issue context for AI agents (`bees prime`)
+- Exporting issue context for AI agents (`bees list --json`, `bees show --json`)
 - Tracking issue hierarchies and dependency graphs
 - Needing SQLite-backed performance for large issue sets
 - Syncing issues to JSONL for portability (`bees sync`)
@@ -24,14 +24,13 @@ Bees is a lightweight, local-first issue tracker designed for AI-augmented devel
 
 - **SQLite storage**: WAL-mode SQLite database for fast queries
 - **Single binary**: Written in Zig, compiles to a small static binary
-- **AI-augmented**: `bees prime` outputs markdown for LLM context, `bees sync` exports JSONL
+- **AI-augmented**: `bees prime` dumps a workflow cheatsheet for agents, `bees sync` exports JSONL, `--json` flags on read commands
 - **Dependency-aware**: Query ready issues with `bees ready`, supports blocks/related/parent-child
-- **VS Code integration**: Compatible with beads VS Code extensions via `.beads` symlink
 - **Local-first**: No server required, everything stored in `.bees/` directory
 
 ## Installation
 
-Install via mise: add `[tools."github:ctxshift/bees"]` with `version = "latest"` to `mise.toml` (see `templates/mise.toml`), then `mise install`. Full install matrix, platform asset patterns, pre-built binaries, source build, and VS Code extensions: `references/installation.md`.
+Install via mise: add `[tools."github:ctxshift/bees"]` with `version = "latest"` to `mise.toml` (see `templates/mise.toml`), then `mise install`. Full install matrix, platform asset patterns, pre-built binaries, and source build: `references/installation.md`.
 
 ## Getting Started
 
@@ -77,7 +76,7 @@ Returns issues with no unresolved dependencies.
 
 ## Commands Reference
 
-Per-flag syntax for all 12 subcommands (`create`, `list`, `show`, `update`, `close`, `ready`, `dep`, `label`, `comment`, `config`, `sync`, `prime`): `references/commands.md`.
+Per-flag syntax for the 13 day-to-day subcommands (`create`, `list`, `show`, `update`, `close`, `ready`, `dep`, `label`, `comment`, `config`, `sync`, `import`, `prime`): `references/commands.md`. bees 0.4.0 has 19 top-level commands; for the rest (`upgrade`, `edit`, `rename-prefix`, `daemon`, `version`, and the `ls` alias) run `bees <cmd> --help` — except `bees upgrade --help`, which executes a real database migration instead of printing help (see Troubleshooting).
 
 ## Dependency Management
 
@@ -100,7 +99,8 @@ bees dep add <id> <blocker-id>           # id depends on blocker-id
 `bees ready` returns issues where:
 - Status is `open`
 - No open `blocks` dependencies remain
-- Parent issues (if any) are still open
+
+Only `blocks`-type dependencies gate readiness. `parent-child` and `related` dependencies never do — a child issue stays in `bees ready` whether its parent is open or closed (verified against bees 0.4.0). To make a child wait on its parent, add an explicit `blocks` edge.
 
 ### Cycles are NOT rejected — check before adding a reverse edge
 
@@ -129,15 +129,15 @@ bees sync
 
 The JSONL file contains one JSON object per line, compatible with standard data processing tools.
 
-### bees prime (Markdown for LLMs)
+### bees prime (Agent Workflow Cheatsheet)
 
-Generate a markdown summary for LLM context windows:
+Dump the static workflow-context cheatsheet for AI agents:
 
 ```bash
 bees prime
 ```
 
-Output includes issue titles, descriptions, labels, dependencies, and status in a readable markdown format. Pipe directly into agent prompts or save to file.
+The output is a fixed markdown dump of workflow rules and essential commands — it contains **no issue data** (verified against bees 0.4.0: a repo with 4 issues produced zero mentions of any issue id). It takes no flags. For issue context — titles, descriptions, labels, dependencies, status — use `bees list --json` and `bees show <id> --json`.
 
 `--json` flag coverage and jq scripting recipes: `references/commands.md`.
 
@@ -149,19 +149,15 @@ Output includes issue titles, descriptions, labels, dependencies, and status in 
 ├── issues.jsonl     # JSONL export (created by bees sync)
 ├── metadata.json    # Repository metadata
 ├── config.json      # Local configuration
-└── .beads           # Symlink for VS Code extension compatibility
+└── .gitignore       # Excludes bees.db from version control
 ```
 
 ### SQLite as Primary Storage
 
 Unlike beads (which uses JSONL as primary with SQLite cache), bees uses SQLite as the primary data store:
 - WAL mode for concurrent read access
-- No need for `rebuild` commands
 - `bees sync` exports to JSONL for portability
-
-### The .beads Symlink
-
-Bees creates a `.beads` symlink pointing to the `.bees/` directory. This enables compatibility with VS Code extensions designed for beads (`vscode-beads` and `beads-kanban`).
+- `bees import` rebuilds the database from `issues.jsonl` (drops and re-creates `bees.db`) — use after pulling a new `issues.jsonl`
 
 ## Workflow Examples
 
@@ -221,10 +217,6 @@ bees ready                       # Find next issue
 
 An automated task-loop script (poll `bees ready --json`, work, close, sync): `references/commands.md`.
 
-## VS Code Integration
-
-The `.beads` symlink makes the beads VS Code extensions work with bees; extension install commands: `references/installation.md`.
-
 ## Bees vs Beads
 
 | Feature | Bees | Beads |
@@ -233,12 +225,11 @@ The `.beads` symlink makes the beads VS Code extensions work with bees; extensio
 | Language | Zig | Go |
 | Binary | Single static binary | Go binary |
 | Sync model | One-directional export (`bees sync`) | Bidirectional git sync (`bd sync`/`bd pull`) |
-| AI context | `bees prime` (markdown output) | `--json` flags only |
+| AI context | `bees prime` (static workflow cheatsheet); issue data via `--json` flags | `--json` flags only |
 | Init modes | Local-first only | Full, stealth, contributor |
 | Comments | `bees comment add` | `bd comment` |
 | Dependency types | blocks, related, parent (`-t` flag) | blocks only |
-| VS Code | Via `.beads` symlink | Native |
-| Conflict resolution | Not needed (SQLite primary) | `bd rebuild` from JSONL |
+| Rebuild from JSONL | `bees import` | `bd rebuild` |
 
 ## Best Practices
 
@@ -275,7 +266,7 @@ One bees issue == one slice. A complex slice still gets ONE bees issue; the five
 
 ### AI Integration Tips
 
-- Use `bees prime` to inject issue context into agent prompts
+- Use `bees prime` to inject the workflow cheatsheet into agent prompts; inject issue context with `bees list --json` / `bees show <id> --json`
 - Use `bees ready --json` for automated task queue polling
 - Use `bees sync` to create portable JSONL snapshots
 - Close issues atomically after completion
@@ -331,6 +322,10 @@ sqlite3 .bees/bees.db "PRAGMA integrity_check;"
 lsof .bees/bees.db
 ```
 
+### `bees upgrade --help` runs the migration
+
+`bees upgrade --help` does not print help — it executes the real upgrade (refreshes `.bees/.gitignore` and applies schema migrations to `bees.db`), verified against bees 0.4.0. Do not probe `upgrade` with `--help` on a tracker you are not ready to migrate.
+
 ### Build Issues (from source)
 
 Troubleshooting for source builds lives with the build instructions: `references/installation.md`.
@@ -345,8 +340,8 @@ bees sync
 
 ## References
 
-- `references/commands.md`: Per-flag syntax for all 12 subcommands, `--json` output, jq scripting recipes, and the agent task-loop script
-- `references/installation.md`: Install matrix (mise, pre-built binaries, source build), VS Code extensions, and build troubleshooting
+- `references/commands.md`: Per-flag syntax for the 13 day-to-day subcommands, `--json` output, jq scripting recipes, and the agent task-loop script
+- `references/installation.md`: Install matrix (mise, pre-built binaries, source build) and build troubleshooting
 - `references/teams-integration.md`: Protocol for mirroring bees issues into Claude's task list for Agent Teams coordination
 - `references/migration-from-beads.md`: Guide for migrating from beads to bees
 

--- a/plugins/core/skills/bees/references/commands.md
+++ b/plugins/core/skills/bees/references/commands.md
@@ -1,6 +1,8 @@
 # Bees Commands Reference
 
-Per-flag syntax for every `bees` subcommand, JSON output for scripting, and the agent task-loop script. Decision-shaped guidance (dependency types, ready queue, workflows, best practices) stays in the skill body.
+Per-flag syntax for the 13 day-to-day `bees` subcommands, JSON output for scripting, and the agent task-loop script. Decision-shaped guidance (dependency types, ready queue, workflows, best practices) stays in the skill body.
+
+bees 0.4.0 has 19 top-level commands. The rest (`init`, `upgrade`, `edit`, `rename-prefix`, `daemon`, `version`, and the `ls` alias for `list`) are out of scope here — run `bees <cmd> --help` for their syntax. Exception: do NOT run `bees upgrade --help` casually — it executes a real database migration instead of printing help (verified against bees 0.4.0).
 
 ## Commands Reference
 
@@ -33,10 +35,17 @@ List issues with filtering:
 bees list
 bees list --status open
 bees list --status closed
-bees list --labels "bug"
 bees list --assignee "alice"
 bees list --json
 ```
+
+Flags (from `bees list --help`, bees 0.4.0):
+- `-s` / `--status`: Filter by status (open, in_progress, closed, deferred)
+- `-p` / `--priority`: Filter by priority
+- `-a` / `--assignee`: Filter by assignee
+- `--json`: Output as JSON array
+
+There is **no** label filter — `bees list --labels` exits 1 with `Error: InvalidArgument`. Filter labels client-side: `bees list --json | jq '[.[] | select(.labels | index("bug"))]'`.
 
 ### show
 
@@ -70,13 +79,14 @@ The `-r` flag adds a closing reason.
 
 ### ready
 
-List issues with no unresolved dependencies:
+List open issues with no unresolved blocking dependencies:
 
 ```bash
 bees ready
 bees ready --json
-bees ready --labels "priority:high"
 ```
+
+`--json` is the **only** flag `ready` accepts (`bees ready --help`, bees 0.4.0); `bees ready --labels` exits 1. Only `blocks`-type dependencies gate readiness — see "Ready Queue" in the skill body.
 
 ### dep
 
@@ -117,13 +127,14 @@ bees comment list <id>
 
 ### config
 
-View and set configuration:
+Get and set configuration values:
 
 ```bash
-bees config                    # Show current config
-bees config set key value      # Set a config value
-bees config get key            # Get a config value
+bees config get <key>          # Get a config value
+bees config set <key> <value>  # Set a config value
 ```
+
+A bare `bees config` does not show the current config — it exits 1 with `Error: subcommand required (get, set)`.
 
 ### sync
 
@@ -135,17 +146,25 @@ bees sync
 
 Writes issues from the SQLite database to `issues.jsonl` in the `.bees/` directory. This is a one-directional export (database to JSONL).
 
+### import
+
+Rebuild the database from JSONL:
+
+```bash
+bees import
+```
+
+Rebuilds the database from `issues.jsonl` — drops and re-creates `.bees/bees.db` (`bees import --help`). Use after pulling a new `issues.jsonl`. This is bees' equivalent of beads' `bd rebuild`.
+
 ### prime
 
-Generate markdown output for LLM context:
+Dump the static agent-workflow cheatsheet:
 
 ```bash
 bees prime
-bees prime --status open
-bees prime --labels "sprint:current"
 ```
 
-Outputs a formatted markdown summary of issues suitable for including in AI agent prompts.
+Outputs a fixed markdown workflow-context dump for AI agents (core rules, essential commands, session-recovery guidance). The output contains **no issue data** — verified against bees 0.4.0: a repo with 4 issues produced 58 lines with zero mentions of any issue id. `prime` accepts no flags; `bees prime --status` and `bees prime --labels` both exit 1. For issue context, use `bees list --json` and `bees show <id> --json`.
 
 ## JSON Output and Scripting
 

--- a/plugins/core/skills/bees/references/installation.md
+++ b/plugins/core/skills/bees/references/installation.md
@@ -1,6 +1,6 @@
 # Bees Installation
 
-Full install matrix (mise, pre-built binaries, source build), VS Code integration, and build troubleshooting. The mise route is the common case; a stub remains in the skill body.
+Full install matrix (mise, pre-built binaries, source build) and build troubleshooting. The mise route is the common case; a stub remains in the skill body.
 
 ## Installation
 
@@ -41,26 +41,6 @@ git clone https://github.com/ctxshift/bees.git
 cd bees
 zig build -Doptimize=ReleaseSafe
 ```
-
-## VS Code Integration
-
-Bees creates a `.beads` symlink to `.bees/` for compatibility with the beads VS Code extensions:
-
-### Beads Extension (`planet57.vscode-beads`)
-
-```bash
-code --install-extension planet57.vscode-beads
-```
-
-Task list sidebar, syntax highlighting, and issue ID autocompletion.
-
-### Beads Kanban (`DavidCForbes.beads-kanban`)
-
-```bash
-code --install-extension DavidCForbes.beads-kanban
-```
-
-Drag-and-drop kanban board with dependency visualization.
 
 ## Troubleshooting
 

--- a/plugins/core/skills/bees/references/migration-from-beads.md
+++ b/plugins/core/skills/bees/references/migration-from-beads.md
@@ -6,7 +6,6 @@ Guide for converting from beads (`bd`) to bees for issue tracking.
 
 Consider migrating when:
 - SQLite performance benefits matter for large issue sets
-- `bees prime` markdown output is needed for AI agent context
 - Simpler sync model (one-directional export) is preferred
 - Multiple dependency types (blocks, related, parent) are needed
 
@@ -25,10 +24,10 @@ Consider migrating when:
 | `bd comment` | `bees comment add` | Subcommand style: `bees comment add <id> <text>` |
 | `bd assign` | `bees update -a` | Via update flag |
 | `bd label --add` | `bees label add` | Separate subcommand |
-| `bd rebuild` | _(none)_ | Not needed; SQLite is primary storage |
+| `bd rebuild` | `bees import` | Rebuilds `bees.db` from `issues.jsonl` |
 | `bd init --stealth` | _(none)_ | Bees is always local-first |
 | `bd reopen` | `bees update --status open` | Via status update |
-| `.beads/` | `.bees/` | Different directory, `.beads` symlink created |
+| `.beads/` | `.bees/` | Different directory |
 | `[bd:ID]` | `[bees:ID]` | Claude Teams subject convention |
 
 ## Data Migration Script
@@ -42,26 +41,28 @@ Nushell script template to export beads issues and import into bees:
 let tasks = (bd list --json | from json)
 
 # Create each task in bees
+# bees create has no label flag; labels are replayed with `bees label add`,
+# one label per call, using the new ID from `bees create --json`.
 for task in $tasks {
-    mut args = ["create", $task.title]
+    mut args = ["create", $task.title, "--json"]
 
     if ($task.description? | is-not-empty) {
         $args = ($args | append ["-d", $task.description])
-    }
-    if ($task.labels? | is-not-empty) {
-        $args = ($args | append ["-l", ($task.labels | str join ",")])
     }
     if ($task.assignee? | is-not-empty) {
         $args = ($args | append ["-a", $task.assignee])
     }
 
     print $"Creating: ($task.title)"
-    ^bees ...$args
+    let created = (^bees ...$args | from json)
+
+    for label in ($task.labels? | default []) {
+        ^bees label add $created.id $label
+    }
 
     # Close if the beads task was closed
     if ($task.status == "closed") {
-        # Note: you'll need the new bees ID from the create output
-        print $"  (task was closed in beads - close manually after verifying ID)"
+        ^bees close $created.id -r "closed in beads before migration"
     }
 }
 
@@ -72,7 +73,6 @@ print "Then recreate dependencies with: bees dep add <id> <blocker-id>"
 After running the script:
 1. Verify issues with `bees list`
 2. Recreate dependencies manually with `bees dep add`
-3. Replay labels with `bees label add` if not captured in create
 
 ## Mise Task Migration
 
@@ -97,8 +97,8 @@ After running the script:
 | `beads:assign` | _(use bees:update)_ | `bees update -a` |
 | `beads:label` | `bees:label:add` / `bees:label:remove` | Separate add/remove |
 | `beads:tree` | _(none)_ | No tree view |
-| `beads:rebuild` | _(none)_ | Not needed with SQLite |
-| _(none)_ | `bees:prime` | New: markdown for LLMs |
+| `beads:rebuild` | `bees:import` | Rebuilds `bees.db` from `issues.jsonl` |
+| _(none)_ | `bees:prime` | New: static workflow cheatsheet for agents |
 | _(none)_ | `bees:config` | New: configuration management |
 
 ## Worker Agent Switchover
@@ -115,14 +115,12 @@ To switch from `beads-worker` to `bees-worker`:
 Both tools can run in the same repository:
 
 - Beads uses `.beads/` directory
-- Bees uses `.bees/` directory (with `.beads` symlink)
-- The `.beads` symlink created by bees may conflict with an existing `.beads/` directory
-- To coexist: initialize bees first, or rename the existing `.beads/` before running `bees init`
+- Bees uses `.bees/` directory
+- The directories are independent; there is no conflict (`bees init` creates only `.bees/`)
 
 Add both directories to `.gitignore` if using stealth/local-only mode:
 
 ```gitignore
 .beads/
 .bees/
-.beads
 ```

--- a/plugins/core/skills/bees/templates/mise.toml
+++ b/plugins/core/skills/bees/templates/mise.toml
@@ -64,29 +64,32 @@ def main [issue_id: string] {
 description = "Create a new issue"
 run = '''
 #!/usr/bin/env nu
+# bees create has NO label flag and NO parent flag; its -p is PRIORITY.
+# Add labels after creation with `bees label add <id> <label>` (one per call);
+# add parent links with `bees dep add <child> <parent> -t parent-child`.
 def main [
     title: string
     --description (-d): string  # Issue description
-    --labels (-l): string       # Comma-separated labels
+    --type (-t): string         # Issue type (task, bug, feature, epic, story)
+    --priority (-p): int        # Priority (1=critical .. 4=low)
     --assignee (-a): string     # Assignee name
     --owner (-o): string        # Owner name
-    --parent (-p): string       # Parent issue ID
 ] {
     mut args = ["create", $title]
     if ($description | is-not-empty) {
         $args = ($args | append ["-d", $description])
     }
-    if ($labels | is-not-empty) {
-        $args = ($args | append ["-l", $labels])
+    if ($type | is-not-empty) {
+        $args = ($args | append ["-t", $type])
+    }
+    if ($priority | is-not-empty) {
+        $args = ($args | append ["-p", ($priority | into string)])
     }
     if ($assignee | is-not-empty) {
         $args = ($args | append ["-a", $assignee])
     }
     if ($owner | is-not-empty) {
         $args = ($args | append ["-o", $owner])
-    }
-    if ($parent | is-not-empty) {
-        $args = ($args | append ["-p", $parent])
     }
     ^bees ...$args
 }
@@ -138,37 +141,27 @@ def main [
 description = "Export issues to JSONL format"
 run = "bees sync"
 
-[tasks."bees:prime"]
-description = "Generate markdown output for LLM context"
-run = '''
-#!/usr/bin/env nu
-def main [
-    --status (-s): string   # Filter by status
-    --labels (-l): string   # Filter by labels
-] {
-    mut args = ["prime"]
-    if ($status | is-not-empty) {
-        $args = ($args | append ["--status", $status])
-    }
-    if ($labels | is-not-empty) {
-        $args = ($args | append ["--labels", $labels])
-    }
-    ^bees ...$args
-}
-'''
+[tasks."bees:import"]
+description = "Rebuild the database from issues.jsonl (drops and re-creates bees.db)"
+run = "bees import"
 
+# bees prime takes no flags and outputs a static workflow cheatsheet (no issue
+# data). For issue context use bees:list / bees:show, which wrap --json.
+[tasks."bees:prime"]
+description = "Dump the static agent workflow cheatsheet"
+run = "bees prime"
+
+# bees config requires a get/set subcommand; a bare `bees config` exits 1.
 [tasks."bees:config"]
-description = "Show or set bees configuration"
+description = "Get or set a bees configuration value"
 run = '''
 #!/usr/bin/env nu
 def main [
-    action?: string  # "set" or "get" (omit to show all)
-    key?: string     # Config key
+    action: string   # "set" or "get"
+    key: string      # Config key
     value?: string   # Config value (for set)
 ] {
-    if ($action | is-empty) {
-        bees config
-    } else if $action == "set" {
+    if $action == "set" {
         bees config set $key $value
         print $"(ansi green)Set ($key) = ($value)(ansi reset)"
     } else if $action == "get" {
@@ -241,28 +234,30 @@ def main [issue_id: string] {
 }
 '''
 
+# bees label takes ONE label per invocation — a comma-separated string is
+# stored verbatim as a single literal label (e.g. "a,b").
 [tasks."bees:label:add"]
-description = "Add labels to an issue"
+description = "Add a label to an issue (one label per call)"
 run = '''
 #!/usr/bin/env nu
 def main [
     issue_id: string # Issue ID
-    labels: string   # Comma-separated labels to add
+    label: string    # Single label to add
 ] {
-    bees label add $issue_id $labels
-    print $"(ansi cyan)Added labels to ($issue_id): ($labels)(ansi reset)"
+    bees label add $issue_id $label
+    print $"(ansi cyan)Added label to ($issue_id): ($label)(ansi reset)"
 }
 '''
 
 [tasks."bees:label:remove"]
-description = "Remove labels from an issue"
+description = "Remove a label from an issue (one label per call)"
 run = '''
 #!/usr/bin/env nu
 def main [
     issue_id: string # Issue ID
-    labels: string   # Comma-separated labels to remove
+    label: string    # Single label to remove
 ] {
-    bees label remove $issue_id $labels
-    print $"(ansi yellow)Removed labels from ($issue_id): ($labels)(ansi reset)"
+    bees label remove $issue_id $label
+    print $"(ansi yellow)Removed label from ($issue_id): ($label)(ansi reset)"
 }
 '''

--- a/plugins/core/skills/sources.md
+++ b/plugins/core/skills/sources.md
@@ -173,7 +173,7 @@ This file documents the sources used to create the core plugin skills.
 - **URL**: https://github.com/ctxshift/bees
 - **Purpose**: Source code, installation instructions, and CLI documentation for the SQLite-backed issue tracker
 - **Date Accessed**: 2026-03-20
-- **Key Topics**: SQLite WAL storage, Zig binary, JSONL export, markdown prime, dependency types, local-first design
+- **Key Topics**: SQLite WAL storage, Zig binary, JSONL export/import, workflow-cheatsheet prime, dependency types, local-first design
 
 ### Bees GitHub Releases
 - **URL**: https://github.com/ctxshift/bees/releases
@@ -181,19 +181,12 @@ This file documents the sources used to create the core plugin skills.
 - **Date Accessed**: 2026-03-20
 - **Key Topics**: Asset naming patterns for mise installation
 
-### VS Code Extensions (Shared with Beads)
-- **URL**: https://marketplace.visualstudio.com/items?itemName=planet57.vscode-beads
-- **Purpose**: Core beads/bees integration for VS Code via .beads symlink
-- **URL**: https://marketplace.visualstudio.com/items?itemName=DavidCForbes.beads-kanban
-- **Purpose**: Visual kanban board compatible with bees via .beads symlink
-
 ### Key Concepts Extracted
 - SQLite WAL-mode database as primary storage (vs beads' JSONL primary + SQLite cache)
 - Single Zig binary with cross-platform builds
-- `bees prime` for markdown LLM context output
-- `bees sync` for one-directional JSONL export
+- `bees prime` for a static agent-workflow cheatsheet (no issue data)
+- `bees sync` for one-directional JSONL export; `bees import` to rebuild the database from JSONL
 - Three dependency types: blocks, related, parent
-- `.beads` symlink for VS Code extension compatibility
 
 ## Container Skill
 

--- a/plugins/pm/.claude-plugin/plugin.json
+++ b/plugins/pm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Product management toolkit: harvest implementation-agnostic feature specs from prototypes with SDLC guardrails and author PRDs as implementation contracts",
   "author": {
     "name": "vinnie357"

--- a/plugins/pm/skills/spec-harvest/references/bees-to-spec.md
+++ b/plugins/pm/skills/spec-harvest/references/bees-to-spec.md
@@ -6,10 +6,10 @@ Read-only bees surface for pm-discovery's bees-map shard and the provenance cita
 
 The bees-map shard and pm-spec-writer use only these commands:
 
-- `bees list --status open|closed --labels <tag> --assignee <name> --json`
+- `bees list [--status open|closed] [--assignee <name>] [--json]` — no label filter exists; filter labels client-side via `--json` + jq
 - `bees show <id> [--json]`
-- `bees ready [--json --labels <tag>]`
-- `bees prime [--status open --labels <tag>]` — markdown export, LLM-ready
+- `bees ready [--json]` — the only flag `ready` accepts
+- `bees prime` — static agent-workflow cheatsheet, no flags, contains no issue data
 - `bees dep list <id>`
 - `bees comment list <id>`
 - `bees config get <key>`
@@ -39,7 +39,7 @@ Spec harvesting reads the prototype's existing tracker state; it never mutates i
 
 ## Detection
 
-Check for a `.bees/` directory at the prototype root before running the bees-map shard. A bees repository contains `bees.db` (SQLite, WAL mode), `issues.jsonl`, `metadata.json`, `config.json`, and a `.beads` compatibility symlink.
+Check for a `.bees/` directory at the prototype root before running the bees-map shard. A bees repository contains `bees.db` (SQLite, WAL mode), `issues.jsonl`, `metadata.json`, and `config.json`.
 
 When `.bees/` is absent:
 - Skip the bees-map shard entirely.


### PR DESCRIPTION
- Correct `bees prime` docs: it dumps a static workflow cheatsheet with no issue data (verified: 4-issue repo, 58 lines, 0 issue-id mentions); point issue context at `bees list --json` / `bees show --json`
- Delete the `.beads` symlink claims everywhere: `bees init` creates only `.bees/` and the binary removes legacy symlinks (SKILL.md x5, installation.md VS Code section, sources.md, migration coexistence, pm bees-to-spec detection heuristic)
- Correct `bees ready` semantics: only `blocks` deps gate readiness; parent-child deps never do (child verified ready before and after parent close)
- Fix flag defects: no `--labels` on `list`/`ready`, `prime` takes zero flags, bare `bees config` exits 1 (get/set required), `create` has no label/parent flag (`-p` is priority)
- Document `bees import` (rebuild DB from issues.jsonl) and replace "no rebuild needed" claims; add `bees:import` task
- Fix mise tasks in template AND root mise.toml: `bees:create` (drop -l/parent, add -t/-p priority), `bees:prime` (no flags), `bees:config` (require get/set), `bees:label:add/remove` (one label per call; comma strings stored literally)
- Rewrite migration script: capture new id via `bees create --json`, replay labels one per call, auto-close migrated closed tasks (script executed against bees 0.4.0)
- Scope the subcommand-count claim: 13 day-to-day of 19 total; add `bees upgrade --help` gotcha (it executes a real DB migration)
- Bump core 0.2.34, pm 0.1.1, all-skills 0.4.66