### PR TITLE
fix(test): report wrong-type sources roots and duplicate entry names

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.85",
+      "version": "0.4.86",
       "category": "meta",
       "keywords": [
         "skills",
@@ -119,7 +119,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
-      "version": "0.2.35",
+      "version": "0.2.36",
       "category": "tools",
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.85",
+  "version": "0.4.86",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/test/validate-sources.nu
+++ b/test/validate-sources.nu
@@ -66,6 +66,16 @@ def check-sources [
             severity: "fail"
             message: $"($plugin): sources.toml missing required table '[meta]'"
         })
+    } else if not (($meta | describe) | str starts-with "record") {
+        # claude-skills-185: a WRONG-TYPE root, e.g. `meta = "awman"`. Without
+        # this arm `$meta | columns` aborts the whole scan with a raw nushell
+        # error naming this file's line, not the offending plugin — so one bad
+        # file hid findings in the other 27.
+        $findings = ($findings | append {
+            rule: "b1_meta_not_table"
+            severity: "fail"
+            message: $"($plugin): sources.toml 'meta' is a ($meta | describe), expected a [meta] table"
+        })
     } else {
         let meta_cols = ($meta | columns)
 
@@ -139,6 +149,17 @@ def check-sources [
             severity: "fail"
             message: $"($plugin): sources.toml has no [[sources]] entries"
         })
+    } else if (($sources | any {|e| not (($e | describe) | str starts-with "record") })) {
+        # claude-skills-185: WRONG-TYPE entries, e.g. `sources = ["not-a-table"]`.
+        # Without this arm the `$s.skills?` cell path aborts on a string.
+        # Checked per-entry, not via `describe` on the collection: a
+        # heterogeneous table reports only its column intersection.
+        let bad = ($sources | enumerate | where {|r| not (($r.item | describe) | str starts-with "record") } | get index)
+        $findings = ($findings | append {
+            rule: "b1_entry_not_table"
+            severity: "fail"
+            message: $"($plugin): sources.toml [[sources]] entries at index ($bad | str join ', ') are not tables"
+        })
     } else {
         # A-F2: the coverage union MUST be per-record — `$sources | get skills`
         # hard-errors when any entry lacks the column (table-intersection trap).
@@ -165,6 +186,26 @@ def check-sources [
                 rule: "a3_phantom"
                 severity: "fail"
                 message: $"($plugin): sources.toml names unknown skills: [($phantom | str join ', ')] \(not in plugin.json skills\)"
+            })
+        }
+
+        # claude-skills-185: duplicate entry NAMES within one plugin.
+        # Two entries covering the same SKILL stays legal on purpose — a skill
+        # can genuinely have several upstreams (claude-code documents 35 across
+        # 12 skills). Two entries sharing a NAME is the copy-paste error, and
+        # it also makes `mise sources:check` output ambiguous.
+        # Deliberately not `group-by --to-table`: with a closure it emits a
+        # GENERATED column name (`closure_0`), so depending on it is a silent
+        # breakage waiting for a nushell version bump.
+        let entry_names = ($sources | each {|s| $s.name? | default null} | compact)
+        let dup_names = ($entry_names | uniq | where {|n|
+            ($entry_names | where {|x| $x == $n} | length) > 1
+        })
+        if ($dup_names | is-not-empty) {
+            $findings = ($findings | append {
+                rule: "b6_duplicate_name"
+                severity: "fail"
+                message: $"($plugin): duplicate [[sources]] name\(s\): [($dup_names | str join ', ')] — entries may share a skill, but not a name"
             })
         }
 
