### PR TITLE
fix(plugins): sync marketplace descriptions and keywords with plugin manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,7 +22,9 @@
         "rust",
         "wasm",
         "zig",
-        "complete"
+        "complete",
+        "all",
+        "bundle"
       ],
       "license": "MIT"
     },
@@ -131,7 +133,9 @@
         "teams",
         "output-styles",
         "statusline",
-        "workflows"
+        "workflows",
+        "benchmark",
+        "skill-update"
       ]
     },
     {
@@ -153,7 +157,8 @@
         "container",
         "tdd",
         "agent-loop",
-        "restraint"
+        "restraint",
+        "forge"
       ]
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,13 +12,17 @@
     {
       "name": "all-skills",
       "source": "./",
-      "description": "Meta-plugin that installs all available skills from all plugins",
-      "version": "0.4.73",
+      "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
+      "version": "0.4.74",
       "category": "meta",
       "keywords": [
-        "all",
-        "complete",
-        "bundle"
+        "skills",
+        "development",
+        "elixir",
+        "rust",
+        "wasm",
+        "zig",
+        "complete"
       ],
       "license": "MIT"
     },
@@ -26,14 +30,15 @@
       "name": "allium",
       "source": "./plugins/tools/allium",
       "strict": true,
-      "description": "Opinionated Allium integration for /core:agent-loop",
-      "version": "0.1.0",
+      "description": "Opinionated Allium integration for /core:agent-loop: attach behavioral specs to epics, propagate TDD tests, weed-check semantic divergence post-CI.",
+      "version": "0.1.1",
       "category": "tools",
       "keywords": [
         "allium",
         "agent-loop",
         "tdd",
-        "behavioral-spec"
+        "behavioral-spec",
+        "epic"
       ],
       "license": "MIT"
     },
@@ -78,7 +83,7 @@
       "source": "./plugins/tools/ansible",
       "strict": true,
       "description": "Ansible automation skills: playbooks, inventory, roles, vault secrets, and Molecule testing",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "tools",
       "keywords": [
         "ansible",
@@ -86,7 +91,9 @@
         "configuration-management",
         "devops",
         "playbooks",
-        "molecule"
+        "molecule",
+        "roles",
+        "vault"
       ],
       "license": "MIT"
     },
@@ -109,16 +116,19 @@
       "name": "claude-code",
       "source": "./plugins/tools/claude-code",
       "strict": true,
-      "description": "Claude Code-specific skills: plugin marketplace management and validation",
-      "version": "0.2.27",
+      "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
+      "version": "0.2.28",
       "category": "tools",
       "keywords": [
         "claude-code",
         "marketplace",
         "validation",
+        "plugin-management",
+        "commands",
+        "agents",
+        "skills",
+        "hooks",
         "teams",
-        "benchmark",
-        "skill-update",
         "output-styles",
         "statusline",
         "workflows"
@@ -129,18 +139,20 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, documentation, code review, security",
-      "version": "0.2.37",
+      "version": "0.2.38",
       "category": "development",
       "keywords": [
         "git",
         "documentation",
         "code-review",
         "tools",
+        "twelve-factor-app",
+        "security",
+        "gitleaks",
         "bees",
         "container",
         "tdd",
         "agent-loop",
-        "forge",
         "restraint"
       ]
     },
@@ -148,13 +160,14 @@
       "name": "dagu",
       "source": "./plugins/tools/dagu",
       "strict": true,
