### PR TITLE
refactor(claude-skills): reshape SKILL.md as a router, 441 to 202 lines

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.81",
+      "version": "0.4.82",
       "category": "meta",
       "keywords": [
         "skills",
@@ -119,7 +119,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
-      "version": "0.2.31",
+      "version": "0.2.32",
       "category": "tools",
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.81",
+  "version": "0.4.82",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.31",
+  "version": "0.2.32",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/claude-skills/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-skills/SKILL.md
@@ -7,120 +7,52 @@ description: Guide for creating Agent Skills with progressive disclosure and bes
 
 Guide for creating modular, self-contained Agent Skills that extend Claude's capabilities with specialized knowledge.
 
-## What Are Agent Skills?
+## How skills load
 
-Agent Skills are organized directories containing instructions, scripts, and resources that Claude can dynamically discover and load. They enable a single general-purpose agent to gain domain-specific expertise without requiring separate custom agents for each use case.
+A skill is a directory of instructions and resources that Claude discovers and loads on demand. Loading happens in tiers, and the tier a fact lands in decides whether Claude ever sees it:
 
-### Key Concepts
+- **Level 1 — discovery.** Only the `name` and `description` reach the system prompt. Claude decides relevance from these alone.
+- **Level 2 — activation.** The full `SKILL.md` body loads. Every line costs on every activation.
+- **Level 3+ — deep context.** Bundled `references/` files load only when a specific scenario calls for one.
 
-- **Modularity**: Self-contained packages that can be mixed and matched
-- **Reusability**: Share and distribute expertise across projects and teams
-- **Progressive Disclosure**: Load context only when needed, keeping interactions efficient
-- **Specialization**: Deep domain knowledge without sacrificing generality
+Write to that structure: the body carries decisions, gotchas, and enforced constraints; references carry look-it-up material. A body that holds everything upfront defeats the mechanism.
 
-### Skill Categories
+Skills also fall into two categories, and the category sets testing and maintenance expectations. **Capability uplift** builds on general model abilities (a structured code-review procedure) and stays stable across model versions. **Encoded preference** captures local conventions (a team's commit format) and needs revisiting when models change.
 
-Skills fall into two categories (source: Anthropic PDF Guide):
-
-**Capability Uplift**: Enhances Claude's core abilities (coding, analysis, reasoning). These are stable across model versions because they build on general capabilities. Example: a code review skill that adds structured review steps.
-
-**Encoded Preference**: Encodes user-specific workflows, formatting, and conventions. These need updates when models change because they depend on model behavior for fidelity. Example: a commit message skill that enforces team-specific format.
-
-When creating a skill, identify its category — this determines testing strategy and maintenance expectations.
-
-## How Skills Work
-
-Skills operate on a principle of progressive disclosure across multiple levels:
-
-### Level 1: Discovery
-Agent system prompts include only skill names and descriptions, allowing Claude to decide when each skill is relevant based on the task at hand.
-
-### Level 2: Activation
-When Claude determines a skill applies, it loads the full `SKILL.md` file into context, gaining access to the complete procedural knowledge and guidelines.
-
-### Level 3+: Deep Context
-Additional bundled files (like references, forms, or documentation) load only when needed for specific scenarios, keeping token usage efficient.
-
-This tiered approach maintains efficient context windows while supporting potentially unbounded skill complexity.
-
-## Skill Structure
-
-### Minimal Requirements
-
-Every skill must have:
+## Skill structure
 
 ```
 skill-name/
-└── SKILL.md
+├── SKILL.md           # Required: frontmatter + body
+├── scripts/           # Optional: executable code for deterministic tasks
+├── references/        # Optional: documentation loaded on-demand
+└── assets/            # Optional: templates, images, boilerplate
 ```
 
-### Complete Structure
+`SKILL.md` is the only required file: YAML frontmatter, then Markdown body.
 
-More complex skills can include additional resources:
-
-```
-skill-name/
-├── SKILL.md           # Required: Core skill definition
-├── scripts/           # Optional: Executable code for deterministic tasks
-├── references/        # Optional: Documentation loaded on-demand
-└── assets/            # Optional: Templates, images, boilerplate
-```
-
-## SKILL.md Format
-
-Each `SKILL.md` file must begin with YAML frontmatter followed by Markdown content:
-
-```markdown
----
-name: skill-name
-description: Concise explanation of when Claude should use this skill
-license: MIT
----
-
-# Skill Name
-
-Main instructional content goes here...
-```
-
-### YAML Properties
+## Frontmatter
 
 Source: [Claude Code Skills documentation](https://code.claude.com/docs/en/skills#frontmatter-reference). All fields are optional; only `description` is recommended.
 
-- `name`: Display name. If omitted, defaults to the directory name. Lowercase letters, numbers, and hyphens only (max 64 characters).
-- `description` (recommended): What the skill does and when to use it. Claude uses this to decide when to apply the skill. Two distinct limits apply: Claude Code truncates the combined `description` + `when_to_use` at 1,536 characters in the skill listing — put the key use case first — and this marketplace enforces a stricter 1024-character cap on `description` in `test/validate-skills-quality.nu`.
+- `name`: Display name. Defaults to the directory name if omitted. Lowercase letters, numbers, and hyphens only (max 64 characters).
+- `description` (recommended): What the skill does and when to use it. Two distinct limits apply: Claude Code truncates the combined `description` + `when_to_use` at 1,536 characters in the skill listing — put the key use case first — and this marketplace enforces a stricter 1024-character cap on `description` in `test/validate-skills-quality.nu`.
 - `when_to_use`: Additional trigger phrases or example requests, appended to `description` in the listing.
 - `license`: License name or filename reference.
 
-The full upstream frontmatter reference (with `disable-model-invocation`, `user-invocable`, `allowed-tools`, `model`, `effort`, `context: fork`, `agent`, `hooks`, `paths`, `shell`, `arguments`, `argument-hint`, `metadata`) lives in `references/frontmatter-fields.md`. Load that reference when authoring a skill that needs anything beyond name/description/license.
+The full upstream reference — `disable-model-invocation`, `user-invocable`, `allowed-tools`, `model`, `effort`, `context: fork`, `agent`, `hooks`, `paths`, `shell`, `arguments`, `argument-hint`, `metadata` — is in `references/frontmatter-fields.md`. Load it when authoring a skill that needs anything beyond name/description/license.
 
-**Description constraints**:
-- Use third person (not "I can help you" or "You can use this")
-- Include both **what it does** AND **when to use it**
-- Pattern: `[What it does]. Use when [trigger conditions].`
+Write the description in third person, stating both what the skill does and when to use it: `[What it does]. Use when [trigger conditions].`
 
 > **Critical**: The `description` is the ONLY text Claude sees during skill discovery (Level 1). The body's "When to Use" section only loads AFTER activation (Level 2) and cannot trigger it. All activation triggers belong in the description.
 
+Tune a description by failure mode: too broad produces false positives — add domain-specific terms; too narrow produces false negatives — add synonyms and trigger scenarios. Activation-rate targets and eval prompt counts live in `/claude-code:claude-skills-benchmark`.
+
 ### Frontmatter policy for THIS marketplace
 
-The upstream Claude Code spec allows `allowed-tools` on a skill — it pre-approves listed tools while the skill is active. **This marketplace's `test/validate-plugin.nu` rejects `allowed-tools` on skills as a hard validation failure.** Reasoning:
+The upstream spec allows `allowed-tools` on a skill, pre-approving listed tools while it is active. **This marketplace's `test/validate-plugin.nu` rejects `allowed-tools` on skills as a hard validation failure.** Tool filtering belongs on **agents** — the `tools:` frontmatter on an agent file — not on the skills an agent loads. Skills here stay capability-driven and inherit tools from the calling context; an agent needing constrained access defines its own allowlist.
 
-- Tool filtering belongs on **agents** (the `tools:` frontmatter on an agent file), not on skills the agent loads. See the `claude-agents` skill.
-- Skills in this marketplace stay capability-driven (knowledge, procedure) and inherit tools from the calling context.
-- An agent that needs constrained tool access defines its own allowlist; skills it consumes do not override that.
-
-When working in this marketplace: keep skill frontmatter to `name`, `description`, optional `license`, optional `metadata`. Use `allowed-tools` on agents instead.
-
-When working in another project that does not enforce this policy, the upstream `allowed-tools` field is valid and documented.
-
-### Markdown Body
-
-The content section has no structural restrictions. Include:
-
-- When to activate the skill
-- Core procedural knowledge
-- Best practices and guidelines
-- Examples and patterns
-- References to additional resources (if any)
+Keep skill frontmatter to `name`, `description`, optional `license`, optional `metadata`. In another project that does not enforce this policy, upstream `allowed-tools` is valid.
 
 ## Pre-edit checklist
 
@@ -191,83 +123,19 @@ The three `CLAUDE_*` names are written bare because they are used as brace expan
 
 Disable shell injection across user/project/plugin skills via `"disableSkillShellExecution": true` in settings — useful for managed environments.
 
-## Creating Skills: Seven-Step Workflow
+## Authoring workflow
 
-### 1. Understanding Through Examples
+1. **Collect real use cases first.** Concrete examples reveal what the skill must support; theoretical requirements do not.
+2. **Decide what each resource is for** — `scripts/` for deterministic work that would otherwise be rewritten each time, `references/` for material loaded on demand, `assets/` for output templates that never enter context.
+3. **Create the directory**, with its name matching the `name` property exactly.
+4. **Write the body in imperative form.** Keep procedure in `SKILL.md`, detail in references.
+5. **Record every source** in the plugin's `sources.md` — URL, what was taken from it, and why. This is what makes a claim auditable later.
+6. **Validate before publishing.** Write eval prompts that should and should not activate the skill, run them, record actual pass/fail counts, and confirm references load when needed. Full methodology in `references/evaluation-guide.md`.
+7. **Iterate on evidence.** Optimize the description against observed false positives and negatives, and test across Haiku, Sonnet, and Opus. If the base model passes the evals with the skill unloaded, the skill is unnecessary — deprecate it.
 
-Gather concrete use cases to clarify what the skill needs to support. Real-world examples reveal actual needs better than theoretical requirements.
+Write the evals before the content, and compare output with the skill loaded against output without it. Measure pass rates and token usage rather than judging quality subjectively; a single run proves nothing. `references/evaluation-guide.md` covers eval-driven development and blind A/B comparison, and `templates/evaluation-checklist.md` is a copyable checklist.
 
-**Example:**
-```
-Use Case: Help developers follow Git best practices
-Examples:
-- Creating conventional commit messages
-- Rebasing feature branches
-- Resolving merge conflicts
-- Creating descriptive branch names
-```
-
-### 2. Planning Resources
-
-Analyze examples to identify needed components:
-
-- **Scripts**: For tasks requiring deterministic reliability or that would need repeated rewriting
-- **References**: Documentation to load into context as needed
-- **Assets**: Output files like templates or boilerplate (not loaded into context)
-
-### 3. Initialization
-
-Create the skill directory structure with the required `SKILL.md` file. Ensure the directory name matches the `name` property exactly.
-
-```bash
-mkdir -p my-skill/{scripts,references,assets}
-touch my-skill/SKILL.md
-```
-
-### 4. Editing
-
-Develop resource files and update `SKILL.md` with:
-- Purpose and activation criteria
-- Usage guidelines and best practices
-- Implementation details and examples
-- References to supplementary files
-
-**Use imperative/infinitive form** rather than second-person instruction for clarity.
-
-Keep core procedural information in `SKILL.md` and detailed reference material in separate files.
-
-### 5. Documentation
-
-**Document all sources in the plugin's `sources.md`**. For each skill created, record:
-- URLs of documentation, guides, and references used
-- Purpose of each source
-- Key topics and concepts extracted
-- Date accessed (if relevant)
-
-This maintains traceability and helps others understand the skill's foundation.
-
-### 6. Validation
-
-Test the skill using the validation loop pattern:
-
-1. Define success criteria (what correct activation and output look like)
-2. Create eval prompts — both in-scope (should activate) and out-of-scope (should not)
-3. Run evaluations and record pass/fail rates
-4. Verify progressive disclosure works (references load when needed)
-5. Check token usage remains efficient
-6. If any validation fails, iterate on the skill before publishing
-
-For the complete evaluation methodology, see `references/evaluation-guide.md`.
-
-### 7. Iteration
-
-Refine based on real-world usage and evaluation data:
-- **Optimize descriptions**: Reduce false positives (too broad) and false negatives (too narrow)
-- **Test across models**: Verify behavior on Haiku, Sonnet, and Opus
-- **Monitor activation**: Track when the skill triggers correctly vs incorrectly
-- **Deprecation signal**: If the base model passes evals without the skill loaded, the skill is unnecessary — deprecate it
-
-For description optimization techniques, see `references/evaluation-guide.md`.
+**Specify constraints, not implementations** — "ensure commit messages follow conventional format", not "run git commit -m with prefix type(scope):". Instructions rigid enough to break on a minor model update are too rigid; loose enough to produce inconsistent results, too loose. `references/design-patterns.md` has the full degree-of-freedom framework, the platform-capability matrix, and guidance on when to execute a bundled script versus read it for patterns to adapt.
 
 ## Five-tier authoring pipeline
 
@@ -277,120 +145,17 @@ Skill updates that only edit markdown skip P2 (test author) — content-grep tes
 
 The pipeline runs inside ONE bees issue per skill update slice. The Sub-team Leader (or bees-worker acting as one) spawns the five stages as separate Task invocations; intermediate artifacts go to bees comments on that issue and git commits on the feature branch. Skill updates do not produce five chained bees rows.
 
-## Best Practices
+## Sizing a skill
 
-### Evaluation-Driven Development
+The context window is shared, and a skill's body loads in full on every activation — so justify each line's presence rather than each file's.
 
-Build skills using an evaluation-first approach (source: Anthropic Blog Post):
+**Compaction behavior sets the real budget.** A skill loads as a single message and stays for the session. Auto-compaction keeps the first 5,000 tokens of each invoked skill, with a 25,000-token combined budget filled from most-recently-invoked first, so older skills can drop after compaction. Re-invoke a skill if it stops influencing behavior.
 
-1. **Write evals first**: Define test prompts and expected behaviors before writing skill content
-2. **Test with and without**: Compare Claude's output with the skill loaded vs without it
-3. **Measure, don't guess**: Track pass rates, token usage, and timing — not subjective quality
-4. **Run A/B comparisons**: Use independent agents to compare skill versions blindly
-5. **Detect obsolescence**: When the base model passes evals without the skill, deprecate it
+## Security
 
-For the complete methodology, see `references/evaluation-guide.md`. For a copyable checklist, see `templates/evaluation-checklist.md`.
+Install skills only from trusted sources. A skill body is executable input: it can carry shell-injection lines that run before anyone reads the output. Before installing an unfamiliar skill, audit its bundled files and scripts, its code dependencies, any instruction directing Claude to an external service, and any request for credentials or destructive operations.
 
-### Degree of Freedom
-
-Balance specificity against fragility in skill instructions (source: Anthropic PDF Guide):
-
-- **Specify constraints, not implementations**: "Ensure commit messages follow conventional format" not "Run git commit -m with prefix type(scope):"
-- **Allow model adaptation**: Instructions must work across Haiku, Sonnet, and Opus without modification
-- **Test fragility**: If a minor model update breaks your skill, instructions are too rigid
-- **Test looseness**: If Claude produces inconsistent results, instructions are too loose
-
-For the full framework with examples, see `references/design-patterns.md`.
-
-### Context Window Discipline
-
-The context window is a shared resource (source: [Claude Code Skills docs](https://code.claude.com/docs/en/skills#add-supporting-files)):
-
-- Keep SKILL.md under **500 lines** (enforced by the `lines` check in `test/validate-skills-quality.nu`, matching the upstream guideline). Split detailed content into `references/` once the body exceeds the cap.
-- Move detailed reference material (API specs, deep-dive docs, examples) to separate files. Load only when needed.
-- Monitor cumulative load: skill + prompt + conversation history must all fit.
-- Every line in SKILL.md is loaded on every activation — justify each line's presence.
-
-**Skill content lifecycle:** A skill loads as a single message and stays for the session. Auto-compaction keeps the first 5,000 tokens of each invoked skill, with a 25,000-token combined budget filled from most-recently-invoked first. Older skills can be dropped after compaction. Re-invoke a skill if it stops influencing behavior post-compaction.
-
-### Structure for Scale
-
-Split unwieldy `SKILL.md` files into separate referenced documents:
-- Keep commonly-used contexts together
-- Separate mutually exclusive information to reduce token usage
-- Use progressive disclosure to load details only when needed
-- **Reference depth**: Keep references one level deep only (SKILL.md → reference, not reference → reference)
-- **TOC in long references**: Give a reference file a Table of Contents when a reader would jump to a section rather than read it straight through
-- **Scripts**: Execute scripts for deterministic tasks; read scripts for patterns to adapt contextually
-
-For design patterns and detailed guidance, see `references/design-patterns.md`.
-
-### Claude A/B Testing
-
-Compare skill effectiveness using blind evaluation (source: Anthropic Blog Post):
-
-1. Run the same prompt through Agent A (with skill) and Agent B (without skill)
-2. Each agent uses a clean context — no accumulated state between tests
-3. A comparator agent judges outputs without knowing which is which
-4. Track token usage, timing, and quality metrics independently
-5. Run enough evals to separate signal from noise — a single run proves nothing; report the actual pass/fail counts
-
-For detailed setup instructions, see `references/evaluation-guide.md`.
-
-### Claude's Perspective
-
-The skill name and description heavily influence when Claude activates it. Pay particular attention to:
-
-- **Name**: Reflects the domain in clear hyphen-case (e.g., `git-operations`, `elixir-phoenix`)
-- **Description**: States both what the skill does and when to use it, in third person
-
-> **Critical**: The `description` is the ONLY text Claude sees during skill discovery (Level 1).
-> The body's "When to Use" section only loads AFTER activation (Level 2) and cannot trigger it.
-> All activation triggers must be in the description using patterns like "Use when [scenarios]".
-
-**Description optimization** (source: Anthropic Blog Post):
-- **False positives**: Description too broad — add domain-specific terms
-- **False negatives**: Description too narrow — add synonyms and trigger scenarios
-- Activation-rate targets and eval prompt counts live in `/claude-code:claude-skills-benchmark` ("Description Optimization" and "Writing Evals")
-
-Monitor real usage patterns and iterate based on actual behavior.
-
-### Platform Constraints
-
-Skills run in different environments with different capabilities (source: Anthropic PDF Guide):
-
-| Platform | Script Execution | Network | Filesystem |
-|----------|-----------------|---------|------------|
-| Claude Code (CLI) | Full Bash access | Available | Full access |
-| Claude.ai (Web) | Sandbox only | Limited | Limited |
-| API | Tool-dependent | Tool-dependent | Tool-dependent |
-| Mobile | None | None | Read-only |
-
-Document which platform features each skill requires. Never assume external API availability.
-
-### Iterate Collaboratively
-
-Work with Claude to capture successful approaches and common mistakes into reusable skill components. Ask Claude to self-reflect on what contextual information actually matters.
-
-### Write for AI Consumption
-
-Use clear, imperative language that Claude can follow:
-
-- "Follow the Conventional Commits specification"
-- "Use descriptive branch names with type prefixes"
-- "Run tests before committing"
-
-Include concrete examples wherever possible to illustrate patterns and approaches.
-
-### Security Considerations
-
-Install skills only from trusted sources. When evaluating unfamiliar skills:
-- Thoroughly audit bundled files and scripts
-- Review code dependencies
-- Examine instructions directing Claude to connect with external services
-- Verify the skill doesn't request sensitive information or dangerous operations
-
-### Disclosure Discipline for Public Repositories
+### Disclosure discipline for public repositories
 
 Skill content ships to public repositories; secret *references* disclose infrastructure even when no credential leaks, and secret scanners do not catch them. In every SKILL.md, reference, and template:
 
@@ -401,24 +166,19 @@ Skill content ships to public repositories; secret *references* disclose infrast
 
 Enforce with a repo lint in CI where available (this marketplace runs `mise test:disclosure`).
 
-## Anti-Fabrication Requirements
+## Anti-fabrication requirements
 
 Every SKILL.md must include anti-fabrication rules — either inline or by referencing `core:anti-fabrication`. The authoritative rules (evidence-based claims via tool execution, no superlatives, no unsubstantiated metrics, no unmeasured time estimates, explicit uncertainty markers) live in the `core:anti-fabrication` skill; skill-creation-specific guidance is in `references/anti-fabrication.md`.
 
-## Skill Examples
-
-For annotated examples of simple and complex skills with category classifications, see `references/examples.md`.
-
-## Common Pitfalls
-
-For common mistakes and how to avoid them, see `references/examples.md`.
-
 ## References
 
+Annotated examples of simple and complex skills, category classifications, and common pitfalls are in `references/examples.md`.
+
+```
 claude-skills/
 ├── references/
-│   ├── design-patterns.md    # Degree of freedom, validation loops, conditional workflows
-│   ├── evaluation-guide.md   # Eval-driven development, A/B testing, multi-model testing
+│   ├── design-patterns.md    # Degree of freedom, platform matrix, script execution, reference structure
+│   ├── evaluation-guide.md   # Eval-driven development, A/B testing, description optimization
 │   ├── anti-fabrication.md   # Skill-creation-specific anti-fab guidance
 │   ├── context-engineering-claude-5.md  # What changed for Claude 5 generation models
 │   ├── frontmatter-fields.md # Full upstream frontmatter reference
@@ -430,6 +190,7 @@ claude-skills/
     ├── level2.md                # Example skill body
     ├── level3.md                # Example skill folder structure
     └── skill.md                 # Example basic skill
+```
 
 For more information:
 - **Agent Skills Blog**: https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills

--- a/plugins/tools/claude-code/skills/claude-skills/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-skills/SKILL.md
@@ -35,7 +35,7 @@ skill-name/
 
 Source: [Claude Code Skills documentation](https://code.claude.com/docs/en/skills#frontmatter-reference). All fields are optional; only `description` is recommended.
 
-- `name`: Display name. Defaults to the directory name if omitted. Lowercase letters, numbers, and hyphens only (max 64 characters).
+- `name`: Display name. Defaults to the directory name if omitted. Lowercase letters, numbers, and hyphens only (max 64 characters). Reflect the domain in clear hyphen-case — `git-operations`, `elixir-phoenix`.
 - `description` (recommended): What the skill does and when to use it. Two distinct limits apply: Claude Code truncates the combined `description` + `when_to_use` at 1,536 characters in the skill listing — put the key use case first — and this marketplace enforces a stricter 1024-character cap on `description` in `test/validate-skills-quality.nu`.
 - `when_to_use`: Additional trigger phrases or example requests, appended to `description` in the listing.
 - `license`: License name or filename reference.
@@ -129,9 +129,9 @@ Disable shell injection across user/project/plugin skills via `"disableSkillShel
 2. **Decide what each resource is for** — `scripts/` for deterministic work that would otherwise be rewritten each time, `references/` for material loaded on demand, `assets/` for output templates that never enter context.
 3. **Create the directory**, with its name matching the `name` property exactly.
 4. **Write the body in imperative form.** Keep procedure in `SKILL.md`, detail in references.
-5. **Record every source** in the plugin's `sources.md` — URL, what was taken from it, and why. This is what makes a claim auditable later.
+5. **Record every source** in the plugin's `sources.md` — URL, what was taken from it, why, and the date accessed where currency matters. This is what makes a claim auditable later.
 6. **Validate before publishing.** Write eval prompts that should and should not activate the skill, run them, record actual pass/fail counts, and confirm references load when needed. Full methodology in `references/evaluation-guide.md`.
-7. **Iterate on evidence.** Optimize the description against observed false positives and negatives, and test across Haiku, Sonnet, and Opus. If the base model passes the evals with the skill unloaded, the skill is unnecessary — deprecate it.
+7. **Iterate on evidence.** Optimize the description against observed false positives and negatives, and test across Haiku, Sonnet, and Opus. Capture approaches that worked and mistakes that recurred back into the skill, asking Claude which context actually changed its behavior. If the base model passes the evals with the skill unloaded, the skill is unnecessary — deprecate it.
 
 Write the evals before the content, and compare output with the skill loaded against output without it. Measure pass rates and token usage rather than judging quality subjectively; a single run proves nothing. `references/evaluation-guide.md` covers eval-driven development and blind A/B comparison, and `templates/evaluation-checklist.md` is a copyable checklist.
 

--- a/plugins/tools/claude-code/skills/claude-skills/references/design-patterns.md
+++ b/plugins/tools/claude-code/skills/claude-skills/references/design-patterns.md
@@ -9,6 +9,8 @@
 - [Checklist-Based Workflows](#checklist-based-workflows)
 - [Conditional Workflows](#conditional-workflows)
 - [Script Execution vs Reading](#script-execution-vs-reading)
+  - [Platform Considerations](#platform-considerations)
+  - [Reference File Structure](#reference-file-structure)
 - [Self-Documenting Constants](#self-documenting-constants)
 - [Visual Analysis Pattern](#visual-analysis-pattern)
 
@@ -173,12 +175,25 @@ Skills can include scripts, but Claude interacts with them differently depending
 
 ### Platform Considerations
 
-- **Claude Code (CLI)**: Full Bash access, can execute scripts directly
-- **Claude.ai (Web)**: Code execution sandbox, limited filesystem
-- **API**: Depends on tool configuration; may not have shell access
-- **Mobile**: Read-only; no script execution
+Skills run in environments with different capabilities (source: Anthropic PDF Guide):
 
-Document which mode each script supports in the skill's SKILL.md.
+| Platform | Script Execution | Network | Filesystem |
+|----------|-----------------|---------|------------|
+| Claude Code (CLI) | Full Bash access | Available | Full access |
+| Claude.ai (Web) | Sandbox only | Limited | Limited |
+| API | Tool-dependent | Tool-dependent | Tool-dependent |
+| Mobile | None | None | Read-only |
+
+Document which platform features a skill requires, and which mode each bundled script supports.
+Never assume external API availability.
+
+### Reference File Structure
+
+- Keep references **one level deep** — SKILL.md cites a reference; a reference never cites another.
+- Give a reference a Table of Contents when a reader would jump to a section rather than read it
+  straight through.
+- Separate mutually exclusive material into different files so a reader loads only one of them;
+  keep commonly co-used material together in one.
 
 ## Self-Documenting Constants
 

--- a/test/quality-baseline.json
+++ b/test/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Ratchet baseline for test/validate-skills-quality.nu. Each allowed_failures entry is a record: key (plugin/skill:check; corpus-wide duplicate groups use dupe/<md5-8 of the sorted member file set>:duplicate_block — the validator prints each group's member paths; syntax-vs-usage vocabulary findings use syntax/<format>:vocab_disjoint for the formats commands/agents/hooks — the validator prints both vocabularies), class (BUG | DEBT | CHECK_DEFECT — CHECK_DEFECT means the check itself is defective; the entry's issue field names the tracker item for the check fix), issue (tracker id the waiver is filed under), first_seen (ISO date, or the literal 'migrated' for entries predating the schema), detail_count (integer for detail-producing checks: lines/links/orphans/invocations/version_pin/ref_depth/duplicate_block/vocab_disjoint; null otherwise). Entries are pre-existing failures allowed to keep failing at their recorded count. Do not add entries for new code; fix the skill instead. When a fix lands or a count drops, the validator requires shrinking the baseline. Regenerate: nu test/validate-skills-quality.nu --update-baseline (shrink-only — removes fixed keys and lowers counts; errors instead of adding keys, never raises a count). Known residual: the ratchet bounds the NUMBER of findings per waived check, not their identity, so a same-commit swap of one finding for another of equal size passes.",
+  "_comment": "Ratchet baseline for test/validate-skills-quality.nu. Each allowed_failures entry is a record: key (plugin/skill:check; corpus-wide duplicate groups use dupe/<md5-8 of the sorted member file set>:duplicate_block — the validator prints each group's member paths; syntax-vs-usage vocabulary findings use syntax/<format>:vocab_disjoint for the formats commands/agents/hooks — the validator prints both vocabularies), class (BUG | DEBT | CHECK_DEFECT — CHECK_DEFECT means the check itself is defective; the entry's issue field names the tracker item for the check fix), issue (tracker id the waiver is filed under), first_seen (ISO date, or the literal 'migrated' for entries predating the schema), detail_count (integer for detail-producing checks: lines/links/orphans/invocations/version_pin/ref_depth/duplicate_block/vocab_disjoint/fm_schema; null otherwise). Entries are pre-existing failures allowed to keep failing at their recorded count. Do not add entries for new code; fix the skill instead. When a fix lands or a count drops, the validator requires shrinking the baseline. Regenerate: nu test/validate-skills-quality.nu --update-baseline (shrink-only — removes fixed keys and lowers counts; errors instead of adding keys, never raises a count). Known residual: the ratchet bounds the NUMBER of findings per waived check, not their identity, so a same-commit swap of one finding for another of equal size passes.",
   "allowed_failures": [
     {
       "key": "agent-sandboxing/agent-substrate-overview:examples",
@@ -224,13 +224,6 @@
       "issue": "claude-skills-149",
       "first_seen": "2026-07-26",
       "detail_count": 2
-    },
-    {
-      "key": "dupe/ccc3a496:duplicate_block",
-      "class": "DEBT",
-      "issue": "claude-skills-149",
-      "first_seen": "2026-07-26",
-      "detail_count": 7
     },
     {
       "key": "dupe/da5499df:duplicate_block",


### PR DESCRIPTION
First of two PRs for claude-skills-128. This one reshapes `claude-skills` — the bee's stated priority, because it loads whenever anyone authors a skill, so its bloat costs on every activation. **441 → 202 lines**, against in-repo exemplars `claude-teams` (96 lines / 4 refs) and `claude-workflows` (114 / 3). `plugin-marketplace` and `claude-plugins` share a different pattern — their validation-error catalogs re-teach what the scripts already report precisely — and follow in PR 2. The bee stays open until both land.

**Shape, not line count.** The bee says explicitly *do not close this on line count alone*: the 500-line cap program already brought every skill under cap, and that is a different property. What the body keeps is decision-shaped or enforcement-bearing — the pre-edit checklist mapping each rule to its validator check, this marketplace's `allowed-tools` policy and why, the frontmatter schema, the load-time substitution gotchas, the compaction budget, disclosure discipline, the five-tier rule. What left is look-it-up material with a reference that already covers it better.

**Deleted where a reference genuinely covers it** — each replaced by a pointer that carries the decision, not a bare see-also:

| Cut | Now covered by |
|---|---|
| Evaluation-Driven Development, 11 lines | `references/evaluation-guide.md` |
| Degree of Freedom, 10 lines | `references/design-patterns.md` "Degree of Freedom Framework" — adds a spectrum table and worked too-rigid/too-loose examples |
| Claude A/B Testing, 11 lines | `references/evaluation-guide.md` "Claude A/B Testing" — same procedure plus "What to Compare" |
| Second copy of the Level-1 description callout | the copy kept in Frontmatter |
| Description-optimization mechanics | `references/evaluation-guide.md` "Description Optimization" |

**Compressed:** the seven-step workflow (77 lines → 7 numbered lines; its worked git-skill example and `mkdir -p my-skill/{...}` constrained rather than informed), the three nested headings that restated progressive disclosure three times (35 → 12), skill structure (two code blocks → one), and Structure for Scale / Write for AI Consumption / Security, which restated the checklist or each other. Iterate Collaboratively was folded into the workflow's iteration step rather than dropped — Gate 3 correctly flagged that it restated nothing else, so calling it redundant would have been false.

**Moved into `references/design-patterns.md`:** the platform-capability table, which joins a partial "Platform Considerations" there that previously covered only the script-execution column — the split is now consolidated. Reference-file structure rules (one level deep, TOC, mutual exclusion) moved alongside.

**Kept in the body deliberately:** the auto-compaction figures (5,000 tokens per skill / 25,000 combined, most-recently-invoked first) appear in no reference and change how an author sizes a skill. Security stays because it covers auditing third-party skills before install, which `/core:security` does not.

**The substitution section is byte-identical and was never edited.** Lines documenting shell injection and `$`-placeholders execute and expand at load time; their `KEY=` and backslash markers are load-bearing. Verified **heading-anchored, not line-anchored** — the section shifted up by 68 lines, and `git diff` has no line-range mode — by extracting from `## Dynamic context and substitutions` to the next real heading in both `origin/main` and the branch and comparing: identical. A whole-file grep confirms every injection trigger and substitution placeholder in the file still sits inside that one section, so no load-verification round is required.

**Waivers 68 → 67.** The `duplicate_block` group `dupe/ccc3a496` (root CLAUDE.md vs this SKILL.md, 7 shared windows) is **gone** — the duplicated best-practices prose was the shared text. Baseline shrunk via `--update-baseline`. claude-skills-149 stays open; four of its five groups remain.

**Two review corrections worth recording.** The plan asserted the `## References` tree kept `orphans` green. It does not: `find-orphan-files` requires a literal `references/<basename>` token, and its own self-test asserts a bare basename fails — the tree lists bare basenames. The citations actually holding the check up were prose, and **five of them lived in sections this PR deletes**. All 7 references now carry a resolvable citation in the new prose, verified against `ls references/*.md` rather than against the grep that produced the edit. The plan also called the Evaluation-Driven Development block "duplicated verbatim"; it is not — the reference's five steps are a different five, and "measure, don't guess … not subjective quality" existed only in the body, so its pointer carries that clause.

Fence-aware measurement mattered twice here: the first extraction of the protected section stopped at `## Current diff` **inside** a five-backtick fence, which would have spliced only 20 of its 43 lines.

`mise test` exit 0, gitleaks clean, 202/500 lines, score 17/17.

**Gate 3 corrections applied in `3e29310`.** The review's deletion audit found four items that existed nowhere afterward. Three are restored as clauses: the name-reflects-the-domain guidance with its `git-operations` example, "date accessed" in the sources record, and the iteration-capture sentence above. The fourth — "the content section has no structural restrictions" — is deliberately not restored: it states an absence of rules and gives an author nothing to act on. Two figures in this description were wrong and are corrected above (the section shifted 68 lines, not ~120; the workflow is 7 numbered steps, not 9).