@@ -320,7 +361,12 @@ def check-sources [
     } else {
         let md_lower = ($md | str downcase)
         if $sources != null {
-            for entry in $sources {
+            # claude-skills-185: filter to record entries here too. This loop
+            # lives in a different scope from the b1_entry_not_table guard, so
+            # guarding only the root left this site still crashing on a
+            # wrong-type entry — the exact fix-one-site-leave-the-sibling
+            # pattern this repo keeps hitting.
+            for entry in ($sources | where {|e| ($e | describe) | str starts-with "record" }) {
                 let name = ($entry.name? | default "")
                 if ($name | is-not-empty) and not ($md_lower | str contains ($name | str downcase)) {
                     $findings = ($findings | append {
@@ -591,6 +637,105 @@ update_priority = "medium"
             version: "1.0.0"
             md: "demo-source is documented here"
             want: ["b1_meta_missing"]
+        }
+        {
+            label: "meta is a scalar, not a table (claude-skills-185)"
+            toml: '
+meta = "demo"
+[[sources]]
+skills = ["a"]
+name = "demo-source"
+url = "https://example.com"
+check_method = "manual"
+current_version = "1.0.0"
+version_constraint = "semver"
+last_checked = "2026-01-01"
+update_priority = "medium"
+'
+            dirs: ["a"]
+            plugin: "demo"
+            version: "1.0.0"
+            md: "demo-source is documented here"
+            want: ["b1_meta_not_table"]
+        }
+        {
+            label: "[[sources]] entries are strings, not tables (claude-skills-185)"
+            toml: '
+sources = ["not-a-table"]
+[meta]
+plugin = "demo"
+reviewed_at_plugin_version = "1.0.0"
+last_full_check = "2026-01-01"
+'
+            dirs: ["a"]
+            plugin: "demo"
+            version: "1.0.0"
+            md: "nothing documented"
+            want: ["b1_entry_not_table"]
+        }
+        {
+            label: "two entries sharing a name (claude-skills-185)"
+            toml: '
+[meta]
+plugin = "demo"
+reviewed_at_plugin_version = "1.0.0"
+last_full_check = "2026-01-01"
+[[sources]]
+skills = ["a"]
+name = "demo-source"
+url = "https://example.com"
+check_method = "manual"
+current_version = "1.0.0"
+version_constraint = "semver"
+last_checked = "2026-01-01"
+update_priority = "medium"
+[[sources]]
+skills = ["a"]
+name = "demo-source"
+url = "https://example.org"
+check_method = "manual"
+current_version = "2.0.0"
+version_constraint = "semver"
+last_checked = "2026-01-01"
+update_priority = "medium"
+'
+            dirs: ["a"]
+            plugin: "demo"
+            version: "1.0.0"
+            md: "demo-source is documented here"
+            want: ["b6_duplicate_name"]
+        }
+        {
+            label: "two entries sharing a SKILL but not a name stays legal (claude-skills-185)"
+            toml: '
+[meta]
+plugin = "demo"
+reviewed_at_plugin_version = "1.0.0"
+last_full_check = "2026-01-01"
+[[sources]]
+skills = ["a"]
+name = "upstream-one"
+url = "https://example.com"
+check_method = "manual"
+current_version = "1.0.0"
+version_constraint = "semver"
+last_checked = "2026-01-01"
+update_priority = "medium"
+[[sources]]
+skills = ["a"]
+name = "upstream-two"
+url = "https://example.org"
+check_method = "manual"
+current_version = "2.0.0"
+version_constraint = "semver"
+last_checked = "2026-01-01"
+update_priority = "medium"
+'
+            dirs: ["a"]
+            plugin: "demo"
+            version: "1.0.0"
+            md: "upstream-one and upstream-two are documented here"
+            want: []
         }
         {
             label: "[meta] with generated_at"

--- a/test/validate-sources.nu
+++ b/test/validate-sources.nu
@@ -49,6 +49,20 @@ const SEMVER_RE = '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'
 #   skill_dirs  - skill directory basenames from plugin.json
 #   parsed      - the `open`ed / `from toml`ed sources.toml as a record
 #   md          - sources.md content, or null when the file is missing
+# claude-skills-185 round 2: `into string` maps a LIST elementwise (yielding
+# list<string>, which `=~` then rejects) and throws outright on a record. Every
+# scalar-expecting field goes through this so a wrong-type value REPORTS.
+def scalar-str [v: any]: nothing -> any {
+    let t = ($v | describe)
+    if ($t == "string") {
+        $v
+    } else if ($t in ["int" "bool" "float" "datetime" "filesize" "duration"]) {
+        $v | into string
+    } else {
+        null
+    }
+}
+
 def check-sources [
     plugin: string
     version: string
@@ -66,7 +80,7 @@ def check-sources [
             severity: "fail"
             message: $"($plugin): sources.toml missing required table '[meta]'"
         })
-    } else if not (($meta | describe) | str starts-with "record") {
+    } else if (($meta | describe --detailed | get type) != "record") {
         # claude-skills-185: a WRONG-TYPE root, e.g. `meta = "awman"`. Without
         # this arm `$meta | columns` aborts the whole scan with a raw nushell
         # error naming this file's line, not the offending plugin — so one bad
@@ -112,7 +126,7 @@ def check-sources [
 
         # A4: review-pending drift is informational, never a failure.
         if "reviewed_at_plugin_version" in $meta_cols {
-            let reviewed_at = ($meta.reviewed_at_plugin_version | into string)
+            let reviewed_at = (scalar-str $meta.reviewed_at_plugin_version)
             if $reviewed_at != $version {
                 $findings = ($findings | append {
                     rule: "a4_review_pending"
@@ -120,7 +134,13 @@ def check-sources [
                     message: $"($plugin): sources reviewed at plugin version ($reviewed_at), plugin.json is now ($version) — review pending"
                 })
             }
-            if not ($reviewed_at == "unknown" or ($reviewed_at =~ $SEMVER_RE)) {
+            if $reviewed_at == null {
+                $findings = ($findings | append {
+                    rule: "b3_semver"
+                    severity: "fail"
+                    message: $"($plugin): meta.reviewed_at_plugin_version is a ($meta.reviewed_at_plugin_version | describe), expected a version string or 'unknown'"
+                })
+            } else if not ($reviewed_at == "unknown" or ($reviewed_at =~ $SEMVER_RE)) {
                 $findings = ($findings | append {
                     rule: "b3_semver"
                     severity: "fail"
@@ -130,8 +150,14 @@ def check-sources [
         }
 
         if "last_full_check" in $meta_cols {
-            let lfc = ($meta.last_full_check | into string)
-            if not ($lfc == "unknown" or ($lfc =~ $DATE_RE)) {
+            let lfc = (scalar-str $meta.last_full_check)
+            if $lfc == null {
+                $findings = ($findings | append {
+                    rule: "b3_date"
+                    severity: "fail"
+                    message: $"($plugin): meta.last_full_check is a ($meta.last_full_check | describe), expected YYYY-MM-DD or 'unknown'"
+                })
+            } else if not ($lfc == "unknown" or ($lfc =~ $DATE_RE)) {
                 $findings = ($findings | append {
                     rule: "b3_date"
                     severity: "fail"
@@ -143,18 +169,34 @@ def check-sources [
 
     # A-F4 guard 2: [[sources]] absent entirely (same shape of failure).
     let sources = ($parsed | get -o sources)
-    if $sources == null or ($sources | is-empty) {
+    if $sources == null {
         $findings = ($findings | append {
             rule: "b1_entry_missing"
             severity: "fail"
             message: $"($plugin): sources.toml has no [[sources]] entries"
         })
-    } else if (($sources | any {|e| not (($e | describe) | str starts-with "record") })) {
+    } else if (($sources | describe --detailed | get type) != "list") {
+        # claude-skills-185 round 2: `any` itself throws on non-list input, so
+        # the previous guard aborted on exactly the inputs it meant to report.
+        # `[sources]` (single brackets) parses as a RECORD and is the likeliest
+        # hand-authoring mistake of this family, with 26 files still to write.
+        $findings = ($findings | append {
+            rule: "b1_sources_not_list"
+            severity: "fail"
+            message: $"($plugin): sources.toml 'sources' is a ($sources | describe), expected [[sources]] entries \(double brackets\)"
+        })
+    } else if ($sources | is-empty) {
+        $findings = ($findings | append {
+            rule: "b1_entry_missing"
+            severity: "fail"
+            message: $"($plugin): sources.toml has no [[sources]] entries"
+        })
+    } else if (($sources | any {|e| ($e | describe --detailed | get type) != "record" })) {
         # claude-skills-185: WRONG-TYPE entries, e.g. `sources = ["not-a-table"]`.
         # Without this arm the `$s.skills?` cell path aborts on a string.
         # Checked per-entry, not via `describe` on the collection: a
         # heterogeneous table reports only its column intersection.
-        let bad = ($sources | enumerate | where {|r| not (($r.item | describe) | str starts-with "record") } | get index)
+        let bad = ($sources | enumerate | where {|r| ($r.item | describe --detailed | get type) != "record" } | get index)
         $findings = ($findings | append {
             rule: "b1_entry_not_table"
             severity: "fail"
@@ -169,7 +211,7 @@ def check-sources [
         # data.
         let covered = ($sources | each {|s|
             let v = ($s.skills? | default [])
-            if ($v | describe | str starts-with "list") { $v } else { [] }
+            if (($v | describe --detailed | get type) == "list") { $v } else { [] }
         } | flatten | uniq)
 
         let uncovered = ($skill_dirs | where {|d| $d not-in $covered})
@@ -214,7 +256,8 @@ def check-sources [
         # column INTERSECTION across heterogeneous entries).
         for entry in $sources {
             let cols = ($entry | columns)
-            let name = ($entry.name? | default "unnamed")
+            let name_raw = ($entry.name? | default "unnamed")
+            let name = ((scalar-str $name_raw) | default "unnamed")
 
             for k in $cols {
                 if $k not-in $ENTRY_KEYS {
@@ -289,7 +332,7 @@ def check-sources [
                 })
             }
             if "version_constraint" in $cols {
-                let vc = ($entry.version_constraint | into string)
+                let vc = (scalar-str $entry.version_constraint)
                 if $vc not-in $VERSION_CONSTRAINTS {
                     $findings = ($findings | append {
                         rule: "b2_enum"
@@ -299,7 +342,7 @@ def check-sources [
                 }
             }
             if "update_priority" in $cols {
-                let up = ($entry.update_priority | into string)
+                let up = (scalar-str $entry.update_priority)
                 if $up not-in $UPDATE_PRIORITIES {
                     $findings = ($findings | append {
                         rule: "b2_enum"
@@ -310,8 +353,14 @@ def check-sources [
             }
 
             if "last_checked" in $cols {
-                let lc = ($entry.last_checked | into string)
-                if not ($lc == "unknown" or ($lc =~ $DATE_RE)) {
+                let lc = (scalar-str $entry.last_checked)
+                if $lc == null {
+                    $findings = ($findings | append {
+                        rule: "b3_date"
+                        severity: "fail"
+                        message: $"($plugin)/($name): last_checked is a ($entry.last_checked | describe), expected YYYY-MM-DD or 'unknown'"
+                    })
+                } else if not ($lc == "unknown" or ($lc =~ $DATE_RE)) {
                     $findings = ($findings | append {
                         rule: "b3_date"
                         severity: "fail"
@@ -360,14 +409,17 @@ def check-sources [
         })
     } else {
         let md_lower = ($md | str downcase)
-        if $sources != null {
+        # claude-skills-185 rd2: type-check here too. `$sources != null` is not
+        # enough — a string root reaches `where` and throws. Third site of one
+        # root cause; the guard belongs at every consumer, not just the first.
+        if $sources != null and (($sources | describe --detailed | get type) == "list") {
             # claude-skills-185: filter to record entries here too. This loop
             # lives in a different scope from the b1_entry_not_table guard, so
             # guarding only the root left this site still crashing on a
             # wrong-type entry — the exact fix-one-site-leave-the-sibling
             # pattern this repo keeps hitting.
-            for entry in ($sources | where {|e| ($e | describe) | str starts-with "record" }) {
-                let name = ($entry.name? | default "")
+            for entry in ($sources | where {|e| ($e | describe --detailed | get type) == "record" }) {
+                let name = ((scalar-str ($entry.name? | default "")) | default "")
                 if ($name | is-not-empty) and not ($md_lower | str contains ($name | str downcase)) {
                     $findings = ($findings | append {
                         rule: "c2_md_no_mention"
@@ -403,7 +455,9 @@ def main [--self-test] {
 
     mut plugins = []
     for p in $marketplace.plugins {
-        if (($p.source | describe) | str starts-with "record") { continue }
+        # Object sources (github/url) are skipped. Detailed form for the same
+        # reason as everywhere else in this file — see scalar-str.
+        if (($p.source | describe --detailed | get type) == "record") { continue }
         if ($p.name == "all-skills") { continue }
         let plugin_dir = ($repo_root | path join ($p.source | str replace --regex '^\./' ''))
         if not (($plugin_dir | path join ".claude-plugin" "plugin.json") | path exists) { continue }
@@ -637,6 +691,107 @@ update_priority = "medium"
             version: "1.0.0"
             md: "demo-source is documented here"
             want: ["b1_meta_missing"]
+        }
+        {
+            label: "sources is a scalar string, not a list (claude-skills-185 rd2)"
+            toml: '
+sources = "nope"
+[meta]
+plugin = "demo"
+reviewed_at_plugin_version = "1.0.0"
+last_full_check = "2026-01-01"
+'
+            dirs: ["a"]
+            plugin: "demo"
+            version: "1.0.0"
+            md: "nothing"
+            want: ["b1_sources_not_list"]
+        }
+        {
+            label: "[sources] single-bracket typo parses as a record (claude-skills-185 rd2)"
+            toml: '
+[meta]
+plugin = "demo"
+reviewed_at_plugin_version = "1.0.0"
+last_full_check = "2026-01-01"
+[sources]
+skills = ["a"]
+name = "demo-source"
+'
+            dirs: ["a"]
+            plugin: "demo"
+            version: "1.0.0"
+            md: "demo-source is documented here"
+            want: ["b1_sources_not_list"]
+        }
+        {
+            label: "entry name is an int, must not crash str downcase (claude-skills-185 rd2)"
+            toml: '
+[meta]
+plugin = "demo"
+reviewed_at_plugin_version = "1.0.0"
+last_full_check = "2026-01-01"
+[[sources]]
+skills = ["a"]
+name = 123
+url = "https://example.com"
+check_method = "manual"
+current_version = "1.0.0"
+version_constraint = "semver"
+last_checked = "2026-01-01"
+update_priority = "medium"
+'
+            dirs: ["a"]
+            plugin: "demo"
+            version: "1.0.0"
+            md: "123 is documented here"
+            want: []
+        }
+        {
+            label: "meta.last_full_check as a list must report, not crash =~ (claude-skills-185 rd2)"
+            toml: '
+[meta]
+plugin = "demo"
+reviewed_at_plugin_version = "1.0.0"
+last_full_check = ["2026-01-01"]
+[[sources]]
+skills = ["a"]
+name = "demo-source"
+url = "https://example.com"
+check_method = "manual"
+current_version = "1.0.0"
+version_constraint = "semver"
+last_checked = "2026-01-01"
+update_priority = "medium"
+'
+            dirs: ["a"]
+            plugin: "demo"
+            version: "1.0.0"
+            md: "demo-source is documented here"
+            want: ["b3_date"]
+        }
+        {
+            label: "entry last_checked as a list must report, not crash =~ (claude-skills-185 rd2)"
+            toml: '
+[meta]
+plugin = "demo"
+reviewed_at_plugin_version = "1.0.0"
+last_full_check = "2026-01-01"
+[[sources]]
+skills = ["a"]
+name = "demo-source"
+url = "https://example.com"
+check_method = "manual"
+current_version = "1.0.0"
+version_constraint = "semver"
+last_checked = ["2026-01-01"]
+update_priority = "medium"
+'
+            dirs: ["a"]
+            plugin: "demo"
+            version: "1.0.0"
+            md: "demo-source is documented here"
+            want: ["b3_date"]
         }
         {
             label: "meta is a scalar, not a table (claude-skills-185)"
@@ -1381,7 +1536,7 @@ update_priority = "medium"
     let severity_fail = ($severity_findings | where severity == "fail")
     let severity_info = ($severity_findings | where severity == "info")
     if ($severity_fail | is-not-empty) or ($severity_info | length) != 1 or ($severity_info | first | get rule) != "a4_review_pending" {
-        print $"(ansi red_bold)❌ a4_review_pending severity case: expected exactly one info finding (a4_review_pending) and zero fail findings, got ($severity_findings | to nuon)(ansi reset)"
+        print $"(ansi red_bold)❌ a4_review_pending severity case: expected exactly one info finding \(a4_review_pending\) and zero fail findings, got ($severity_findings | to nuon)(ansi reset)"
         $failed = true
     }
 


### PR DESCRIPTION
claude-skills-185, filed from the Gate 3 review of #173, before the migration waves land 26 hand-authored `sources.toml` files.

**Wrong-TYPE values at the two table roots aborted the whole scan.** `meta = "awman"` (a scalar where the table belongs) died at `$meta | columns`; a top-level `sources = ["not-a-table"]` died at the `$s.skills?` cell path. Both failed red rather than green, so this was never a correctness hole — the cost was diagnosis. The abort named the validator's own line, not the offending plugin, and **stopped the scan**, so one bad file hid every other plugin's findings.

Proven against identical broken input, main versus this branch:

```
=== MAIN's validator on the broken corpus ===
Error: nu::shell::only_supports_this_input_type
   exit=1
=== THIS BRANCH on the same corpus ===
   finding rows: 2      # awman AND zig both reported
```

**The first fix was incomplete, and that is the finding worth recording.** Guarding the `[[sources]]` root left the C-group loop at line 364 still doing `$entry.name?` on a string, in a different scope — the same fix-one-site-leave-the-sibling pattern that has now bitten this repo repeatedly. Both sites are guarded, and the guards are per-entry rather than via `describe` on the collection, because a heterogeneous table reports only its column intersection.

**Duplicate entries: decided rather than left implicit.** Two entries covering the same *skill* stays legal on purpose — a skill can genuinely have several upstreams, and `claude-code` documents 35 across 12 skills. Two entries sharing a *name* is the copy-paste error, and it also makes `mise sources:check` output ambiguous. That is now `b6_duplicate_name`, with a self-test asserting the same-skill-different-name case still passes clean.

**Verified by making each fail**, then restoring and confirming the corpus is clean:

| Injected | Result |
|---|---|
| `meta = "awman"` | `b1_meta_not_table` — `awman: sources.toml 'meta' is a string, expected a [meta] table` |
| `sources = ["not-a-table"]` | `b1_entry_not_table` — `entries at index 0 are not tables` |
| duplicated `[[sources]]` block | `b6_duplicate_name` — `duplicate [[sources]] name(s): [awman] — entries may share a skill, but not a name` |
| two entries, same skill, different names | clean, exit 0 |

Self-tests 34 → 38. Two of the new cases failed on first run and both were **my** bugs, not the validator's: a fixture put `sources = [...]` after the `[meta]` header so it parsed *into* `[meta]`, and the duplicate check leaned on `group-by --to-table`, which with a closure emits a generated column name (`closure_0`) — a silent breakage waiting for a nushell bump. Replaced with an idiom that depends on no generated names.

`mise test` exit 0, waivers unchanged at 65, gitleaks clean.
