### PR TITLE
fix(core): describe all thirteen skills the plugin ships

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -142,7 +142,7 @@
       "name": "core",
       "source": "./plugins/core",
       "strict": true,
-      "description": "Essential development skills: Git, TDD, code review, security scanning, documentation, restraint, anti-fabrication, twelve-factor config, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
+      "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
       "version": "0.2.40",
       "category": "development",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.79",
+      "version": "0.4.80",
       "category": "meta",
       "keywords": [
         "skills",
@@ -142,8 +142,8 @@
       "name": "core",
       "source": "./plugins/core",
       "strict": true,
-      "description": "Essential development skills: Git, documentation, code review, security",
-      "version": "0.2.39",
+      "description": "Essential development skills: Git, TDD, code review, security scanning, documentation, restraint, anti-fabrication, twelve-factor config, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
+      "version": "0.2.40",
       "category": "development",
       "keywords": [
         "git",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.79",
+  "version": "0.4.80",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "core",
   "version": "0.2.40",
-  "description": "Essential development skills: Git, TDD, code review, security scanning, documentation, restraint, anti-fabrication, twelve-factor config, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
+  "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
   "author": {
     "name": "vinnie357"
   },

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "core",
-  "version": "0.2.39",
-  "description": "Essential development skills: Git, documentation, code review, security",
+  "version": "0.2.40",
+  "description": "Essential development skills: Git, TDD, code review, security scanning, documentation, restraint, anti-fabrication, twelve-factor config, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
   "author": {
     "name": "vinnie357"
   },


### PR DESCRIPTION
`core`'s description named **4 of the 13 skills** it ships — Git, documentation, code review, security — omitting mise, nushell, twelve-factor, anti-fabrication, bees, container, tdd, agent-loop, and restraint.

Both manifests carried the same text, so this was invisible to the agreement check added in PR #161. That check enforces the two copies **match**, not that either is **accurate** — the limit it was filed against.

Description is Level 1 discovery text: the only thing a user sees when browsing the marketplace, and `core` is the most-loaded plugin in the repo.

Before:
> Essential development skills: Git, documentation, code review, security

After:
> Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container

All 13 verified represented by a programmatic check against the manifest's own `skills` list, accepting either the hyphenated or spaced form of each name.

Follows house style — `elixir` names 9 of its skills, `rust` 8, both as `"<Domain> skills: <topics>"`, and `elixir` likewise names a specific tool (Tidewave MCP). At 214 characters it sits between the corpus median of 102 and the max of 421.

Two labels sharpened on review. `security` is specifically gitleaks secret and credential detection, so "security scanning" would over-draw users wanting SAST or vulnerability scanning; naming the tool is both more precise and more searchable, and `security` remains a keyword. `twelve-factor` covers microservices, containers, and Kubernetes — "config" narrowed it, so it now reads "twelve-factor apps".

Version bumps: core 0.2.39 → 0.2.40, all-skills 0.4.79 → 0.4.80.

Closes claude-skills-171.
