### PR TITLE
fix(versions): bump EOL runtime pins and migrate actions toolkit examples to ESM

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.80",
+      "version": "0.4.81",
       "category": "meta",
       "keywords": [
         "skills",
@@ -85,7 +85,7 @@
       "source": "./plugins/tools/ansible",
       "strict": true,
       "description": "Ansible automation skills: playbooks, inventory, roles, vault secrets, and Molecule testing",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "category": "tools",
       "keywords": [
         "ansible",
@@ -143,7 +143,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
-      "version": "0.2.40",
+      "version": "0.2.41",
       "category": "development",
       "keywords": [
         "git",
@@ -166,7 +166,7 @@
       "source": "./plugins/tools/dagu",
       "strict": true,
       "description": "Dagu workflow orchestration: workflow authoring, web UI, and REST API",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "category": "tools",
       "keywords": [
         "dagu",
@@ -215,7 +215,7 @@
       "source": "./plugins/tools/github",
       "strict": true,
       "description": "GitHub Actions, Workflows, act local testing, community health files, Dependabot consolidation, and PR review",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "category": "tools",
       "keywords": [
         "github",
@@ -256,7 +256,7 @@
       "source": "./plugins/tools/agent-sandboxing",
       "strict": true,
       "description": "Agent sandboxing for AI coding agents: microVM and kernel-isolated execution environments. Index skill (sandbox) routes to substrate-specific paths. Currently covers the kubernetes-sigs/agent-sandbox path on kind, GKE, and kina (Kubernetes-in-Apple-Containers), with Kata, gVisor, and Apple Container microVM substrates. Ships 7 skills + 6 slash commands + nushell scripts. Designed to expand to non-k8s sandboxing paths.",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "category": "tools",
       "keywords": [
         "agent-sandbox",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.80",
+  "version": "0.4.81",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/security/SKILL.md
+++ b/plugins/core/skills/security/SKILL.md
@@ -284,7 +284,7 @@ Add gitleaks to pre-commit hooks:
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.18.0
+    rev: v8.30.1
     hooks:
       - id: gitleaks
 ```

--- a/plugins/core/skills/twelve-factor/references/factor-examples.md
+++ b/plugins/core/skills/twelve-factor/references/factor-examples.md
@@ -33,12 +33,12 @@ myapp-repo/
 
 ```dockerfile
 # Multi-stage build for dependency isolation
-FROM node:18-alpine AS dependencies
+FROM node:24-alpine AS dependencies
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --only=production
 
-FROM node:18-alpine AS runtime
+FROM node:24-alpine AS runtime
 WORKDIR /app
 COPY --from=dependencies /app/node_modules ./node_modules
 COPY . .

--- a/plugins/tools/agent-sandboxing/.claude-plugin/plugin.json
+++ b/plugins/tools/agent-sandboxing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sandboxing",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Agent sandboxing for AI coding agents: microVM and kernel-isolated execution environments. Index skill (sandbox) routes to substrate-specific paths. Currently covers the kubernetes-sigs/agent-sandbox path on kind, GKE, and kina (Kubernetes-in-Apple-Containers), with Kata, gVisor, and Apple Container microVM substrates. Ships 7 skills + 6 slash commands + nushell scripts. Designed to expand to non-k8s sandboxing paths.",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/agent-sandboxing/skills/claude-code-on-sandbox/SKILL.md
+++ b/plugins/tools/agent-sandboxing/skills/claude-code-on-sandbox/SKILL.md
@@ -23,7 +23,7 @@ The plugin ships `templates/Dockerfile.claude-code` and `templates/mise.toml.cla
 
 ```dockerfile
 # syntax=docker/dockerfile:1.7
-FROM debian:12-slim AS base
+FROM debian:13-slim AS base
 
 ARG MISE_VERSION=2026.5.0
 ENV MISE_DATA_DIR=/opt/mise \

--- a/plugins/tools/agent-sandboxing/templates/Dockerfile.claude-code
+++ b/plugins/tools/agent-sandboxing/templates/Dockerfile.claude-code
@@ -4,7 +4,7 @@
 # Mise-driven so the image stays consistent with the rest of the marketplace.
 # See /core:mise and the claude-code-on-sandbox skill for the usage pattern.
 
-FROM debian:12-slim AS base
+FROM debian:13-slim AS base
 
 ARG MISE_VERSION=2026.5.0
 ENV MISE_DATA_DIR=/opt/mise \

--- a/plugins/tools/ansible/.claude-plugin/plugin.json
+++ b/plugins/tools/ansible/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ansible",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Ansible automation skills: playbooks, inventory, roles, vault secrets, and Molecule testing",
   "author": {
     "name": "rginnow"

--- a/plugins/tools/ansible/skills/ansible-testing/SKILL.md
+++ b/plugins/tools/ansible/skills/ansible-testing/SKILL.md
@@ -264,8 +264,8 @@ platforms:
   - name: ubuntu22
     image: geerlingguy/docker-ubuntu2204-ansible
     pre_build_image: true
-  - name: ubuntu20
-    image: geerlingguy/docker-ubuntu2004-ansible
+  - name: ubuntu24
+    image: geerlingguy/docker-ubuntu2404-ansible
     pre_build_image: true
   - name: rocky9
     image: geerlingguy/docker-rockylinux9-ansible

--- a/plugins/tools/ansible/skills/ansible-testing/references/molecule-scenarios.md
+++ b/plugins/tools/ansible/skills/ansible-testing/references/molecule-scenarios.md
@@ -143,8 +143,8 @@ platforms:
     groups:
       - debian_family
 
-  - name: ubuntu20
-    image: geerlingguy/docker-ubuntu2004-ansible
+  - name: ubuntu24
+    image: geerlingguy/docker-ubuntu2404-ansible
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
@@ -159,8 +159,8 @@ platforms:
     groups:
       - redhat_family
 
-  - name: debian12
-    image: geerlingguy/docker-debian12-ansible
+  - name: debian13
+    image: geerlingguy/docker-debian13-ansible
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true

--- a/plugins/tools/dagu/.claude-plugin/plugin.json
+++ b/plugins/tools/dagu/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dagu",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Dagu workflow orchestration: workflow authoring, web UI, and REST API",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/dagu/skills/workflows/references/executors.md
+++ b/plugins/tools/dagu/skills/workflows/references/executors.md
@@ -36,7 +36,7 @@ steps:
     executor:
       type: docker
       config:
-        image: node:18
+        image: node:24
         volumes:
           - /host/path:/container/path
         env:

--- a/plugins/tools/github/.claude-plugin/plugin.json
+++ b/plugins/tools/github/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "GitHub Actions, Workflows, act local testing, community health files, Dependabot consolidation, and PR review",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/github/skills/act/SKILL.md
+++ b/plugins/tools/github/skills/act/SKILL.md
@@ -263,7 +263,7 @@ act push -j deploy --secret-file .secrets
 act -j test
 
 # Test specific matrix combination (modify workflow temporarily)
-act -j test --matrix node-version:20
+act -j test --matrix node-version:24
 ```
 
 ### Workflow Development Cycle

--- a/plugins/tools/github/skills/actions/SKILL.md
+++ b/plugins/tools/github/skills/actions/SKILL.md
@@ -392,6 +392,8 @@ runs:
 ```javascript
 import * as core from '@actions/core';
 import * as cache from '@actions/cache';
+import * as exec from '@actions/exec';
+import * as glob from '@actions/glob';
 
 async function run() {
   const paths = [
@@ -399,7 +401,10 @@ async function run() {
     '.npm'
   ];
 
-  const key = `deps-${process.platform}-${hashFiles('package-lock.json')}`;
+  // hashFiles is async and lives in @actions/glob — the bare hashFiles()
+  // of workflow YAML has no JavaScript equivalent.
+  const hash = await glob.hashFiles('package-lock.json');
+  const key = `deps-${process.platform}-${hash}`;
 
   // Restore cache
   const cacheKey = await cache.restoreCache(paths, key);
@@ -417,6 +422,7 @@ async function run() {
 ### Artifact Upload Action
 
 ```javascript
+import * as core from '@actions/core';
 import { DefaultArtifactClient } from '@actions/artifact';
 
 async function uploadArtifact() {

--- a/plugins/tools/github/skills/actions/SKILL.md
+++ b/plugins/tools/github/skills/actions/SKILL.md
@@ -39,6 +39,14 @@ my-action/
 - Bundle all dependencies (use @vercel/ncc)
 - Support Node.js LTS versions
 
+**Current toolkit majors are ESM-only** — `@actions/core` 3.x, `@actions/github` 9.x,
+`@actions/exec` 3.x, `@actions/cache` 6.x. Each publishes `"type": "module"` with an exports map
+offering only an `import` condition, so `require('@actions/core')` throws
+`ERR_PACKAGE_PATH_NOT_EXPORTED` even on `node24`: Node's `require(esm)` finds no `require` or
+`module-sync` condition to match. Set `"type": "module"` in the action's `package.json` and use
+`import` — ncc emits an ES module automatically inside such a package boundary, so the bundling
+step below is unchanged. An action that cannot migrate must use dynamic `await import(...)`.
+
 **Example action.yml:**
 ```yaml
 name: 'My JavaScript Action'
@@ -80,7 +88,7 @@ my-action/
 
 **Example Dockerfile:**
 ```dockerfile
-FROM alpine:3.18
+FROM alpine:3.24
 
 RUN apk add --no-cache bash curl jq
 
@@ -102,7 +110,7 @@ inputs:
   node-version:
     description: 'Node.js version'
     required: false
-    default: '20'
+    default: '24'
 runs:
   using: 'composite'
   steps:
@@ -149,7 +157,7 @@ outputs:                     # Define all outputs
 
 **JavaScript:**
 ```javascript
-const core = require('@actions/core');
+import * as core from '@actions/core';
 const token = core.getInput('token', { required: true });
 const config = core.getInput('config') || 'default.yml';
 ```
@@ -180,7 +188,7 @@ Essential npm packages for JavaScript actions:
 
 ### @actions/core
 ```javascript
-const core = require('@actions/core');
+import * as core from '@actions/core';
 
 // Inputs/Outputs
 const input = core.getInput('name');
@@ -209,7 +217,7 @@ core.exportVariable('VAR_NAME', 'value');
 
 ### @actions/github
 ```javascript
-const github = require('@actions/github');
+import * as github from '@actions/github';
 
 // Context
 const context = github.context;
@@ -233,7 +241,7 @@ const { data: issues } = await octokit.rest.issues.listForRepo({
 
 ### @actions/exec
 ```javascript
-const exec = require('@actions/exec');
+import * as exec from '@actions/exec';
 
 // Execute commands
 await exec.exec('npm', ['install']);
@@ -253,7 +261,7 @@ await exec.exec('git', ['log', '--oneline'], {
 
 Always validate and sanitize inputs:
 ```javascript
-const core = require('@actions/core');
+import * as core from '@actions/core';
 
 function validateInput(input) {
   // Check for command injection
@@ -299,7 +307,7 @@ const octokit = github.getOctokit(token);
 npm audit
 
 # Use specific versions
-npm install @actions/core@1.10.0
+npm install @actions/core@3.0.1
 
 # Bundle dependencies
 npm install -g @vercel/ncc
@@ -382,8 +390,8 @@ runs:
 ### Cache Management Action
 
 ```javascript
-const core = require('@actions/core');
-const cache = require('@actions/cache');
+import * as core from '@actions/core';
+import * as cache from '@actions/cache';
 
 async function run() {
   const paths = [
@@ -409,10 +417,10 @@ async function run() {
 ### Artifact Upload Action
 
 ```javascript
-const artifact = require('@actions/artifact');
+import { DefaultArtifactClient } from '@actions/artifact';
 
 async function uploadArtifact() {
-  const artifactClient = artifact.create();
+  const artifactClient = new DefaultArtifactClient();
   const files = [
     'dist/bundle.js',
     'dist/styles.css'
@@ -420,19 +428,25 @@ async function uploadArtifact() {
 
   const rootDirectory = 'dist';
   const options = {
-    continueOnError: false
+    retentionDays: 10
   };
 
-  const uploadResponse = await artifactClient.uploadArtifact(
+  const { id, size } = await artifactClient.uploadArtifact(
     'build-artifacts',
     files,
     rootDirectory,
     options
   );
 
-  core.setOutput('artifact-id', uploadResponse.artifactId);
+  core.setOutput('artifact-id', id);
+  core.info(`Uploaded ${size} bytes`);
 }
 ```
+
+`@actions/artifact` v2+ replaced the `artifact.create()` factory with `DefaultArtifactClient` and
+returns `{id, size, digest}` instead of `artifactId`; `uploadArtifact` still takes `rootDirectory`
+third. The v1 `continueOnError` option is gone — options are `retentionDays`, `compressionLevel`,
+`skipArchive`. Uploading twice to one artifact name is no longer possible; use distinct names.
 
 ## Troubleshooting
 


### PR DESCRIPTION
claude-skills-174 named two stale versions. A corpus sweep found the count wrong and the headline item much bigger than a bump.

**The `@actions/core` item is a breaking-change migration, not a number.** Current majors of every toolkit package the `actions` skill teaches are ESM-only — `core` 3.x, `github` 9.x, `exec` 3.x, `cache` 6.x each publish `"type": "module"` with an exports map offering only an `import` condition. The skill used `require()` in **seven** code blocks. Bumping line 302 alone would have left seven examples that cannot run on the version the skill tells the reader to install — strictly worse than leaving it stale.

Verified empirically, not from docs: `npm i @actions/core@3.0.1` on node v24.18.0 (the `node24` runtime's major), then `require()` throws `ERR_PACKAGE_PATH_NOT_EXPORTED` while `import` works. Node's `require(esm)` does not rescue it — there is no `require` or `module-sync` condition to match. This mattered because the toolkit's own README still shows `require()` and contradicts its own RELEASES.md; the published `exports` map is the only trustworthy source.

**Fixed**

| File | Was | Now | Why |
|---|---|---|---|
| `github/actions/SKILL.md` | 7× `require(...)`, `@actions/core@1.10.0` | ESM `import`, `@actions/core@3.0.1` | toolkit is ESM-only |
| `github/actions/SKILL.md` | `artifact.create()`, `uploadResponse.artifactId`, `continueOnError` | `new DefaultArtifactClient()`, `{id, size}`, `retentionDays` | v1 API removed |
| `github/actions/SKILL.md` | `alpine:3.18`, composite `node-version` default `'20'` | `alpine:3.24`, `'24'` | EOL |
| `github/act/SKILL.md` | `--matrix node-version:20` | `:24` | node 20 EOL 2026-04-30 |
| `core/security/SKILL.md` | gitleaks `rev: v8.18.0` | `v8.30.1` | 12 releases behind |
| `core/twelve-factor/references/factor-examples.md` | `node:18-alpine` ×2 | `node:24-alpine` | EOL 2025-04-30 |
| `dagu/workflows/references/executors.md` | `node:18` | `node:24` | EOL |
| `agent-sandboxing` SKILL + `templates/Dockerfile.claude-code` | `debian:12-slim` | `debian:13-slim` | debian 12 EOL **2026-07-11** |
| `ansible/ansible-testing` SKILL + reference | `ubuntu2004`, `debian12` images and platform labels | `ubuntu2404`, `debian13` | Ubuntu 20.04 support ended 2025-05-31; debian 12 EOL |

Node's active LTS today is 24 (26 becomes LTS 2026-10-28). Replacement images confirmed to exist on Docker Hub before use.

**Deliberately not changed** — the rule applied was *fix what is EOL, or where following the document produces code that cannot run.* `postgres:15` (EOL 2027-11-11), `redis:7-alpine` (7.2/7.4 still patched), `ubuntu-systemd:22.04` (LTS to 2027), `rockylinux9` (EOL 2032) are all in support. `ARG MISE_VERSION=2026.5.0` is not EOL and mise ships weekly — bumping resets a clock that drifts again within days.

**Four of the ten fixes came from the plan review, not my sweep.** My regex matched `image: <name>:<tag>` and missed versions encoded in the image *name* (`...ubuntu2004...`) and in a CLI flag value. Same silent-under-match class recorded in memory; the review also caught that an earlier draft specified a 3-arg `uploadArtifact`, which would have shipped the exact broken example this PR exists to remove — `rootDirectory` is still required, only the client construction and response shape changed.

**Not fixed, being filed:** nothing catches these drifting. The bee says they are invisible to `version_pin`, which is right for the wrong reason — that check parses `Current stable: X` prose against `sources.md`, and never looks inside code fences. There are 13 such literals across 7 files. Extending sources.md agreement to them is feasible and offline but only moves the rot: the corpus already shows the `mise` skill's prose pin passing `version_pin` while months behind upstream. Agreement is not freshness. The follow-up proposes a manually-run drift-report task that queries upstream, honest about needing network, rather than a CI check comparing one stale file against another.

Plugin versions bumped: core, github, dagu, agent-sandboxing, ansible, all-skills. `mise test` exit 0, waivers unchanged at 68, gitleaks clean, `actions/SKILL.md` at 488/500 lines.
