### PR TITLE
fix(claude-code): stop CLAUDE_PLUGIN_ROOT from expanding in skill bodies

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.76",
+      "version": "0.4.77",
       "category": "meta",
       "keywords": [
         "skills",
@@ -119,7 +119,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "category": "tools",
       "keywords": [
         "claude-code",
@@ -256,7 +256,7 @@
       "source": "./plugins/tools/agent-sandboxing",
       "strict": true,
       "description": "Agent sandboxing for AI coding agents: microVM and kernel-isolated execution environments. Index skill (sandbox) routes to substrate-specific paths. Currently covers the kubernetes-sigs/agent-sandbox path on kind, GKE, and kina (Kubernetes-in-Apple-Containers), with Kata, gVisor, and Apple Container microVM substrates. Ships 7 skills + 6 slash commands + nushell scripts. Designed to expand to non-k8s sandboxing paths.",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "category": "tools",
       "keywords": [
         "agent-sandbox",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.76",
+  "version": "0.4.77",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/agent-sandboxing/.claude-plugin/plugin.json
+++ b/plugins/tools/agent-sandboxing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sandboxing",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Agent sandboxing for AI coding agents: microVM and kernel-isolated execution environments. Index skill (sandbox) routes to substrate-specific paths. Currently covers the kubernetes-sigs/agent-sandbox path on kind, GKE, and kina (Kubernetes-in-Apple-Containers), with Kata, gVisor, and Apple Container microVM substrates. Ships 7 skills + 6 slash commands + nushell scripts. Designed to expand to non-k8s sandboxing paths.",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/agent-sandboxing/skills/sandbox/SKILL.md
+++ b/plugins/tools/agent-sandboxing/skills/sandbox/SKILL.md
@@ -86,7 +86,7 @@ Both isolate untrusted agent code from the host. Both are valid; pick the one wh
 - `templates/SandboxTemplate.{kata,gvisor,kina}.yaml` — three variants; pick by substrate.
 - `templates/SandboxClaim.session.yaml` — per-session claim with `shutdownPolicy: Delete`.
 - `templates/NetworkPolicy.anthropic.yaml` — standalone default-deny + Anthropic egress allowlist (when `networkPolicyManagement: Unmanaged`).
-- `${CLAUDE_PLUGIN_ROOT}/scripts/render-claim.nu`, `wait-bound.nu`, `list-claims.nu` — nushell scripts at the plugin root (not inside this skill directory), invoked by the slash commands.
+- `CLAUDE_PLUGIN_ROOT/scripts/render-claim.nu`, `wait-bound.nu`, `list-claims.nu` — nushell scripts at the plugin root (not inside this skill directory), invoked by the slash commands. Shown as a bare path here, not the brace-expansion form, because the braced form itself expands to an absolute path when this skill loads.
 - `mise.toml` — plugin-root mise.toml pinning `nu` + `jq`; exposes `mise run render-claim` / `wait-bound` / `list-claims` / `install-controller` for direct operator use without Claude.
 
 ## Anti-fabrication

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/claude-hooks/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-hooks/SKILL.md
@@ -29,32 +29,12 @@ Plugin hooks at `<plugin-root>/hooks/hooks.json` are auto-discovered. No registr
 
 ## Plugin Hook File Structure
 
-Plugin `hooks/hooks.json` uses the wrapper format:
-
-```json
-{
-  "description": "Brief explanation of what these hooks do",
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Write|Edit|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/check.sh",
-            "timeout": 5
-          }
-        ]
-      }
-    ]
-  }
-}
-```
+Plugin `hooks/hooks.json` uses the wrapper format — see `references/hook-examples.md` ("Plugin hooks.json wrapper format") for the complete file.
 
 - `description` — optional, surfaced in plugin metadata
 - `hooks` — required wrapper containing event arrays
 - `matcher` — regex of tool names (PreToolUse/PostToolUse) or session lifecycle phases (SessionStart)
-- `${CLAUDE_PLUGIN_ROOT}` — absolute path to the plugin root, expanded at runtime
+- `CLAUDE_PLUGIN_ROOT` — absolute path to the plugin root, expanded at runtime. Written bare here (not as `${...}`) because the braced form itself expands when this skill loads — see `references/hook-examples.md` for the real brace-expansion usage.
 
 ## Hook Events
 
@@ -74,15 +54,7 @@ Plugin `hooks/hooks.json` uses the wrapper format:
 
 ### Command Hooks
 
-Execute a shell command. Deterministic, fast.
-
-```json
-{
-  "type": "command",
-  "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/validate.sh",
-  "timeout": 60
-}
-```
+Execute a shell command. Deterministic, fast. See `references/hook-examples.md` ("Command hook") for an example.
 
 ### Prompt Hooks
 
@@ -102,27 +74,7 @@ Supported events for prompt hooks: `Stop`, `SubagentStop`, `UserPromptSubmit`, `
 
 `SessionStart` is the strongest compliance mechanism: stdout from the hook script becomes part of the model's first input. Memory and skills inform; SessionStart compels.
 
-Plugin example (`plugins/example/hooks/hooks.json`):
-
-```json
-{
-  "description": "Inject project conventions at session start",
-  "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "startup|resume|clear",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh",
-            "timeout": 5
-          }
-        ]
-      }
-    ]
-  }
-}
-```
+Plugin example (`plugins/example/hooks/hooks.json`) — see `references/hook-examples.md` ("SessionStart — plugin example").
 
 Companion script (`plugins/example/hooks/session-start.sh`):
 
@@ -151,49 +103,13 @@ Exit code from a `PreToolUse` command hook controls whether the tool runs:
 - Exit 0: continue
 - Exit non-zero: block the tool, show stderr to the user
 
-Example — block force-push to main:
-
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/guard-push.sh"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
+Example — block force-push to main: see `references/hook-examples.md` ("PreToolUse — block force-push to main").
 
 `guard-push.sh` reads the tool input from stdin (JSON), parses with `jq`, and exits non-zero on a forbidden pattern.
 
 ## PostToolUse — Auto-Format, Lint, Sync
 
-`PostToolUse` runs after the tool completes. Exit codes are logged but do not affect the tool result.
-
-```json
-{
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Write|Edit|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/format.sh"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
+`PostToolUse` runs after the tool completes. Exit codes are logged but do not affect the tool result. See `references/hook-examples.md` ("PostToolUse — auto-format after edits") for an example.
 
 The hook reads the tool input from stdin and runs the formatter on the modified file.
 
@@ -223,7 +139,7 @@ Stdout from `SessionStart` and `UserPromptSubmit` hooks is injected into the mod
 ## Best Practices
 
 - **Keep hooks fast.** Hooks block the harness. Aim for under 1 second for `PreToolUse`/`PostToolUse`. Set explicit `timeout` values.
-- **Use `${CLAUDE_PLUGIN_ROOT}`.** Never hardcode plugin paths.
+- **Use `CLAUDE_PLUGIN_ROOT`** (as a brace expansion in real hook commands — see `references/hook-examples.md`). Never hardcode plugin paths.
 - **Validate stdin.** Hook input is JSON; use `jq` and exit cleanly on parse failure.
 - **Scope matchers narrowly.** Match `Write|Edit` over matching all tools.
 - **Mark scripts executable.** `chmod +x` after creating shell scripts; the hook will fail silently otherwise.
@@ -242,7 +158,7 @@ Validate hook behavior with actual execution before claiming it works. Run the h
 
 ## Templates
 
-- `templates/plugin-hook.md` — plugin `hooks/hooks.json` configuration with `PostToolUse`, `Write|Edit` matcher, and `${CLAUDE_PLUGIN_ROOT}`
+- `templates/plugin-hook.md` — plugin `hooks/hooks.json` configuration with `PostToolUse`, `Write|Edit` matcher, and `CLAUDE_PLUGIN_ROOT`
 - `templates/skill-hook.md` — skill/subagent frontmatter hook example for `PreToolUse`, `PostToolUse`, `Stop`
 
 ## References

--- a/plugins/tools/claude-code/skills/claude-hooks/references/hook-examples.md
+++ b/plugins/tools/claude-code/skills/claude-hooks/references/hook-examples.md
@@ -1,0 +1,100 @@
+# Hook Configuration Examples
+
+Copy-paste `hooks.json` and hook-definition examples for `claude-hooks`. `${CLAUDE_PLUGIN_ROOT}` in
+these blocks is the literal brace-expansion syntax — copy it as-is into a real `hooks.json`; Claude
+Code expands it at plugin-load time to the plugin's installation directory. (This file is delivered
+byte-exact via `Read`, unlike the skill body, so the token survives here.)
+
+## Plugin hooks.json wrapper format
+
+```json
+{
+  "description": "Brief explanation of what these hooks do",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/check.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Command hook
+
+```json
+{
+  "type": "command",
+  "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/validate.sh",
+  "timeout": 60
+}
+```
+
+## SessionStart — plugin example (`plugins/example/hooks/hooks.json`)
+
+```json
+{
+  "description": "Inject project conventions at session start",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## PreToolUse — block force-push to main
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/guard-push.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## PostToolUse — auto-format after edits
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/format.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```

--- a/plugins/tools/claude-code/skills/plugin-marketplace/SKILL.md
+++ b/plugins/tools/claude-code/skills/plugin-marketplace/SKILL.md
@@ -116,61 +116,17 @@ Each plugin entry in the `plugins` array requires:
 
 ## Environment Variables
 
-Use `${CLAUDE_PLUGIN_ROOT}` in paths to reference the plugin's installation directory:
-
-```json
-{
-  "skills": [
-    "${CLAUDE_PLUGIN_ROOT}/skills/my-skill"
-  ],
-  "commands": [
-    "${CLAUDE_PLUGIN_ROOT}/commands"
-  ]
-}
-```
-
-This ensures paths work correctly regardless of installation location.
+`CLAUDE_PLUGIN_ROOT` resolves to the plugin's installation directory; used as a brace expansion (`${...}`) in `skills`/`commands`/`agents`/`hooks`/`mcpServers` paths so they work regardless of install location. Shown bare here because the braced form expands when this skill loads — see `references/marketplace-examples.md` ("Environment Variables — path usage") for a copyable example.
 
 ## Advanced Plugin Entry Features
 
 ### Inline Plugin Definitions
 
-Use `strict: false` to define complete plugin manifests inline without requiring plugin.json:
-
-```json
-{
-  "name": "my-plugin",
-  "source": "./plugins/my-plugin",
-  "strict": false,
-  "description": "Complete plugin definition inline",
-  "version": "1.0.0",
-  "author": {
-    "name": "Developer Name"
-  },
-  "skills": [
-    "${CLAUDE_PLUGIN_ROOT}/skills/skill-one",
-    "${CLAUDE_PLUGIN_ROOT}/skills/skill-two"
-  ]
-}
-```
+Use `strict: false` to define complete plugin manifests inline without requiring plugin.json. See `references/marketplace-examples.md` ("Inline Plugin Definitions") for a full entry, including how `skills` paths use `CLAUDE_PLUGIN_ROOT`.
 
 ### Component Path Override
 
-Customize component locations:
-
-```json
-{
-  "name": "custom-paths",
-  "source": "./plugins/custom",
-  "strict": false,
-  "commands": ["${CLAUDE_PLUGIN_ROOT}/custom-commands"],
-  "agents": ["${CLAUDE_PLUGIN_ROOT}/custom-agents"],
-  "hooks": {
-    "onInstall": "${CLAUDE_PLUGIN_ROOT}/hooks/install.sh"
-  },
-  "mcpServers": "${CLAUDE_PLUGIN_ROOT}/mcp-config.json"
-}
-```
+Customize component locations — see `references/marketplace-examples.md` ("Component Path Override") for a full example overriding `commands`, `agents`, `hooks`, and `mcpServers` paths with `CLAUDE_PLUGIN_ROOT`.
 
 ### Metadata Supplementation
 
@@ -351,39 +307,7 @@ This creates `.claude-plugin/marketplace.json` with required fields.
 
 ### Step 3: Add Plugin Entries
 
-For each plugin, decide on strict mode and add entry:
-
-```json
-{
-  "name": "marketplace-name",
-  "owner": {
-    "name": "Your Name",
-    "email": "you@example.com"
-  },
-  "metadata": {
-    "description": "Your marketplace description",
-    "version": "1.0.0",
-    "pluginRoot": "./plugins"
-  },
-  "plugins": [
-    {
-      "name": "plugin-name",
-      "source": "plugin-name",
-      "strict": false,
-      "description": "Plugin description",
-      "version": "1.0.0",
-      "author": {
-        "name": "Your Name"
-      },
-      "license": "MIT",
-      "category": "development",
-      "skills": [
-        "${CLAUDE_PLUGIN_ROOT}/skills/skill-one"
-      ]
-    }
-  ]
-}
-```
+For each plugin, decide on strict mode and add entry — see `references/marketplace-examples.md` ("Creating a marketplace — Step 3: Add Plugin Entries") for a complete marketplace.json entry with a `skills` path using `CLAUDE_PLUGIN_ROOT`.
 
 ### Step 4: Validate
 
@@ -430,7 +354,7 @@ This scans for plugin.json files and suggests marketplace.json structure.
 
 ### Skills Not Loading
 
-- Verify skill paths use `${CLAUDE_PLUGIN_ROOT}` if needed
+- Verify skill paths use `CLAUDE_PLUGIN_ROOT` if needed
 - Check that skill directories contain SKILL.md files
 - Validate skill paths in plugin entry or plugin.json
 
@@ -452,6 +376,7 @@ nu ${CLAUDE_PLUGIN_ROOT}/scripts/validate-marketplace.nu .claude-plugin/marketpl
 
 For the detailed schema specification, see:
 - `references/schema-specification.md`: Complete JSON schema
+- `references/marketplace-examples.md`: Copyable CLAUDE_PLUGIN_ROOT path examples for skills/commands/agents/hooks/mcpServers entries
 
 ## Script Usage
 

--- a/plugins/tools/claude-code/skills/plugin-marketplace/references/marketplace-examples.md
+++ b/plugins/tools/claude-code/skills/plugin-marketplace/references/marketplace-examples.md
@@ -1,0 +1,96 @@
+# Marketplace Config Examples
+
+Copy-paste `marketplace.json` fragments for `plugin-marketplace`. `${CLAUDE_PLUGIN_ROOT}` in these
+blocks is the literal brace-expansion syntax — copy it as-is; Claude Code expands it at plugin-load
+time to the plugin's installation directory. (This file is delivered byte-exact via `Read`, unlike
+the skill body, so the token survives here.)
+
+## Environment Variables — path usage
+
+```json
+{
+  "skills": [
+    "${CLAUDE_PLUGIN_ROOT}/skills/my-skill"
+  ],
+  "commands": [
+    "${CLAUDE_PLUGIN_ROOT}/commands"
+  ]
+}
+```
+
+This ensures paths work correctly regardless of installation location.
+
+## Inline Plugin Definitions
+
+Use `strict: false` to define complete plugin manifests inline without requiring plugin.json:
+
+```json
+{
+  "name": "my-plugin",
+  "source": "./plugins/my-plugin",
+  "strict": false,
+  "description": "Complete plugin definition inline",
+  "version": "1.0.0",
+  "author": {
+    "name": "Developer Name"
+  },
+  "skills": [
+    "${CLAUDE_PLUGIN_ROOT}/skills/skill-one",
+    "${CLAUDE_PLUGIN_ROOT}/skills/skill-two"
+  ]
+}
+```
+
+## Component Path Override
+
+Customize component locations:
+
+```json
+{
+  "name": "custom-paths",
+  "source": "./plugins/custom",
+  "strict": false,
+  "commands": ["${CLAUDE_PLUGIN_ROOT}/custom-commands"],
+  "agents": ["${CLAUDE_PLUGIN_ROOT}/custom-agents"],
+  "hooks": {
+    "onInstall": "${CLAUDE_PLUGIN_ROOT}/hooks/install.sh"
+  },
+  "mcpServers": "${CLAUDE_PLUGIN_ROOT}/mcp-config.json"
+}
+```
+
+## Creating a marketplace — Step 3: Add Plugin Entries
+
+For each plugin, decide on strict mode and add entry:
+
+```json
+{
+  "name": "marketplace-name",
+  "owner": {
+    "name": "Your Name",
+    "email": "you@example.com"
+  },
+  "metadata": {
+    "description": "Your marketplace description",
+    "version": "1.0.0",
+    "pluginRoot": "./plugins"
+  },
+  "plugins": [
+    {
+      "name": "plugin-name",
+      "source": "plugin-name",
+      "strict": false,
+      "description": "Plugin description",
+      "version": "1.0.0",
+      "author": {
+        "name": "Your Name"
+      },
+      "license": "MIT",
+      "category": "development",
+      "skills": [
+        "${CLAUDE_PLUGIN_ROOT}/skills/skill-one"
+      ]
+    }
+  ]
+}
+```


### PR DESCRIPTION
Skill bodies are substituted before Claude sees them, so `${CLAUDE_PLUGIN_ROOT}` in a SKILL.md body arrives already replaced by an absolute cache path. Loading `claude-hooks` returned this:

> - **Use `/Users/…/plugins/cache/…/claude-code/0.2.28`.** Never hardcode plugin paths.

A page instructing the reader to hardcode the path it forbids, in the same sentence. Every `hooks.json` example in that skill was teaching an agent to write a hardcoded path, and the practical consumer *is* an agent that loads the skill and then writes the JSON.

**Fences do not protect** — the token expands inside triple-backtick JSON exactly as in prose. No escape exists either: the backslash does not escape the braced form (claude-skills-169), and a preceding character does not help, because braced substitution has no line-start rule to defeat.

Three treatments, classified **per occurrence**:

- **Copyable `hooks.json` / `marketplace.json` examples → `references/`.** `Read` delivers raw bytes with no substitution, so the braced token survives byte-exact where a reader copies it. Uses the existing progressive-disclosure convention rather than inventing a marker. New: `claude-hooks/references/hook-examples.md`, `plugin-marketplace/references/marketplace-examples.md`
- **Prose sites where the token is the subject → bare `CLAUDE_PLUGIN_ROOT`**, matching the convention PR #163 established for the other `CLAUDE_*` variables, each with a note on why it is bare and a pointer to the copyable form
- **Runnable `nu ${CLAUDE_PLUGIN_ROOT}/scripts/…` invocations → left braced, untouched.** Expansion is the *feature* there: it hands the agent an absolute path it can execute

That third category is 13 of 33 sites and was missed by the first plan. Both other treatments break it — a bare name yields a non-runnable command, and relocating to `references/` hands the agent the braced form via `Read`, which never resolves since `CLAUDE_PLUGIN_ROOT` is not set in a shell. `claude-plugins/SKILL.md` turned out to be *entirely* this category and is untouched.

Two scope corrections to the filed issue, both verified rather than assumed: `core/skills/security/SKILL.md`'s occurrence is in **frontmatter**, which is not delivered on load, so it was never affected; and `references/` files were never at risk, so `schema-specification.md`'s 8 occurrences stay as-is. Real scope was 33 body sites in 4 files, not 41 across 6.

Verified: 13 functional invocations before and after, zero non-functional braced tokens left in any body, 16 preserved in the new references. Waivers unchanged at 68; all three touched skills score 17/17.

Version bumps: claude-code 0.2.29 → 0.2.30, agent-sandboxing 0.2.5 → 0.2.6, all-skills 0.4.76 → 0.4.77.

Closes claude-skills-172.