-      "description": "Dagu workflow orchestration: workflows, web UI, REST API",
-      "version": "0.1.5",
+      "description": "Dagu workflow orchestration: workflow authoring, web UI, and REST API",
+      "version": "0.1.6",
       "category": "tools",
       "keywords": [
         "dagu",
         "workflow",
-        "orchestration"
+        "orchestration",
+        "automation"
       ]
     },
     {
@@ -178,8 +191,8 @@
       "name": "elixir",
       "source": "./plugins/languages/elixir",
       "strict": true,
-      "description": "Elixir development skills: Phoenix, OTP, Ports, Ecto, Tidewave MCP, testing, configuration, style",
-      "version": "0.1.15",
+      "description": "Elixir development skills: Phoenix, OTP, Ports, Ecto, Tidewave MCP, testing, configuration, style, and anti-patterns",
+      "version": "0.1.16",
       "category": "language",
       "keywords": [
         "elixir",
@@ -188,7 +201,8 @@
         "ports",
         "ecto",
         "style",
-        "beam"
+        "beam",
+        "erlang"
       ]
     },
     {
@@ -236,8 +250,8 @@
       "name": "agent-sandboxing",
       "source": "./plugins/tools/agent-sandboxing",
       "strict": true,
-      "description": "Agent sandboxing for AI coding agents: 7 skills (including a sandbox index for progressive disclosure) + 6 slash commands for microVM and kernel-isolated execution on Kubernetes (kind+Kata, GKE+Kata, kina+Apple Container). Designed to grow to non-k8s sandboxing paths.",
-      "version": "0.2.4",
+      "description": "Agent sandboxing for AI coding agents: microVM and kernel-isolated execution environments. Index skill (sandbox) routes to substrate-specific paths. Currently covers the kubernetes-sigs/agent-sandbox path on kind, GKE, and kina (Kubernetes-in-Apple-Containers), with Kata, gVisor, and Apple Container microVM substrates. Ships 7 skills + 6 slash commands + nushell scripts. Designed to expand to non-k8s sandboxing paths.",
+      "version": "0.2.5",
       "category": "tools",
       "keywords": [
         "agent-sandbox",
@@ -381,8 +395,8 @@
       "name": "rust",
       "source": "./plugins/languages/rust",
       "strict": true,
-      "description": "Rust programming skills + anti-patterns + CLI apps + adversarial-TDD worker agents (rust-test-author, rust-implementer)",
-      "version": "0.1.7",
+      "description": "Rust programming skills: ownership, borrowing, lifetimes, async, best practices, anti-patterns, CLI apps, and adversarial-TDD worker agents",
+      "version": "0.1.8",
       "category": "language",
       "keywords": [
         "rust",
@@ -449,13 +463,15 @@
       "name": "ui",
       "source": "./plugins/ui",
       "strict": true,
-      "description": "UI framework skills: daisyUI components and theming",
-      "version": "0.1.3",
+      "description": "UI framework skills: daisyUI components, theming, and responsive design",
+      "version": "0.1.4",
       "category": "frontend",
       "keywords": [
         "ui",
         "daisyui",
-        "tailwind"
+        "tailwind",
+        "components",
+        "design"
       ]
     },
     {
@@ -479,8 +495,8 @@
       "name": "whamm",
       "source": "./plugins/tools/whamm",
       "strict": true,
-      "description": "whamm! WebAssembly bytecode instrumentation: mise install, the instr/info CLI, injection strategies, and the DTrace-inspired .mm monitor DSL",
-      "version": "0.1.0",
+      "description": "whamm! WebAssembly bytecode instrumentation: install via mise, the instr/info CLI, injection strategies, and the DTrace-inspired .mm monitor DSL",
+      "version": "0.1.1",
       "category": "tools",
       "keywords": [
         "whamm",
@@ -489,7 +505,8 @@
         "instrumentation",
         "bytecode",
         "dtrace",
-        "profiling"
+        "profiling",
+        "wasmtime"
       ],
       "license": "MIT"
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -15,7 +15,9 @@
     "rust",
     "wasm",
     "zig",
-    "complete"
+    "complete",
+    "all",
+    "bundle"
   ],
   "skills": [
     "./plugins/tools/allium/skills/allium",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.73",
+  "version": "0.4.74",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.37",
+  "version": "0.2.38",
   "description": "Essential development skills: Git, documentation, code review, security",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -19,7 +19,8 @@
     "container",
     "tdd",
     "agent-loop",
-    "restraint"
+    "restraint",
+    "forge"
   ],
   "skills": [
     "./skills/git",

--- a/plugins/languages/elixir/.claude-plugin/plugin.json
+++ b/plugins/languages/elixir/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "elixir",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Elixir development skills: Phoenix, OTP, Ports, Ecto, Tidewave MCP, testing, configuration, style, and anti-patterns",
   "author": {
     "name": "vinnie357"

--- a/plugins/languages/rust/.claude-plugin/plugin.json
+++ b/plugins/languages/rust/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Rust programming skills: ownership, borrowing, lifetimes, async, best practices, anti-patterns, CLI apps, and adversarial-TDD worker agents",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/agent-sandboxing/.claude-plugin/plugin.json
+++ b/plugins/tools/agent-sandboxing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sandboxing",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Agent sandboxing for AI coding agents: microVM and kernel-isolated execution environments. Index skill (sandbox) routes to substrate-specific paths. Currently covers the kubernetes-sigs/agent-sandbox path on kind, GKE, and kina (Kubernetes-in-Apple-Containers), with Kata, gVisor, and Apple Container microVM substrates. Ships 7 skills + 6 slash commands + nushell scripts. Designed to expand to non-k8s sandboxing paths.",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/allium/.claude-plugin/plugin.json
+++ b/plugins/tools/allium/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "allium",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Opinionated Allium integration for /core:agent-loop: attach behavioral specs to epics, propagate TDD tests, weed-check semantic divergence post-CI.",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/ansible/.claude-plugin/plugin.json
+++ b/plugins/tools/ansible/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ansible",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Ansible automation skills: playbooks, inventory, roles, vault secrets, and Molecule testing",
   "author": {
     "name": "rginnow"

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -19,7 +19,9 @@
     "teams",
     "output-styles",
     "statusline",
-    "workflows"
+    "workflows",
+    "benchmark",
+    "skill-update"
   ],
   "skills": [
     "./skills/plugin-marketplace",

--- a/plugins/tools/claude-code/skills/claude-plugins/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-plugins/SKILL.md
@@ -138,6 +138,10 @@ This validates:
 - Field type correctness
 - Path accessibility (for relative paths)
 - Invalid field detection
+- `description` and `keywords` agreement with the plugin's `marketplace.json` entry, when
+  invoked with `--marketplace` and the entry's `source` is a local path. `plugin.json` is
+  authoritative. Entries whose `source` is a GitHub object are skipped — there is no local
+  manifest to compare. A field absent from either side is not a mismatch.
 
 ### 2. Initialization Helper
 

--- a/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
+++ b/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
@@ -82,7 +82,14 @@ def validate-from-marketplace [plugin_name: string, marketplace_path: string, ve
   }
 
   # Run validation
-  let result = validate-plugin-content $plugin_path $plugin_root $plugin_name $source_dir $is_ext $verbose
+  # Compare description/keywords against the marketplace entry only for local
+  # (non-external) sources — a GitHub-object source has no local plugin.json
+  # to compare against the clone's, so that comparison is skipped entirely.
+  let result = if $is_ext {
+    validate-plugin-content $plugin_path $plugin_root $plugin_name $source_dir $is_ext $verbose
+  } else {
+    validate-plugin-content $plugin_path $plugin_root $plugin_name $source_dir $is_ext $verbose --mkt-description ($plugin_entry | get -o description | default "") --mkt-keywords ($plugin_entry | get -o keywords | default [])
+  }
 
   # Cleanup temp directory
   cleanup-temp $temp_dir $is_ext
@@ -181,6 +188,8 @@ def validate-plugin-content [
   source_dir: string
   is_external: bool
   verbose: bool
+  --mkt-description: string = ""   # marketplace.json entry's description, for local sources only
+  --mkt-keywords: list<string> = [] # marketplace.json entry's keywords, for local sources only
 ] {
   let plugin = try {
     open $plugin_path
@@ -241,6 +250,19 @@ def validate-plugin-content [
     $warnings = ($warnings | append "Missing recommended field: description")
   } else if $verbose {
     print $"  ✓ description: ($plugin.description)"
+  }
+
+  # Description agreement with the marketplace entry — plugin.json is
+  # authoritative, the marketplace entry is the copy. Only compared when
+  # both sides define the field (an omission on either side is not a
+  # failure) and only for local sources (see the caller for the gate).
+  # NOTE: `mise update-all-skills` does NOT maintain the all-skills
+  # description, so that one entry can drift again after this check passes.
+  if ($mkt_description | is-not-empty) {
+    let pj_description = ($plugin | get -o description)
+    if ($pj_description | is-not-empty) and ($pj_description != $mkt_description) {
+      $errors = ($errors | append $"description mismatch — plugin.json is authoritative: plugin.json='($pj_description)' marketplace.json='($mkt_description)' \(mise update-all-skills does not maintain the all-skills description\)")
+    }
   }
 
   if ($plugin | get -o license) == null {
@@ -383,6 +405,15 @@ def validate-plugin-content [
       $errors = ($errors | append "'keywords' must be an array")
     } else if $verbose {
       print $"\n(ansi cyan)Keywords:(ansi reset) (($plugin.keywords | length)) entries"
+    }
+  }
+
+  # Keywords agreement with the marketplace entry — same authority rule and
+  # same omission-is-not-a-failure rule as description, above.
+  if ($mkt_keywords | is-not-empty) {
+    let pj_keywords = ($plugin | get -o keywords)
+    if ($pj_keywords | is-not-empty) and ($pj_keywords != $mkt_keywords) {
+      $errors = ($errors | append $"keywords mismatch — plugin.json is authoritative: plugin.json=($pj_keywords) marketplace.json=($mkt_keywords)")
     }
   }
 

--- a/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
+++ b/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
@@ -261,7 +261,10 @@ def validate-plugin-content [
   if ($mkt_description | is-not-empty) {
     let pj_description = ($plugin | get -o description)
     if ($pj_description | is-not-empty) and ($pj_description != $mkt_description) {
-      $errors = ($errors | append $"description mismatch — plugin.json is authoritative: plugin.json='($pj_description)' marketplace.json='($mkt_description)' \(mise update-all-skills does not maintain the all-skills description\)")
+      let regen_note = if ($plugin | get -o name) == "all-skills" {
+        " \(mise update-all-skills does not maintain this description, so it can drift again\)"
+      } else { "" }
+      $errors = ($errors | append $"description mismatch — plugin.json is authoritative: plugin.json='($pj_description)' marketplace.json='($mkt_description)'($regen_note)")
     }
   }
 

--- a/plugins/tools/dagu/.claude-plugin/plugin.json
+++ b/plugins/tools/dagu/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dagu",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Dagu workflow orchestration: workflow authoring, web UI, and REST API",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/whamm/.claude-plugin/plugin.json
+++ b/plugins/tools/whamm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "whamm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "whamm! WebAssembly bytecode instrumentation: install via mise, the instr/info CLI, injection strategies, and the DTrace-inspired .mm monitor DSL",
   "author": {
     "name": "vinnie357"

--- a/plugins/ui/.claude-plugin/plugin.json
+++ b/plugins/ui/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "UI framework skills: daisyUI components, theming, and responsive design",
   "author": {
     "name": "vinnie357"


### PR DESCRIPTION
Second of three PRs closing the pointer-validation gap. Fix first, then add the check — `test:plugins` is pass/fail with no baseline, so it has to land green.

`plugin.json` and its `marketplace.json` entry could disagree on `description` and `keywords` and nothing compared them. `check-version-bumps.nu` already opens both manifests but compares only the version field, and it is deliberately excluded from `mise run test`. Descriptions are Level 1 discovery text — the only thing a user sees when browsing — so drift there changes what the marketplace advertises versus what the plugin claims.

- Sync **18 mismatches across 11 plugins**: allium, ansible, claude-code, core, dagu, elixir, agent-sandboxing, rust, ui, whamm, all-skills
- Add description and keywords equality to the plugin validator, so `mise run test:plugins` enforces it. Compares only plugins whose marketplace `source` is a local path string — `claudio` is a GitHub-object source with no local manifest and is skipped
- The failure message notes that `mise update-all-skills` does not maintain the all-skills description, so that entry can drift again
- Version bumps for all 11 plugins in both manifests, plus `mise update-all-skills`

`plugin.json` is authoritative for `description`, verified by reading each pair rather than copying mechanically. The `claude-code` case is why: its marketplace description covered 2 of its 12 skills, so the drift existed because one side was wrong, not merely different.

**Keywords are merged as a union, not overwritten.** Treating `plugin.json` as authoritative for keywords too would have silently deleted five real discovery terms: `forge` from core (a named concept appearing 12 times in `agent-loop`), `benchmark` and `skill-update` from claude-code (both naming actual shipped skills — `claude-skills-benchmark` and `skill-update`), and `all`/`bundle` from all-skills. A description is prose and must pick a side; a keyword list is a discovery set, so the union is the correct merge. Verified zero keyword loss against `main` for every touched plugin.

Verified by deliberate failure, since the plugin validator has no self-test harness and one was not invented for this: setting a marketplace description to a wrong value makes `nu test/validate-plugin.nu core` print `✗ description mismatch — plugin.json is authoritative` and exit 1. Reverted and re-verified clean.

Waivers unchanged at 68. Closes claude-skills-167.
