### PR TITLE
refactor(github): move syntax reference out of workflows and act bodies

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.66",
+      "version": "0.4.67",
       "category": "meta",
       "keywords": [
         "all",
@@ -165,7 +165,7 @@
       "source": "./plugins/tools/github",
       "strict": true,
       "description": "GitHub Actions, Workflows, act local testing, community health files, Dependabot consolidation, and PR review",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "category": "tools",
       "keywords": [
         "github",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.66",
+  "version": "0.4.67",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/github/.claude-plugin/plugin.json
+++ b/plugins/tools/github/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "GitHub Actions, Workflows, act local testing, community health files, Dependabot consolidation, and PR review",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/github/skills/act/SKILL.md
+++ b/plugins/tools/github/skills/act/SKILL.md
@@ -382,7 +382,7 @@ Commit an `.actrc` so every run gets the same platform image, secrets file, and 
 
 ### Conditional Logic for Local Testing
 
-act sets the `ACT` environment variable inside its containers (per nektos/act docs) and passes the real event name through, so there is no `act` event to test for:
+act sets the `ACT` environment variable inside its containers — per nektos/act docs, which give this exact `!env.ACT` form. The event name is whatever you invoke (`act pull_request` runs as `pull_request`; a bare `act` runs as `push`), so there is no `act` event to test for:
 
 ```yaml
 steps:

--- a/plugins/tools/github/skills/act/SKILL.md
+++ b/plugins/tools/github/skills/act/SKILL.md
@@ -20,41 +20,7 @@ Activate when:
 
 ## Installation
 
-### Using mise (Recommended for this project)
-
-The act tool is configured in the github plugin's mise.toml:
-
-```bash
-# Install act via mise
-mise install act
-
-# Verify installation
-act --version
-```
-
-### Alternative Installation Methods
-
-**macOS (Homebrew):**
-```bash
-brew install act
-```
-
-**Linux (via script):**
-```bash
-curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
-```
-
-**From source:**
-```bash
-git clone https://github.com/nektos/act.git
-cd act
-make install
-```
-
-**Windows (Chocolatey):**
-```powershell
-choco install act-cli
-```
+Install via mise: `mise install act` (pinned in the github plugin's mise.toml), then verify with `act --version`. Homebrew, Linux script, source, and Chocolatey methods: see `references/setup-and-config.md`.
 
 ## How act Works
 
@@ -69,13 +35,7 @@ act reads workflow files from `.github/workflows/` and:
 
 ## Prerequisites
 
-- **Docker**: act requires Docker to run workflows
-- **Workflow files**: Valid `.github/workflows/*.yml` files in repository
-
-Verify Docker is running:
-```bash
-docker ps
-```
+act requires a running Docker daemon (verify with `docker ps`) and valid `.github/workflows/*.yml` files. Details: see `references/setup-and-config.md`.
 
 ## Basic Usage
 
@@ -132,43 +92,7 @@ act -n -v
 
 ## Event Payloads
 
-### Custom Event Data
-
-Create event JSON file:
-
-```json
-{
-  "pull_request": {
-    "number": 123,
-    "head": {
-      "ref": "feature-branch"
-    },
-    "base": {
-      "ref": "main"
-    }
-  }
-}
-```
-
-Use with act:
-```bash
-act pull_request -e event.json
-```
-
-### workflow_dispatch Inputs
-
-```json
-{
-  "inputs": {
-    "environment": "staging",
-    "debug": true
-  }
-}
-```
-
-```bash
-act workflow_dispatch -e inputs.json
-```
+Custom event JSON and `workflow_dispatch` input payloads, passed with `-e file.json`: see `references/setup-and-config.md`. A worked PR-event example stays under Common Patterns below.
 
 ## Secrets Management
 
@@ -209,58 +133,7 @@ act -s MY_SECRET
 
 ## Configuration
 
-### .actrc File
-
-Create `.actrc` in repository root or home directory:
-
-```
-# Use specific platform
--P ubuntu-latest=catthehacker/ubuntu:act-latest
-
-# Default secrets file
---secret-file .secrets
-
-# Default environment
---env-file .env
-
-# Container architecture
---container-architecture linux/amd64
-
-# Verbose output
--v
-```
-
-### Custom Runner Images
-
-```bash
-# Use custom image for platform
-act -P ubuntu-latest=my-custom-image:latest
-
-# Use medium size images (recommended)
-act -P ubuntu-latest=catthehacker/ubuntu:act-latest
-
-# Use micro images (faster, less compatible)
-act -P ubuntu-latest=node:16-buster-slim
-```
-
-### Recommended Images
-
-act supports different image sizes:
-
-**Medium images (recommended):**
-- Better compatibility with GitHub Actions
-- More pre-installed tools
-- Slower startup but fewer failures
-
-```bash
--P ubuntu-latest=catthehacker/ubuntu:act-latest
--P ubuntu-22.04=catthehacker/ubuntu:act-22.04
-```
-
-**Micro images:**
-- Faster startup
-- Minimal pre-installed tools
-- May require additional setup
+`.actrc` defaults, custom runner images, and image size trade-offs (medium `catthehacker/ubuntu:act-latest` recommended over micro): see `references/setup-and-config.md`.
 
 ## Environment Variables
 
@@ -286,55 +159,7 @@ act --env NODE_ENV=test --env API_URL=http://localhost:3000
 
 ## Advanced Usage
 
-### Bind Workspace
-
-Mount local directory into container:
-```bash
-act --bind
-```
-
-### Reuse Containers
-
-Keep containers between runs for faster execution:
-```bash
-act --reuse
-```
-
-### Specific Platforms
-
-```bash
-# Run on specific platform
-act -P ubuntu-latest=ubuntu:latest
-
-# Multiple platforms
-act -P ubuntu-latest=ubuntu:latest \
-    -P windows-latest=windows:latest
-```
-
-### Container Architecture
-
-```bash
-# Specify architecture (useful for M1/M2 Macs)
-act --container-architecture linux/amd64
-```
-
-### Network Configuration
-
-```bash
-# Use host network
-act --container-daemon-socket -
-
-# Custom network
-act --network my-network
-```
-
-### Artifact Server
-
-```bash
-# Enable artifact server on specific port
-act --artifact-server-path /tmp/artifacts \
-    --artifact-server-port 34567
-```
+`--bind`, `--reuse`, per-platform images, `--container-architecture` (needed on Apple silicon), networking (`--network` defaults to host; `--container-daemon-socket` is the Docker socket URI), and the artifact server: see `references/setup-and-config.md`.
 
 ## Debugging
 
@@ -353,13 +178,6 @@ act -vv
 ```bash
 # Watch for file changes and re-run
 act --watch
-```
-
-### Interactive Shell
-
-```bash
-# Drop into shell on failure
-act --shell bash
 ```
 
 ### Container Inspection
@@ -527,9 +345,10 @@ act --secret-file .secrets
 # Some actions may not work locally
 
 # Use alternative actions if needed
-# Or skip problematic steps locally:
+# Or skip problematic steps under act. There is no 'act' event — act passes
+# the real event name — so test the ACT env var (per nektos/act docs):
 - name: Problematic step
-  if: github.event_name != 'act'  # Skip in act
+  if: ${{ !env.ACT }}
   uses: some/action@v1
 ```
 
@@ -548,13 +367,7 @@ act -P ubuntu-latest=catthehacker/ubuntu:act-latest
 
 ### .actrc Configuration
 
-Create `.actrc` in repository:
-```
--P ubuntu-latest=catthehacker/ubuntu:act-latest
---secret-file .secrets
---container-architecture linux/amd64
---artifact-server-path /tmp/artifacts
-```
+Commit an `.actrc` so every run gets the same platform image, secrets file, and architecture flags — full example in `references/setup-and-config.md`.
 
 ### .gitignore Entries
 
@@ -569,16 +382,18 @@ Create `.actrc` in repository:
 
 ### Conditional Logic for Local Testing
 
+act sets the `ACT` environment variable inside its containers (per nektos/act docs) and passes the real event name through, so there is no `act` event to test for:
+
 ```yaml
 steps:
   # Skip in local testing
   - name: Deploy
-    if: github.event_name != 'act'
+    if: ${{ !env.ACT }}
     run: ./deploy.sh
 
   # Run only in local testing
   - name: Local setup
-    if: github.event_name == 'act'
+    if: ${{ env.ACT }}
     run: ./local-setup.sh
 ```
 
@@ -608,25 +423,7 @@ act -j test && git commit -m "message"
 act -j test --quiet
 ```
 
-### Quick Validation
-
-```bash
-# Validate workflow syntax
-act -n
-
-# Test specific changes
-act -j affected-job
-```
-
-### CI Parity
-
-```bash
-# Use same images as CI
-act -P ubuntu-latest=ubuntu:22.04
-
-# Use same secrets structure
-act --secret-file .secrets
-```
+For quick validation use the dry run (`act -n`, see Basic Usage). For CI parity, pin the same runner images and secrets structure locally via `.actrc` — see `references/setup-and-config.md`.
 
 ## Scripts and Automation
 
@@ -651,3 +448,7 @@ nu scripts/install-act.nu
 - Execute `act -v` to observe actual error messages before documenting troubleshooting steps
 - Use Read tool to verify workflow files exist before testing them with act
 - Run actual event payloads through act before claiming they work correctly
+
+## References
+
+- `references/setup-and-config.md` — installation methods, prerequisites, `.actrc` configuration, runner images, event payloads, and advanced flags (`--bind`, `--reuse`, networking, artifact server)

--- a/plugins/tools/github/skills/act/references/setup-and-config.md
+++ b/plugins/tools/github/skills/act/references/setup-and-config.md
@@ -1,0 +1,211 @@
+# act Setup and Configuration Reference
+
+Installation methods, prerequisites, `.actrc` configuration, runner images, event payloads, and
+advanced flags for act.
+
+## Contents
+
+- [Installation](#installation)
+- [Prerequisites](#prerequisites)
+- [Configuration](#configuration)
+- [Event Payloads](#event-payloads)
+- [Advanced Usage](#advanced-usage)
+
+## Installation
+
+### Using mise (Recommended for this project)
+
+The act tool is configured in the github plugin's mise.toml:
+
+```bash
+# Install act via mise
+mise install act
+
+# Verify installation
+act --version
+```
+
+### Alternative Installation Methods
+
+**macOS (Homebrew):**
+```bash
+brew install act
+```
+
+**Linux (via script):**
+```bash
+curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
+```
+
+**From source:**
+```bash
+git clone https://github.com/nektos/act.git
+cd act
+make install
+```
+
+**Windows (Chocolatey):**
+```powershell
+choco install act-cli
+```
+
+## Prerequisites
+
+- **Docker**: act requires Docker to run workflows
+- **Workflow files**: Valid `.github/workflows/*.yml` files in repository
+
+Verify Docker is running:
+```bash
+docker ps
+```
+
+## Configuration
+
+### .actrc File
+
+Create `.actrc` in repository root or home directory:
+
+```
+# Use specific platform
+-P ubuntu-latest=catthehacker/ubuntu:act-latest
+
+# Default secrets file
+--secret-file .secrets
+
+# Default environment
+--env-file .env
+
+# Container architecture
+--container-architecture linux/amd64
+
+# Verbose output
+-v
+```
+
+### Custom Runner Images
+
+```bash
+# Use custom image for platform
+act -P ubuntu-latest=my-custom-image:latest
+
+# Use medium size images (recommended)
+act -P ubuntu-latest=catthehacker/ubuntu:act-latest
+
+# Use micro images (faster, less compatible)
+act -P ubuntu-latest=node:16-buster-slim
+```
+
+### Recommended Images
+
+act supports different image sizes:
+
+**Medium images (recommended):**
+- Better compatibility with GitHub Actions
+- More pre-installed tools
+- Slower startup but fewer failures
+
+```bash
+-P ubuntu-latest=catthehacker/ubuntu:act-latest
+-P ubuntu-22.04=catthehacker/ubuntu:act-22.04
+```
+
+**Micro images:**
+- Faster startup
+- Minimal pre-installed tools
+- May require additional setup
+
+## Event Payloads
+
+### Custom Event Data
+
+Create event JSON file:
+
+```json
+{
+  "pull_request": {
+    "number": 123,
+    "head": {
+      "ref": "feature-branch"
+    },
+    "base": {
+      "ref": "main"
+    }
+  }
+}
+```
+
+Use with act:
+```bash
+act pull_request -e event.json
+```
+
+### workflow_dispatch Inputs
+
+```json
+{
+  "inputs": {
+    "environment": "staging",
+    "debug": true
+  }
+}
+```
+
+```bash
+act workflow_dispatch -e inputs.json
+```
+
+## Advanced Usage
+
+### Bind Workspace
+
+Mount local directory into container:
+```bash
+act --bind
+```
+
+### Reuse Containers
+
+Keep containers between runs for faster execution:
+```bash
+act --reuse
+```
+
+### Specific Platforms
+
+```bash
+# Run on specific platform
+act -P ubuntu-latest=ubuntu:latest
+
+# Multiple platforms
+act -P ubuntu-latest=ubuntu:latest \
+    -P windows-latest=windows:latest
+```
+
+### Container Architecture
+
+```bash
+# Specify architecture (useful for M1/M2 Macs)
+act --container-architecture linux/amd64
+```
+
+### Network Configuration
+
+Per `act --help` on 0.2.89: `--network` sets the Docker network for job containers and defaults to
+`host`; `--container-daemon-socket` is the Docker Engine socket URI, where `-` disables
+bind-mounting the socket into job containers.
+
+```bash
+# Custom docker network (default is host)
+act --network my-network
+
+# Disable bind-mounting the Docker socket into job containers
+act --container-daemon-socket -
+```
+
+### Artifact Server
+
+```bash
+# Enable artifact server on specific port
+act --artifact-server-path /tmp/artifacts \
+    --artifact-server-port 34567
+```

--- a/plugins/tools/github/skills/act/references/setup-and-config.md
+++ b/plugins/tools/github/skills/act/references/setup-and-config.md
@@ -78,6 +78,9 @@ Create `.actrc` in repository root or home directory:
 # Container architecture
 --container-architecture linux/amd64
 
+# Where the local artifact server writes (see Artifact Server below)
+--artifact-server-path /tmp/artifacts
+
 # Verbose output
 -v
 ```

--- a/plugins/tools/github/skills/workflows/SKILL.md
+++ b/plugins/tools/github/skills/workflows/SKILL.md
@@ -5,7 +5,7 @@ description: Write and optimize GitHub Actions workflows. Use when creating CI/C
 
 # GitHub Workflows
 
-Activate when creating, modifying, debugging, or optimizing GitHub Actions workflow files. This skill covers workflow syntax, structure, best practices, and common CI/CD patterns.
+Activate when creating, modifying, debugging, or optimizing GitHub Actions workflow files. This skill covers workflow structure, best practices, and common CI/CD patterns; full YAML syntax detail lives in `references/`.
 
 ## When to Use This Skill
 
@@ -21,636 +21,61 @@ Activate when:
 
 ## Workflow File Structure
 
-### Basic Anatomy
-
-```yaml
-name: CI                              # Workflow name (optional)
-
-on:                                   # Trigger events
-  push:
-    branches: [main, develop]
-  pull_request:
-
-env:                                  # Global environment variables
-  NODE_VERSION: '20'
-
-jobs:                                 # Job definitions
-  build:
-    name: Build and Test            # Job name (optional)
-    runs-on: ubuntu-latest          # Runner environment
-
-    steps:
-      - name: Checkout code         # Step name (optional)
-        uses: actions/checkout@v4   # Use an action
-
-      - name: Run tests
-        run: npm test               # Run command
-```
-
-### File Location
-
-Workflows must be in `.github/workflows/` directory:
-```
-.github/
-└── workflows/
-    ├── ci.yml
-    ├── deploy.yml
-    └── release.yml
-```
+File anatomy (`name:`, `on:`, `env:`, `jobs:`) and the `.github/workflows/` location requirement: see `references/workflow-syntax.md`.
 
 ## Trigger Events (on:)
 
-### Push Events
-
-```yaml
-on:
-  push:
-    branches:
-      - main
-      - 'release/**'        # Glob patterns
-    tags:
-      - 'v*'                # Version tags
-    paths:
-      - 'src/**'            # Only when these paths change
-      - '!docs/**'          # Ignore docs changes
-```
-
-### Pull Request Events
-
-```yaml
-on:
-  pull_request:
-    types:
-      - opened
-      - synchronize       # New commits pushed
-      - reopened
-    branches:
-      - main
-    paths-ignore:
-      - '**.md'
-```
-
-### Schedule (Cron)
-
-```yaml
-on:
-  schedule:
-    # Every day at 2am UTC
-    - cron: '0 2 * * *'
-    # Every Monday at 9am UTC
-    - cron: '0 9 * * 1'
-```
-
-### Manual Trigger (workflow_dispatch)
-
-```yaml
-on:
-  workflow_dispatch:
-    inputs:
-      environment:
-        description: 'Deployment environment'
-        required: true
-        type: choice
-        options:
-          - development
-          - staging
-          - production
-      debug:
-        description: 'Enable debug logging'
-        required: false
-        type: boolean
-        default: false
-```
-
-### Multiple Events
-
-```yaml
-on:
-  push:
-    branches: [main]
-  pull_request:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * 0'  # Weekly
-```
+Push/PR branch, tag, and path filters, cron schedules, `workflow_dispatch` inputs, and multi-event triggers: see `references/workflow-syntax.md`.
 
 ## Jobs
 
-### Basic Job Configuration
-
-```yaml
-jobs:
-  build:
-    name: Build Application
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - uses: actions/checkout@v4
-      - run: npm ci
-      - run: npm run build
-```
-
-### Runner Selection
-
-```yaml
-jobs:
-  test:
-    runs-on: ubuntu-latest        # Ubuntu (fastest, most common)
-
-  test-macos:
-    runs-on: macos-latest         # macOS
-
-  test-windows:
-    runs-on: windows-latest       # Windows
-
-  test-specific:
-    runs-on: ubuntu-22.04         # Specific version
-```
-
-### Matrix Strategy
-
-```yaml
-jobs:
-  test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [18, 20, 21]
-        exclude:
-          - os: macos-latest
-            node: 18
-      fail-fast: false            # Continue on failure
-      max-parallel: 4             # Concurrent jobs limit
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
-      - run: npm test
-```
-
-### Job Dependencies
-
-```yaml
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - run: npm run build
-
-  test:
-    needs: build                  # Wait for build
-    runs-on: ubuntu-latest
-    steps:
-      - run: npm test
-
-  deploy:
-    needs: [build, test]          # Wait for multiple jobs
-    runs-on: ubuntu-latest
-    steps:
-      - run: npm run deploy
-```
-
-### Conditional Execution
-
-```yaml
-jobs:
-  deploy:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - run: npm run deploy
-
-  notify:
-    if: failure()                 # Run only if previous jobs failed
-    needs: [build, test]
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Build failed"
-```
+Runner selection, matrix strategy, `needs:` dependencies, and conditional job execution: see `references/jobs-and-steps.md`.
 
 ## Steps
 
-### Using Actions
-
-```yaml
-steps:
-  - name: Checkout repository
-    uses: actions/checkout@v4
-    with:
-      fetch-depth: 0              # Full history
-      submodules: recursive       # Include submodules
-
-  - name: Setup Node.js
-    uses: actions/setup-node@v4
-    with:
-      node-version: '20'
-      cache: 'npm'
-```
-
-### Running Commands
-
-```yaml
-steps:
-  - name: Single command
-    run: npm install
-
-  - name: Multi-line script
-    run: |
-      echo "Installing dependencies"
-      npm ci
-      npm run build
-
-  - name: Shell selection
-    shell: bash
-    run: echo "Using bash"
-```
-
-### Conditional Steps
-
-```yaml
-steps:
-  - name: Run on main branch only
-    if: github.ref == 'refs/heads/main'
-    run: npm run deploy
-
-  - name: Run on PR only
-    if: github.event_name == 'pull_request'
-    run: npm run test:pr
-```
-
-### Continue on Error
-
-```yaml
-steps:
-  - name: Lint (optional)
-    continue-on-error: true
-    run: npm run lint
-
-  - name: Test (required)
-    run: npm test
-```
+Using actions, `run:` commands, conditional steps, and `continue-on-error`: see `references/jobs-and-steps.md`.
 
 ## Environment Variables and Secrets
 
-### Global Variables
+Global/job/step-level `env`, `secrets.*` usage, and inter-step outputs: see `references/jobs-and-steps.md`.
 
-```yaml
-env:
-  NODE_ENV: production
-  API_URL: https://api.example.com
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo $NODE_ENV
-```
-
-### Job-Level Variables
-
-```yaml
-jobs:
-  build:
-    env:
-      BUILD_TYPE: release
-    steps:
-      - run: echo $BUILD_TYPE
-```
-
-### Step-Level Variables
-
-```yaml
-steps:
-  - name: Configure
-    env:
-      CONFIG_PATH: ./config.json
-    run: cat $CONFIG_PATH
-```
-
-### Using Secrets
-
-```yaml
-steps:
-  - name: Deploy
-    env:
-      API_KEY: ${{ secrets.API_KEY }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-    run: ./deploy.sh
-```
-
-### Setting Variables Between Steps
-
-```yaml
-steps:
-  - name: Set version
-    id: version
-    run: echo "VERSION=$(cat version.txt)" >> $GITHUB_OUTPUT
-
-  - name: Use version
-    run: echo "Version is ${{ steps.version.outputs.VERSION }}"
-```
+Gotcha: pass values between steps with `echo "key=value" >> $GITHUB_OUTPUT` — the deprecated `set-output` command no longer works.
 
 ## Contexts
 
-### github Context
-
-```yaml
-steps:
-  - name: Context information
-    run: |
-      echo "Repository: ${{ github.repository }}"
-      echo "Branch: ${{ github.ref_name }}"
-      echo "SHA: ${{ github.sha }}"
-      echo "Actor: ${{ github.actor }}"
-      echo "Event: ${{ github.event_name }}"
-      echo "Run ID: ${{ github.run_id }}"
-```
-
-### env Context
-
-```yaml
-env:
-  MY_VAR: value
-
-steps:
-  - run: echo "${{ env.MY_VAR }}"
-```
-
-### job Context
-
-```yaml
-steps:
-  - name: Job status
-    if: job.status == 'success'
-    run: echo "Job succeeded"
-```
-
-### steps Context
-
-```yaml
-steps:
-  - id: first-step
-    run: echo "output=hello" >> $GITHUB_OUTPUT
-
-  - run: echo "${{ steps.first-step.outputs.output }}"
-```
-
-### runner Context
-
-```yaml
-steps:
-  - run: |
-      echo "OS: ${{ runner.os }}"
-      echo "Arch: ${{ runner.arch }}"
-      echo "Temp: ${{ runner.temp }}"
-```
-
-### matrix Context
-
-```yaml
-strategy:
-  matrix:
-    version: [18, 20]
-
-steps:
-  - run: echo "Node ${{ matrix.version }}"
-```
+`github`, `env`, `job`, `steps`, `runner`, and `matrix` context fields: see `references/contexts-and-expressions.md`.
 
 ## Expressions
 
-### Operators
+Operators, status functions (`success()`, `failure()`, `always()`), and string/JSON/hash functions: see `references/contexts-and-expressions.md`.
 
-```yaml
-steps:
-  # Comparison
-  - if: github.ref == 'refs/heads/main'
-
-  # Logical
-  - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-  - if: github.event_name == 'pull_request' || github.event_name == 'push'
-
-  # Negation
-  - if: "!cancelled()"
-
-  # Contains
-  - if: contains(github.event.head_commit.message, '[skip ci]')
-
-  # StartsWith/EndsWith
-  - if: startsWith(github.ref, 'refs/tags/v')
-  - if: endsWith(github.ref, '-beta')
-```
-
-### Functions
-
-```yaml
-steps:
-  # Status functions
-  - if: success()        # Previous steps succeeded
-  - if: failure()        # Any previous step failed
-  - if: always()         # Always run
-  - if: cancelled()      # Workflow cancelled
-
-  # String functions
-  - run: echo "${{ format('Hello {0}', github.actor) }}"
-  - if: contains(github.event.pull_request.labels.*.name, 'deploy')
-
-  # JSON functions
-  - run: echo '${{ toJSON(github.event) }}'
-  - run: echo '${{ fromJSON(env.CONFIG).database.host }}'
-
-  # Hash function
-  - run: echo "${{ hashFiles('**/package-lock.json') }}"
-```
+Gotcha: quote expression negations — `if: "!cancelled()"` — because a bare leading `!` is a YAML tag and breaks parsing.
 
 ## Artifacts
 
-### Upload Artifacts
-
-```yaml
-steps:
-  - name: Build
-    run: npm run build
-
-  - name: Upload artifacts
-    uses: actions/upload-artifact@v4
-    with:
-      name: build-files
-      path: |
-        dist/
-        build/
-      retention-days: 7
-      if-no-files-found: error
-```
-
-### Download Artifacts
-
-```yaml
-jobs:
-  build:
-    steps:
-      - run: npm run build
-      - uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
-  test:
-    needs: build
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
-      - run: npm test
-```
+`upload-artifact` / `download-artifact` usage, retention, and cross-job handoff: see `references/workflow-syntax.md`.
 
 ## Caching
 
-### npm Cache
-
-```yaml
-steps:
-  - uses: actions/checkout@v4
-  - uses: actions/setup-node@v4
-    with:
-      node-version: '20'
-      cache: 'npm'
-  - run: npm ci
-```
-
-### Manual Cache
-
-```yaml
-steps:
-  - uses: actions/cache@v4
-    with:
-      path: |
-        ~/.npm
-        node_modules
-      key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-      restore-keys: |
-        ${{ runner.os }}-node-
-```
+`setup-node` built-in caching and manual `actions/cache` key construction: see `references/workflow-syntax.md`.
 
 ## Permissions
 
-### Repository Token Permissions
+Workflow- and job-level `GITHUB_TOKEN` permission scopes: see `references/workflow-syntax.md`.
 
-```yaml
-permissions:
-  contents: read              # Repository content
-  pull-requests: write        # PR comments
-  issues: write              # Issue creation/comments
-  checks: write              # Check runs
-  statuses: write            # Commit statuses
-  deployments: write         # Deployments
-  packages: write            # Package registry
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-```
-
-### Job-Level Permissions
-
-```yaml
-jobs:
-  build:
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-```
+Grant least privilege: declare an explicit `permissions:` block (e.g. `contents: read`) rather than inheriting the default token scope.
 
 ## Concurrency
 
-### Prevent Concurrent Runs
-
-```yaml
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true    # Cancel running workflows
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - run: ./deploy.sh
-```
-
-### Job-Level Concurrency
-
-```yaml
-jobs:
-  deploy:
-    concurrency:
-      group: deploy-${{ github.ref }}
-      cancel-in-progress: false
-    steps:
-      - run: ./deploy.sh
-```
+Workflow- and job-level concurrency groups and `cancel-in-progress`: see `references/workflow-syntax.md`.
 
 ## Reusable Workflows
 
-### Define Reusable Workflow
-
-```yaml
-# .github/workflows/reusable-test.yml
-name: Reusable Test Workflow
-
-on:
-  workflow_call:
-    inputs:
-      node-version:
-        required: true
-        type: string
-      coverage:
-        required: false
-        type: boolean
-        default: false
-    outputs:
-      test-result:
-        description: "Test execution result"
-        value: ${{ jobs.test.outputs.result }}
-    secrets:
-      token:
-        required: true
-
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    outputs:
-      result: ${{ steps.test.outputs.result }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ inputs.node-version }}
-      - run: npm test
-        id: test
-```
-
-### Call Reusable Workflow
-
-```yaml
-jobs:
-  test:
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      node-version: '20'
-      coverage: true
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
-```
+`workflow_call` inputs/outputs/secrets and calling syntax: see `references/workflow-syntax.md`.
 
 ## Common CI/CD Patterns
+
+Complete Docker build-and-push and deploy-on-release workflow artifacts: see `references/workflow-syntax.md`. The two patterns below stay here because agents adapt them in-conversation.
 
 ### Node.js CI
 
@@ -679,75 +104,6 @@ jobs:
       - run: npm run lint
       - run: npm test
       - run: npm run build
-```
-
-### Docker Build and Push
-
-```yaml
-name: Docker
-
-on:
-  push:
-    branches: [main]
-    tags: ['v*']
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-```
-
-### Deploy on Release
-
-```yaml
-name: Deploy
-
-on:
-  release:
-    types: [published]
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    environment:
-      name: production
-      url: https://example.com
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Deploy to production
-        env:
-          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
-        run: ./deploy.sh
 ```
 
 ### Monorepo with Path Filtering
@@ -832,46 +188,7 @@ steps:
 
 ## Performance Optimization
 
-### Use Caching
-
-```yaml
-- uses: actions/cache@v4
-  with:
-    path: ~/.npm
-    key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-```
-
-### Optimize Checkout
-
-```yaml
-- uses: actions/checkout@v4
-  with:
-    fetch-depth: 1              # Shallow clone
-    sparse-checkout: |          # Partial checkout
-      src/
-      tests/
-```
-
-### Concurrent Jobs
-
-```yaml
-jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - run: npm run lint
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - run: npm test
-
-  build:
-    needs: [lint, test]         # Parallel lint and test
-    runs-on: ubuntu-latest
-    steps:
-      - run: npm run build
-```
+Dependency caching, shallow/sparse checkout, and parallel job graphs: see `references/workflow-syntax.md`.
 
 ## Anti-Fabrication Requirements
 
@@ -885,3 +202,9 @@ jobs:
 - Report actual permission errors from workflow runs, not fabricated authorization issues
 - Execute actual cache operations before claiming cache hit/miss percentages
 - Use Read tool on action.yml files to verify action inputs/outputs before documenting usage
+
+## References
+
+- `references/workflow-syntax.md` — file structure, triggers, artifacts, caching, permissions, concurrency, reusable workflows, performance optimization, complete Docker/deploy examples
+- `references/jobs-and-steps.md` — job configuration, runners, matrix strategy, dependencies, step mechanics, environment variables and secrets
+- `references/contexts-and-expressions.md` — context objects, operators, and built-in expression functions

--- a/plugins/tools/github/skills/workflows/references/contexts-and-expressions.md
+++ b/plugins/tools/github/skills/workflows/references/contexts-and-expressions.md
@@ -1,0 +1,122 @@
+# Contexts and Expressions Reference
+
+Context objects available inside `${{ }}` expressions, plus operators and built-in functions.
+Workflow file shape and triggers live in workflow-syntax.md; job and step mechanics in
+jobs-and-steps.md.
+
+## Contents
+
+- [Contexts](#contexts)
+- [Expressions](#expressions)
+
+## Contexts
+
+### github Context
+
+```yaml
+steps:
+  - name: Context information
+    run: |
+      echo "Repository: ${{ github.repository }}"
+      echo "Branch: ${{ github.ref_name }}"
+      echo "SHA: ${{ github.sha }}"
+      echo "Actor: ${{ github.actor }}"
+      echo "Event: ${{ github.event_name }}"
+      echo "Run ID: ${{ github.run_id }}"
+```
+
+### env Context
+
+```yaml
+env:
+  MY_VAR: value
+
+steps:
+  - run: echo "${{ env.MY_VAR }}"
+```
+
+### job Context
+
+```yaml
+steps:
+  - name: Job status
+    if: job.status == 'success'
+    run: echo "Job succeeded"
+```
+
+### steps Context
+
+```yaml
+steps:
+  - id: first-step
+    run: echo "output=hello" >> $GITHUB_OUTPUT
+
+  - run: echo "${{ steps.first-step.outputs.output }}"
+```
+
+### runner Context
+
+```yaml
+steps:
+  - run: |
+      echo "OS: ${{ runner.os }}"
+      echo "Arch: ${{ runner.arch }}"
+      echo "Temp: ${{ runner.temp }}"
+```
+
+### matrix Context
+
+```yaml
+strategy:
+  matrix:
+    version: [18, 20]
+
+steps:
+  - run: echo "Node ${{ matrix.version }}"
+```
+
+## Expressions
+
+### Operators
+
+```yaml
+steps:
+  # Comparison
+  - if: github.ref == 'refs/heads/main'
+
+  # Logical
+  - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  - if: github.event_name == 'pull_request' || github.event_name == 'push'
+
+  # Negation — quote it: a bare leading ! is a YAML tag
+  - if: "!cancelled()"
+
+  # Contains
+  - if: contains(github.event.head_commit.message, '[skip ci]')
+
+  # StartsWith/EndsWith
+  - if: startsWith(github.ref, 'refs/tags/v')
+  - if: endsWith(github.ref, '-beta')
+```
+
+### Functions
+
+```yaml
+steps:
+  # Status functions
+  - if: success()        # Previous steps succeeded
+  - if: failure()        # Any previous step failed
+  - if: always()         # Always run
+  - if: cancelled()      # Workflow cancelled
+
+  # String functions
+  - run: echo "${{ format('Hello {0}', github.actor) }}"
+  - if: contains(github.event.pull_request.labels.*.name, 'deploy')
+
+  # JSON functions
+  - run: echo '${{ toJSON(github.event) }}'
+  - run: echo '${{ fromJSON(env.CONFIG).database.host }}'
+
+  # Hash function
+  - run: echo "${{ hashFiles('**/package-lock.json') }}"
+```

--- a/plugins/tools/github/skills/workflows/references/jobs-and-steps.md
+++ b/plugins/tools/github/skills/workflows/references/jobs-and-steps.md
@@ -1,0 +1,231 @@
+# Jobs and Steps Reference
+
+Job configuration, runner selection, matrix strategies, step mechanics, and environment variable
+scoping. Workflow file shape and triggers live in workflow-syntax.md; contexts and expression
+syntax in contexts-and-expressions.md.
+
+## Contents
+
+- [Jobs](#jobs)
+- [Steps](#steps)
+- [Environment Variables and Secrets](#environment-variables-and-secrets)
+
+## Jobs
+
+### Basic Job Configuration
+
+```yaml
+jobs:
+  build:
+    name: Build Application
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci
+      - run: npm run build
+```
+
+### Runner Selection
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest        # Ubuntu (fastest, most common)
+
+  test-macos:
+    runs-on: macos-latest         # macOS
+
+  test-windows:
+    runs-on: windows-latest       # Windows
+
+  test-specific:
+    runs-on: ubuntu-22.04         # Specific version
+```
+
+### Matrix Strategy
+
+```yaml
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: [18, 20, 21]
+        exclude:
+          - os: macos-latest
+            node: 18
+      fail-fast: false            # Continue on failure
+      max-parallel: 4             # Concurrent jobs limit
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm test
+```
+
+### Job Dependencies
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm run build
+
+  test:
+    needs: build                  # Wait for build
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm test
+
+  deploy:
+    needs: [build, test]          # Wait for multiple jobs
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm run deploy
+```
+
+### Conditional Execution
+
+```yaml
+jobs:
+  deploy:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm run deploy
+
+  notify:
+    if: failure()                 # Run only if previous jobs failed
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Build failed"
+```
+
+## Steps
+
+### Using Actions
+
+```yaml
+steps:
+  - name: Checkout repository
+    uses: actions/checkout@v4
+    with:
+      fetch-depth: 0              # Full history
+      submodules: recursive       # Include submodules
+
+  - name: Setup Node.js
+    uses: actions/setup-node@v4
+    with:
+      node-version: '20'
+      cache: 'npm'
+```
+
+### Running Commands
+
+```yaml
+steps:
+  - name: Single command
+    run: npm install
+
+  - name: Multi-line script
+    run: |
+      echo "Installing dependencies"
+      npm ci
+      npm run build
+
+  - name: Shell selection
+    shell: bash
+    run: echo "Using bash"
+```
+
+### Conditional Steps
+
+```yaml
+steps:
+  - name: Run on main branch only
+    if: github.ref == 'refs/heads/main'
+    run: npm run deploy
+
+  - name: Run on PR only
+    if: github.event_name == 'pull_request'
+    run: npm run test:pr
+```
+
+### Continue on Error
+
+```yaml
+steps:
+  - name: Lint (optional)
+    continue-on-error: true
+    run: npm run lint
+
+  - name: Test (required)
+    run: npm test
+```
+
+## Environment Variables and Secrets
+
+### Global Variables
+
+```yaml
+env:
+  NODE_ENV: production
+  API_URL: https://api.example.com
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo $NODE_ENV
+```
+
+### Job-Level Variables
+
+```yaml
+jobs:
+  build:
+    env:
+      BUILD_TYPE: release
+    steps:
+      - run: echo $BUILD_TYPE
+```
+
+### Step-Level Variables
+
+```yaml
+steps:
+  - name: Configure
+    env:
+      CONFIG_PATH: ./config.json
+    run: cat $CONFIG_PATH
+```
+
+### Using Secrets
+
+```yaml
+steps:
+  - name: Deploy
+    env:
+      API_KEY: ${{ secrets.API_KEY }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+    run: ./deploy.sh
+```
+
+### Setting Variables Between Steps
+
+```yaml
+steps:
+  - name: Set version
+    id: version
+    run: echo "VERSION=$(cat version.txt)" >> $GITHUB_OUTPUT
+
+  - name: Use version
+    run: echo "Version is ${{ steps.version.outputs.VERSION }}"
+```

--- a/plugins/tools/github/skills/workflows/references/workflow-syntax.md
+++ b/plugins/tools/github/skills/workflows/references/workflow-syntax.md
@@ -1,0 +1,429 @@
+# Workflow Syntax Reference
+
+Workflow file structure, trigger events, artifacts, caching, permissions, concurrency, reusable
+workflows, performance optimization, and complete workflow examples. Job and step mechanics live in
+jobs-and-steps.md; contexts and expression syntax in contexts-and-expressions.md.
+
+## Contents
+
+- [Workflow File Structure](#workflow-file-structure)
+- [Trigger Events (on:)](#trigger-events-on)
+- [Artifacts](#artifacts)
+- [Caching](#caching)
+- [Permissions](#permissions)
+- [Concurrency](#concurrency)
+- [Reusable Workflows](#reusable-workflows)
+- [Performance Optimization](#performance-optimization)
+- [Complete Workflow Examples](#complete-workflow-examples)
+
+## Workflow File Structure
+
+### Basic Anatomy
+
+```yaml
+name: CI                              # Workflow name (optional)
+
+on:                                   # Trigger events
+  push:
+    branches: [main, develop]
+  pull_request:
+
+env:                                  # Global environment variables
+  NODE_VERSION: '20'
+
+jobs:                                 # Job definitions
+  build:
+    name: Build and Test            # Job name (optional)
+    runs-on: ubuntu-latest          # Runner environment
+
+    steps:
+      - name: Checkout code         # Step name (optional)
+        uses: actions/checkout@v4   # Use an action
+
+      - name: Run tests
+        run: npm test               # Run command
+```
+
+### File Location
+
+Workflows must be in `.github/workflows/` directory:
+```
+.github/
+└── workflows/
+    ├── ci.yml
+    ├── deploy.yml
+    └── release.yml
+```
+
+## Trigger Events (on:)
+
+### Push Events
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'        # Glob patterns
+    tags:
+      - 'v*'                # Version tags
+    paths:
+      - 'src/**'            # Only when these paths change
+      - '!docs/**'          # Ignore docs changes
+```
+
+### Pull Request Events
+
+```yaml
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize       # New commits pushed
+      - reopened
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+```
+
+### Schedule (Cron)
+
+```yaml
+on:
+  schedule:
+    # Every day at 2am UTC
+    - cron: '0 2 * * *'
+    # Every Monday at 9am UTC
+    - cron: '0 9 * * 1'
+```
+
+### Manual Trigger (workflow_dispatch)
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deployment environment'
+        required: true
+        type: choice
+        options:
+          - development
+          - staging
+          - production
+      debug:
+        description: 'Enable debug logging'
+        required: false
+        type: boolean
+        default: false
+```
+
+### Multiple Events
+
+```yaml
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly
+```
+
+## Artifacts
+
+### Upload Artifacts
+
+```yaml
+steps:
+  - name: Build
+    run: npm run build
+
+  - name: Upload artifacts
+    uses: actions/upload-artifact@v4
+    with:
+      name: build-files
+      path: |
+        dist/
+        build/
+      retention-days: 7
+      if-no-files-found: error
+```
+
+### Download Artifacts
+
+```yaml
+jobs:
+  build:
+    steps:
+      - run: npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  test:
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - run: npm test
+```
+
+## Caching
+
+### npm Cache
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: actions/setup-node@v4
+    with:
+      node-version: '20'
+      cache: 'npm'
+  - run: npm ci
+```
+
+### Manual Cache
+
+```yaml
+steps:
+  - uses: actions/cache@v4
+    with:
+      path: |
+        ~/.npm
+        node_modules
+      key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+      restore-keys: |
+        ${{ runner.os }}-node-
+```
+
+## Permissions
+
+### Repository Token Permissions
+
+```yaml
+permissions:
+  contents: read              # Repository content
+  pull-requests: write        # PR comments
+  issues: write              # Issue creation/comments
+  checks: write              # Check runs
+  statuses: write            # Commit statuses
+  deployments: write         # Deployments
+  packages: write            # Package registry
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+```
+
+### Job-Level Permissions
+
+```yaml
+jobs:
+  build:
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+```
+
+## Concurrency
+
+### Prevent Concurrent Runs
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true    # Cancel running workflows
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./deploy.sh
+```
+
+### Job-Level Concurrency
+
+```yaml
+jobs:
+  deploy:
+    concurrency:
+      group: deploy-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - run: ./deploy.sh
+```
+
+## Reusable Workflows
+
+### Define Reusable Workflow
+
+```yaml
+# .github/workflows/reusable-test.yml
+name: Reusable Test Workflow
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        required: true
+        type: string
+      coverage:
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      test-result:
+        description: "Test execution result"
+        value: ${{ jobs.test.outputs.result }}
+    secrets:
+      token:
+        required: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.test.outputs.result }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+      - run: npm test
+        id: test
+```
+
+### Call Reusable Workflow
+
+```yaml
+jobs:
+  test:
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      node-version: '20'
+      coverage: true
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Performance Optimization
+
+### Use Caching
+
+Cache dependencies to avoid re-downloading on every run — see [Caching](#caching) above for the
+`setup-node` built-in cache and manual `actions/cache` configuration.
+
+### Optimize Checkout
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 1              # Shallow clone
+    sparse-checkout: |          # Partial checkout
+      src/
+      tests/
+```
+
+### Concurrent Jobs
+
+```yaml
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm run lint
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm test
+
+  build:
+    needs: [lint, test]         # Parallel lint and test
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm run build
+```
+
+## Complete Workflow Examples
+
+Complete workflow artifacts to copy and adapt. The Node.js CI and monorepo path-filtering patterns
+stay in the skill body because agents adapt them in-conversation.
+
+### Docker Build and Push
+
+```yaml
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+```
+
+### Deploy on Release
+
+```yaml
+name: Deploy
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://example.com
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy to production
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        run: ./deploy.sh
+```

--- a/test/quality-baseline.json
+++ b/test/quality-baseline.json
@@ -366,25 +366,11 @@
       "detail_count": null
     },
     {
-      "key": "github/act:lines",
-      "class": "DEBT",
-      "issue": "claude-skills-143",
-      "first_seen": "migrated",
-      "detail_count": 653
-    },
-    {
       "key": "github/community-health:source",
       "class": "DEBT",
       "issue": "claude-skills-144",
       "first_seen": "migrated",
       "detail_count": null
-    },
-    {
-      "key": "github/workflows:lines",
-      "class": "DEBT",
-      "issue": "claude-skills-143",
-      "first_seen": "migrated",
-      "detail_count": 887
     },
     {
       "key": "qa/qa:ref_depth",


### PR DESCRIPTION
- Move workflows syntax reference (structure, triggers, jobs, steps, env/secrets, contexts, expressions, artifacts, caching, permissions, concurrency, reusable workflows, performance, Docker/deploy examples) into three new reference files; body 887 -> 210 lines
- Move act installation, prerequisites, configuration, event payloads, and advanced flags into references/setup-and-config.md; body 653 -> 454 lines
- Fix three false act claims verified against act 0.2.89: delete nonexistent `act --shell bash` subsection; replace the never-firing `github.event_name != 'act'` skip guard with `${{ !env.ACT }}` (per nektos/act docs); correct `--container-daemon-socket -` misdescribed as "use host network" (it is the Docker socket URI; `--network` already defaults to host)
- Hoist three gotchas as single lines in the workflows body: quoted `"!cancelled()"`, `$GITHUB_OUTPUT` inter-step outputs, least-privilege `permissions:`
- Remove github/workflows:lines and github/act:lines baseline waivers (81 -> 79)
- Bump github 0.3.5 and all-skills 0.4.67 in plugin.json and marketplace.json
- Action version pins (checkout@v4 etc.) deliberately untouched; tracked as claude-skills-161
