### PR TITLE
feat(sources): author sources.toml for wave A batch 1 (8 single-skill plugins)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.86",
+      "version": "0.4.87",
       "category": "meta",
       "keywords": [
         "skills",
@@ -104,7 +104,7 @@
       "source": "./plugins/tools/beads",
       "strict": true,
       "description": "Beads (bd) distributed git-backed graph issue tracker: task management, dependency tracking, AI agent workflows",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "category": "tools",
       "keywords": [
         "beads",
@@ -278,7 +278,7 @@
       "source": "./plugins/tools/linear",
       "strict": true,
       "description": "Linear project management: MCP/GraphQL API, VantageEx epic authoring, auditing, and grooming",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "category": "tools",
       "keywords": [
         "linear",
@@ -295,7 +295,7 @@
       "source": "./plugins/tools/playwright",
       "strict": true,
       "description": "Playwright MCP browser automation for Claude Code",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "tools",
       "keywords": [
         "playwright",
@@ -330,7 +330,7 @@
       "source": "./plugins/tools/proxmox",
       "strict": true,
       "description": "Operate a Proxmox estate: PVE hypervisor, PBS backups, PDM multi-node management, golden-image builds, and terraform/packer automation",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "tools",
       "keywords": [
         "proxmox",
@@ -349,7 +349,7 @@
       "source": "./plugins/tools/qa",
       "strict": true,
       "description": "QA team that validates a running application against Gherkin user stories using Playwright and Tidewave",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "category": "tools",
       "keywords": [
         "qa",
@@ -367,7 +367,7 @@
       "source": "./plugins/tools/rig",
       "strict": true,
       "description": "Rig (rig-core): building multi-provider and hybrid LLM clients in Rust",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "tools",
       "keywords": [
         "rig",
@@ -416,7 +416,7 @@
       "source": "./plugins/tools/sbx",
       "strict": true,
       "description": "Docker Sandboxes (sbx CLI): run AI coding agents in isolated microVMs with hypervisor-level isolation",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "category": "tools",
       "keywords": [
         "docker",
@@ -469,7 +469,7 @@
       "source": "./plugins/ui",
       "strict": true,
       "description": "UI framework skills: daisyUI components, theming, and responsive design",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "category": "frontend",
       "keywords": [
         "ui",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.86",
+  "version": "0.4.87",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/beads/.claude-plugin/plugin.json
+++ b/plugins/tools/beads/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "beads",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Beads (bd) distributed git-backed graph issue tracker: task management, dependency tracking, AI agent workflows",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/beads/skills/sources.md
+++ b/plugins/tools/beads/skills/sources.md
@@ -2,6 +2,8 @@
 
 Source attribution for skills in the beads plugin.
 
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there.
+
 ## Beads Skill
 
 ### Beads Documentation

--- a/plugins/tools/beads/skills/sources.toml
+++ b/plugins/tools/beads/skills/sources.toml
@@ -1,0 +1,24 @@
+# sources.toml - Machine-readable version tracking for skill dependencies
+# Run `mise sources:check` to compare against the latest upstream release.
+
+[meta]
+plugin = "beads"
+reviewed_at_plugin_version = "0.1.0"
+last_full_check = "2026-07-30"
+
+# ----------------------------------------------------------------------------
+# Beads (bd) — distributed git-backed graph issue tracker (Steve Yegge).
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["beads"]
+name = "beads"
+url = "https://steveyegge.github.io/beads/"
+releases_url = "https://github.com/gastownhall/beads/releases"
+check_method = "github-releases"
+github_repo = "gastownhall/beads"
+current_version = "unknown"
+version_constraint = "semver"
+last_checked = "2026-07-30"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "Repo relocated from steveyegge/beads to gastownhall/beads (HTTP redirect confirmed via GitHub API 2026-07-30, latest tag v1.1.2); sources.md (dated 2026-01-24) predates the move and still cites the old org/URL. Covers CLI commands, storage format (JSONL + SQLite cache), sync modes (full/stealth/contributor), and two VS Code marketplace extensions (planet57.vscode-beads, DavidCForbes.beads-kanban) documented as supplementary context, not tracked as separate sources."

--- a/plugins/tools/linear/.claude-plugin/plugin.json
+++ b/plugins/tools/linear/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "linear",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Linear project management: MCP/GraphQL API, VantageEx epic authoring, auditing, and grooming",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/linear/skills/sources.md
+++ b/plugins/tools/linear/skills/sources.md
@@ -1,5 +1,7 @@
 # Linear Plugin Sources
 
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `linear-api` (the MCP/GraphQL docs below), `internal-vantageex-references` (the Symphony/VantageEx/ADR references below).
+
 ## Linear Skill
 
 ### Linear MCP Documentation

--- a/plugins/tools/linear/skills/sources.toml
+++ b/plugins/tools/linear/skills/sources.toml
@@ -1,0 +1,35 @@
+# sources.toml - Machine-readable version tracking for skill dependencies
+# Run `mise sources:check` to compare against the latest upstream release.
+
+[meta]
+plugin = "linear"
+reviewed_at_plugin_version = "0.1.0"
+last_full_check = "2026-07-30"
+
+# ----------------------------------------------------------------------------
+# Linear's hosted MCP server + GraphQL API — the one true external upstream.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["linear"]
+name = "linear-api"
+url = "https://linear.app/docs/mcp"
+releases_url = "https://developers.linear.app/docs/graphql/working-with-the-graphql-api"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-04-04"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "Linear MCP server (streamable HTTP transport, OAuth 2.1, Claude Code integration) plus the GraphQL API used as fallback for operations the MCP surface doesn't cover (queries, mutations, pagination, introspection). Hosted SaaS API with no versioned release feed to poll — check by hand."
+
+# ----------------------------------------------------------------------------
+# Internal cross-repo references — VantageEx's own Linear client, ADRs, and
+# epic templates that this skill's epic-authoring/audit conventions mirror.
+# No external upstream; these are first-party docs in sibling repositories.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["linear"]
+name = "internal-vantageex-references"
+check_method = "none"
+last_checked = "2026-04-04"
+notes = "First-party cross-repo references, not an external upstream: Symphony's existing Linear GraphQL skill (query patterns), VantageEx's production Linear GraphQL client (vantageex/lib/vantageex/linear/client.ex), ADR-027 (epic messaging: description sections, comment channels), ADR-025 (epic lifecycle/status workflow), ADR-016 (layered epic/issue/task hierarchy), the VantageEx epic authoring guide and epic TEMPLATE.md, and this marketplace's own claude-code CLAUDE.md template (4-phase workflow). These inform the epic-authoring and audit conventions in this skill; provenance narrative stays in sources.md."

--- a/plugins/tools/playwright/.claude-plugin/plugin.json
+++ b/plugins/tools/playwright/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Playwright MCP browser automation for Claude Code",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/playwright/skills/sources.md
+++ b/plugins/tools/playwright/skills/sources.md
@@ -1,5 +1,7 @@
 # Playwright Plugin Sources
 
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there.
+
 ## playwright skill
 
 ### Playwright MCP GitHub Repository
@@ -20,7 +22,6 @@
 
 ## Plugin Information
 - **Name**: playwright
-- **Version**: 0.1.0
 - **Description**: Playwright MCP browser automation for Claude Code
 - **Skills**: 1 skill
 - **Created**: 2026-04-04

--- a/plugins/tools/playwright/skills/sources.toml
+++ b/plugins/tools/playwright/skills/sources.toml
@@ -1,0 +1,26 @@
+# sources.toml - Machine-readable version tracking for skill dependencies
+# Run `mise sources:check` to compare against the latest upstream release.
+
+[meta]
+plugin = "playwright"
+reviewed_at_plugin_version = "0.1.0"
+last_full_check = "2026-07-30"
+
+# ----------------------------------------------------------------------------
+# Playwright MCP (microsoft/playwright-mcp) — distributed via npm as
+# @playwright/mcp. No npm check_method in the schema (github-releases |
+# hex-pm | crates-io | manual | none); tracked manually against the npm
+# registry directly.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["playwright"]
+name = "playwright-mcp"
+url = "https://github.com/microsoft/playwright-mcp"
+releases_url = "https://www.npmjs.com/package/@playwright/mcp"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "pre-1.0"
+last_checked = "2026-07-30"
+update_priority = "medium"
+breaking_changes_likely = true
+notes = "Tracked via the npm registry (@playwright/mcp); schema has no npm check_method, so check by querying the registry directly (https://registry.npmjs.org/@playwright/mcp/latest). Live check 2026-07-30 found v0.0.78 (0.x, pre-1.0); sources.md does not pin a version the skill content was verified against. Covers MCP tool catalog/configuration flags and Claude Code's MCP config patterns (claude mcp add, ~/.claude.json)."

--- a/plugins/tools/proxmox/.claude-plugin/plugin.json
+++ b/plugins/tools/proxmox/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proxmox",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Operate a Proxmox estate: PVE hypervisor, PBS backups, PDM multi-node management, golden-image builds, and terraform/packer automation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/proxmox/skills/sources.md
+++ b/plugins/tools/proxmox/skills/sources.md
@@ -1,5 +1,7 @@
 # Sources
 
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `proxmox-pve`, `proxmox-pdm`, `proxmox-pbs`, `terraform-provider-proxmox`, `internal-infra-repo`.
+
 ## proxmox skill
 
 ### Private infra repo Nushell scripts

--- a/plugins/tools/proxmox/skills/sources.toml
+++ b/plugins/tools/proxmox/skills/sources.toml
@@ -1,0 +1,86 @@
+# sources.toml - Machine-readable version tracking for skill dependencies
+# Run `mise sources:check` to compare against the latest upstream release.
+
+[meta]
+plugin = "proxmox"
+reviewed_at_plugin_version = "0.1.0"
+last_full_check = "2026-07-30"
+
+# ----------------------------------------------------------------------------
+# Proxmox VE — hypervisor wiki docs, company press releases, and the 8->9
+# upgrade path. current_version taken from sources.md's own session-proven
+# text ("both upgraded PVE 8.x -> 9.2.4 / Debian 13.5 the same day").
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["proxmox"]
+name = "proxmox-pve"
+url = "https://pve.proxmox.com/wiki/"
+releases_url = "https://www.proxmox.com/en/about/company-details/press-releases/proxmox-virtual-environment-9-0"
+check_method = "manual"
+current_version = "9.2.4"
+version_constraint = "stable"
+last_checked = "2026-07-13"
+update_priority = "high"
+breaking_changes_likely = true
+notes = "Covers PVE wiki (Package_Repositories, Upgrade_from_8_to_9, Cluster_Manager — HTTP 200 confirmed 2026-07-13) and company press releases (8.4, 9.0). Session-proven 8->9 upgrade blockers (systemd-boot removal, Ceph version gate, grub-efi-amd64/force_efi_extra_removable) were recorded live 2026-07-09 in bees issue claude-skills-112 and are NOT documented in any file in this repo or the private infra repo. Private infra runbook proxmox-upgrade.md is stale as of 2026-07-09 per sources.md — it recommends deferring the 8->9 jump that was actually completed that day."
+
+# ----------------------------------------------------------------------------
+# Proxmox Datacenter Manager (PDM) — multi-node/remote management layer.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["proxmox"]
+name = "proxmox-pdm"
+url = "https://pdm.proxmox.com/docs/"
+releases_url = "https://www.proxmox.com/en/about/company-details/press-releases/proxmox-datacenter-manager-1-1"
+check_method = "manual"
+current_version = "1.1"
+version_constraint = "semver"
+last_checked = "2026-07-13"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "PDM docs (remotes.html, access-control.html: pdm realm, PAM/OIDC/LDAP/AD/2FA) plus press releases (1.0, 1.1) and the private infra runbook proxmox-datacenter-manager.md (auth model, cluster-vs-PDM decision, PBS/PDM version pairing, deployment steps)."
+
+# ----------------------------------------------------------------------------
+# Proxmox Backup Server (PBS) — no specific version documented in sources.md.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["proxmox"]
+name = "proxmox-pbs"
+url = "https://pbs.proxmox.com/docs/"
+releases_url = "https://www.proxmox.com/en/proxmox-backup-server"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "stable"
+last_checked = "2026-07-13"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "PBS docs: introduction/architecture, installation, storage/datastore, PVE integration, maintenance (prune vs. garbage collection), backup client encryption. All pages HTTP-200-verified and content spot-checked with curl 2026-07-13."
+
+# ----------------------------------------------------------------------------
+# bpg/terraform-provider-proxmox — the Terraform provider pinned by the
+# private infra repo's Terraform configs.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["proxmox"]
+name = "terraform-provider-proxmox"
+url = "https://github.com/bpg/terraform-provider-proxmox"
+releases_url = "https://registry.terraform.io/providers/bpg/proxmox/latest/docs"
+check_method = "github-releases"
+github_repo = "bpg/terraform-provider-proxmox"
+current_version = "unknown"
+version_constraint = "semver"
+last_checked = "2026-07-13"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "Confirmed reachable (HTTP 200) 2026-07-13. Pinned by the private infra repo's ~/github/infra/terraform/proxmox/main.tf (two provider blocks, per-node proxmox_virtual_environment_vm.k3s_node resources)."
+
+# ----------------------------------------------------------------------------
+# Private infra repo + session-proven knowledge — no external upstream to
+# version-track; first-party scripts/runbooks and live-operation findings.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["proxmox"]
+name = "internal-infra-repo"
+check_method = "none"
+last_checked = "2026-07-13"
+notes = "First-party, no external upstream: private infra repo Nushell scripts (proxmox.nu API-token wrapper, golden-image.nu pure-API pipeline, proxmox-template.nu legacy netboot builder), provisioning scripts (install-base.sh, generalize.sh — existence verified via find, not fully read), and session-proven operational knowledge from live operation against two production nodes (2026-07-09, recorded in bees issue claude-skills-112). Also covers the node-served-docs pattern cited in SKILL.md (https://<node>:8006/pve-docs/... — a pattern, not a fetchable URL, since no live node was reachable during authoring) and the canonical Ubuntu cloud image (cloud-images.ubuntu.com, HTTP 200 confirmed 2026-07-13) that golden-image.nu downloads. A prior source list's four guessed press-release URLs and one guessed PDM product-page URL all returned HTTP 404 (checked 2026-07-13) and are documented in sources.md as corrected, not cited here."

--- a/plugins/tools/qa/.claude-plugin/plugin.json
+++ b/plugins/tools/qa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "QA team that validates a running application against Gherkin user stories using Playwright and Tidewave",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/qa/skills/sources.md
+++ b/plugins/tools/qa/skills/sources.md
@@ -1,5 +1,7 @@
 # Sources
 
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `internal-composition` (the sibling-skill list below), `gherkin-cucumber` (the External section below).
+
 ## qa skill
 
 Internal sources — this skill is composed of conventions from other skills in this marketplace.
@@ -19,7 +21,6 @@ Internal sources — this skill is composed of conventions from other skills in 
 ## Plugin metadata
 
 - **Plugin**: qa
-- **Version**: 0.1.0
 - **Description**: QA team that validates a running application against Gherkin user stories using Playwright and Tidewave
 - **Skills count**: 1 (qa)
 - **Agents count**: 7 (qa-lead, qa-author, qa-playwright, qa-tidewave, qa-backend, qa-test-writer, qa-implementer)

--- a/plugins/tools/qa/skills/sources.toml
+++ b/plugins/tools/qa/skills/sources.toml
@@ -1,0 +1,35 @@
+# sources.toml - Machine-readable version tracking for skill dependencies
+# Run `mise sources:check` to compare against the latest upstream release.
+
+[meta]
+plugin = "qa"
+reviewed_at_plugin_version = "0.1.0"
+last_full_check = "2026-07-30"
+
+# ----------------------------------------------------------------------------
+# Internal composition — this skill is built from conventions in OTHER
+# first-party skills in this marketplace (tdd, bees, playwright, tidewave,
+# phoenix, anti-fabrication), not from an external upstream. check_method
+# = "none" is the explicit representation for that, per claude-skills-182.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["qa"]
+name = "internal-composition"
+check_method = "none"
+last_checked = "2026-05-16"
+notes = "Composed from conventions in sibling first-party skills, not an external upstream: /core:tdd (Red-Green-Refactor cycle quoted in references/validation-loop.md), /core:bees (bees new/close/dep add syntax in references/delta-format.md, plus the bees-manager agent's BEES REQUESTS input contract), /playwright:playwright (MCP tool names used by qa-playwright), /elixir:tidewave (MCP tool names used by qa-tidewave), /elixir:phoenix (module layout, Ecto schemas, LiveView assertions for qa-tidewave context), /core:anti-fabrication (the every-claim-requires-tool-output rule). Provenance narrative stays in sources.md."
+
+# ----------------------------------------------------------------------------
+# Gherkin/Cucumber reference syntax — the one genuine external upstream.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["qa"]
+name = "gherkin-cucumber"
+url = "https://cucumber.io/docs/gherkin/reference/"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-05-16"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "Cucumber's Gherkin specification. references/gherkin-format.md documents a strict subset: Feature / Background / Scenario / Scenario Outline / Examples / Given / When / Then / And / But, single-line steps, no doc strings, no data tables in v0.1.0. Accessed during plan authoring, 2026-05-16."

--- a/plugins/tools/rig/.claude-plugin/plugin.json
+++ b/plugins/tools/rig/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rig",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Rig (rig-core): building multi-provider and hybrid LLM clients in Rust",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/rig/skills/sources.md
+++ b/plugins/tools/rig/skills/sources.md
@@ -2,6 +2,8 @@
 
 This file documents the sources used to create the rig plugin skill.
 
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there.
+
 ## Rig Skill
 
 ### Rig Project Site
@@ -76,7 +78,6 @@ This file documents the sources used to create the rig plugin skill.
 ## Plugin Information
 
 - **Name**: rig
-- **Version**: 0.1.0
 - **Description**: Building multi-provider and hybrid LLM clients in Rust with rig-core
 - **Skills**: 1 skill covering setup, the AgentBuilder quickstart, multi-provider/hybrid
   harness guidance, local models and OpenAI-compatible gateways, agents/tools/extractors/MCP,

--- a/plugins/tools/rig/skills/sources.toml
+++ b/plugins/tools/rig/skills/sources.toml
@@ -1,0 +1,44 @@
+# sources.toml - Machine-readable version tracking for skill dependencies
+# Run `mise sources:check` to compare against the latest upstream release.
+
+[meta]
+plugin = "rig"
+reviewed_at_plugin_version = "0.1.0"
+last_full_check = "2026-07-30"
+
+# ----------------------------------------------------------------------------
+# rig-core (0xPlaygrounds/rig) — the Rust multi-provider/hybrid LLM framework.
+# current_version is the version the skill content was verified against per
+# sources.md, not today's live crates.io value (see notes).
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["rig"]
+name = "rig-core"
+url = "https://rig.rs"
+releases_url = "https://github.com/0xPlaygrounds/rig/releases"
+check_method = "crates-io"
+crate_name = "rig-core"
+current_version = "0.40.0"
+version_constraint = "pre-1.0"
+last_checked = "2026-07-30"
+update_priority = "medium"
+breaking_changes_likely = true
+notes = "Verified against rig-core 0.40.0, workspace layout crates/rig-core/, edition 2024 (2026-07-16/17): lib.rs provider list, providers/{anthropic,openai,gemini}/*.rs, providers/ollama.rs, agent/builder.rs (dynamic_context, rmcp_tool(s) surface), tool/mod.rs (Tool trait), client/{mod,completion}.rs, extractor.rs, completion/{mod,request}.rs. MCP support landed in 0.16.0 per github.com/0xPlaygrounds/rig/discussions/635. Live crates.io check 2026-07-30 shows 0.41.0 now published upstream — skill content not yet re-verified against it. Also cites docs.rig.rs and docs.rs/crate/rig-core/latest as documentation/API-reference mirrors of the same crate, not tracked as separate sources."
+
+# ----------------------------------------------------------------------------
+# Lemonade Server — AMD's local LLM server, referenced for local-model /
+# OpenAI-compatible gateway guidance.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["rig"]
+name = "lemonade-server"
+url = "https://lemonade-server.ai/"
+releases_url = "https://github.com/lemonade-sdk/lemonade"
+check_method = "github-releases"
+github_repo = "lemonade-sdk/lemonade"
+current_version = "unknown"
+version_constraint = "pre-1.0"
+last_checked = "2026-07-17"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "Referenced for the local-model / OpenAI-compatible gateway section (platform support, backends, OpenAI-compatible REST surface at lemonade-server.ai/docs/api/openai/). Apache 2.0, AMD-sponsored. A third-party field report (malachid.com blog, 2025-04-06) on local models returning untyped tool-call args is cited as an observation, not a first-party rig or Lemonade claim — not tracked as a separate source."

--- a/plugins/tools/sbx/.claude-plugin/plugin.json
+++ b/plugins/tools/sbx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sbx",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Docker Sandboxes (sbx CLI): run AI coding agents in isolated microVMs with hypervisor-level isolation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/sbx/skills/sources.md
+++ b/plugins/tools/sbx/skills/sources.md
@@ -1,5 +1,7 @@
 # Sources
 
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there.
+
 ## sbx skill
 
 ### Docker Sandboxes Documentation

--- a/plugins/tools/sbx/skills/sources.toml
+++ b/plugins/tools/sbx/skills/sources.toml
@@ -1,0 +1,25 @@
+# sources.toml - Machine-readable version tracking for skill dependencies
+# Run `mise sources:check` to compare against the latest upstream release.
+
+[meta]
+plugin = "sbx"
+reviewed_at_plugin_version = "0.1.0"
+last_full_check = "2026-07-30"
+
+# ----------------------------------------------------------------------------
+# Docker Sandboxes (sbx CLI) — current_version is the release the skill's
+# install/archive-layout claims were verified against, not today's live tag.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["sbx"]
+name = "docker-sandboxes"
+url = "https://docs.docker.com/ai/sandboxes/"
+releases_url = "https://github.com/docker/sbx-releases/releases"
+check_method = "github-releases"
+github_repo = "docker/sbx-releases"
+current_version = "0.30.0"
+version_constraint = "pre-1.0"
+last_checked = "2026-07-30"
+update_priority = "medium"
+breaking_changes_likely = true
+notes = "Verified against the v0.30.0 release archive layout (bin/sbx + libexec/ + completions/); confirmed the mise github backend installs and extracts it correctly with SLSA provenance verification (2026-05-22). Covers docs.docker.com/reference/cli/sbx (subcommands, flags), /ai/sandboxes (microVM/KVM/per-VM-daemon overview), /ai/sandboxes/get-started (install commands), /ai/sandboxes/usage (agent list, --branch auto), /ai/sandboxes/security (four-layer isolation, deny-by-default network). Live GitHub API check 2026-07-30 shows v0.37.1 now published upstream — skill content not yet re-verified against it. Third-party blog (msbiro.net, Matteo Bisi, 2026-04-07) confirmed policy/exec/dashboard syntax against upstream usage docs; its 'sbx secret' subcommand claim was NOT confirmed and is omitted from the skill per anti-fabrication policy — not tracked as a separate source."

--- a/plugins/ui/.claude-plugin/plugin.json
+++ b/plugins/ui/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "UI framework skills: daisyUI components, theming, and responsive design",
   "author": {
     "name": "vinnie357"

--- a/plugins/ui/skills/sources.md
+++ b/plugins/ui/skills/sources.md
@@ -2,6 +2,8 @@
 
 This file documents the sources used to create the ui plugin skills.
 
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there.
+
 ## daisyUI Skill
 
 ### daisyUI Official Documentation
@@ -57,7 +59,6 @@ This file documents the sources used to create the ui plugin skills.
 ## Plugin Information
 
 - **Name**: ui
-- **Version**: 0.1.0
 - **Description**: UI framework skills: daisyUI components, theming, and responsive design
 - **Skills**: 1 comprehensive daisyUI skill
 - **Created**: 2025-11-15

--- a/plugins/ui/skills/sources.toml
+++ b/plugins/ui/skills/sources.toml
@@ -1,0 +1,25 @@
+# sources.toml - Machine-readable version tracking for skill dependencies
+# Run `mise sources:check` to compare against the latest upstream release.
+
+[meta]
+plugin = "ui"
+reviewed_at_plugin_version = "0.1.0"
+last_full_check = "2026-07-30"
+
+# ----------------------------------------------------------------------------
+# daisyUI — Tailwind CSS component library. Docs-based skill; sources.md does
+# not pin a version the skill content was verified against.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["daisyui"]
+name = "daisyui"
+url = "https://daisyui.com"
+releases_url = "https://github.com/saadeghi/daisyui/releases"
+check_method = "github-releases"
+github_repo = "saadeghi/daisyui"
+current_version = "unknown"
+version_constraint = "semver"
+last_checked = "2026-07-30"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "Docs-based component/theming reference (daisyui.com/docs/intro, /components, /docs/themes, /docs/config, /docs/layout-and-typography); sources.md does not pin a skill-content verification version. github_repo confirmed via GitHub API 2026-07-30 (latest tag v5.7.8)."


### PR DESCRIPTION
- Author `skills/sources.toml` for the 8 single-skill plugins in wave A batch 1: `ui` (daisyui), `beads`, `linear`, `playwright`, `proxmox`, `qa`, `rig`, `sbx`
- Add the `Structured tracking: [sources.toml](sources.toml)` index pointer line to each plugin's `sources.md`
- Delete the stale `- **Version**` bullet from `sources.md` where present (`ui`, `playwright`, `qa`, `rig`) — the reviewed-at-version now lives in `sources.toml`'s `[meta].reviewed_at_plugin_version`
- Bump patch versions in `plugin.json` + `marketplace.json` for all 8 touched plugins plus `all-skills`, and sync via `mise update-all-skills`

## Per-plugin notes

- **ui**: 1 entry (`daisyui`), `check_method = "github-releases"` (`saadeghi/daisyui`, confirmed via live GitHub API check 2026-07-30, latest v5.7.8). `current_version = "unknown"` — sources.md never pinned a version the skill content was verified against.
- **beads**: 1 entry (`beads`), `check_method = "github-releases"`. Live check found the repo relocated from `steveyegge/beads` (documented in sources.md, 2026-01-24) to `gastownhall/beads` (current, latest v1.1.2) — recorded in `notes`, `github_repo` points at the new location.
- **linear**: 2 entries — `linear-api` (`check_method = "manual"`, Linear's hosted MCP/GraphQL docs, no versioned release feed) and `internal-vantageex-references` (`check_method = "none"` — first-party cross-repo references: Symphony's Linear skill, VantageEx's Linear client, three ADRs, the epic template/authoring guide, and this marketplace's CLAUDE.md template).
- **playwright**: 1 entry (`playwright-mcp`), `check_method = "manual"` — the schema has no npm check method, so `@playwright/mcp` is tracked by querying the npm registry directly. Live check found v0.0.78 (pre-1.0).
- **proxmox**: 5 entries, the highest density plugin in this batch (26 URLs / 84 lines) — `proxmox-pve` (current_version `9.2.4`, sourced from sources.md's own session-proven text), `proxmox-pdm` (current_version `1.1`, from the PDM 1.1 press release), `proxmox-pbs` (`current_version = "unknown"`, no PBS version documented), `terraform-provider-proxmox` (github-releases, `bpg/terraform-provider-proxmox`), and `internal-infra-repo` (`check_method = "none"` — private infra-repo scripts/runbooks/Terraform and session-proven 8→9 upgrade knowledge with no external upstream).
- **qa**: 2 entries — `internal-composition` (`check_method = "none"` — this skill is composed of conventions from sibling skills: tdd, bees, playwright, tidewave, phoenix, anti-fabrication) and `gherkin-cucumber` (`check_method = "manual"`, the one genuine external upstream).
- **rig**: 2 entries — `rig-core` (`check_method = "crates-io"`, `current_version = "0.40.0"` matching what sources.md documents the skill was verified against; a live crates.io check today found 0.41.0 now published, noted but not adopted since skill content isn't re-verified against it) and `lemonade-server` (github-releases, `lemonade-sdk/lemonade`).
- **sbx**: 1 entry (`docker-sandboxes`), `check_method = "github-releases"` (`docker/sbx-releases`), `current_version = "0.30.0"` — the release the skill's install/archive-layout claims were verified against. Live check found v0.37.1 now published; noted, not adopted.

## `unknown` fields and why

`current_version = "unknown"`: `ui/daisyui`, `beads`, `playwright-mcp`, `linear-api`, `qa/gherkin-cucumber`, `proxmox-pbs`, `terraform-provider-proxmox`, `rig/lemonade-server` — none of these had a specific version documented in sources.md as what the skill content was verified against, and a guessed value would be fabrication.

`meta.reviewed_at_plugin_version = "0.1.0"` for all 8 (not "unknown"): sourced either directly from sources.md's own `- **Version**` bullet (`ui`, `playwright`, `qa`, `rig`) or, for the 4 plugins with no such bullet (`beads`, `linear`, `proxmox`, `sbx`), from git archaeology — `git log --follow` shows each plugin's `sources.md` has never been touched since its creation commit, and `plugin.json` at that commit was `0.1.0` in every case.

## `check_method = "none"` entries and why

- `linear/internal-vantageex-references` — first-party cross-repo doc/code references (ADRs, epic templates, a production client), not an external upstream.
- `qa/internal-composition` — this skill is explicitly "composed of conventions from other skills in this marketplace" (sources.md's own words); the referenced skills are sibling first-party skills, not external upstreams.
- `proxmox/internal-infra-repo` — private infra-repo Nushell scripts/runbooks/Terraform plus session-proven live-operation knowledge (bees issue claude-skills-112), none of which has an external upstream to version-track.

## Verification evidence

`nu test/validate-sources.nu`:
```
✅ sources.toml validation clean (10 file(s) validated, 18 pending)
```
10 = the 2 pre-existing (`zig`, `awman`) + our 8. Zero findings.

Self-test: `nu test/validate-sources.nu --self-test` → `✅ sources self-test passed (43 cases)`.

Coverage-check proof (`a2_uncovered`): temporarily set `ui/skills/sources.toml`'s only entry to `skills = []`, re-ran the validator, and it correctly reported:
```
a2_uncovered   ui: skills with no sources entry: [daisyui] — add them to an existing entry's skills list, or add a check_method="none" entry
```
Restored the file; `git status --short` on it showed untracked/new with no drift (content re-verified via grep to match the original).

Waiver count (`test/quality-baseline.json` `allowed_failures`): **65 before, 65 after** — unchanged. None of these 8 plugins carried a `:source`-specific waiver, so no shrink applied; `mise test` confirms "65 debt/bug entries to burn down" post-change.

`mise test`: exit 0 (all 30 plugins valid, marketplace.json valid, disclosure lint clean on 588 tracked files, core-list consistent).

`git diff --numstat -- '*.json'`: 9/9 on `marketplace.json` (8 plugins + all-skills), 1/1 on each of the 8 individual `plugin.json` files and the root `plugin.json` — confirms only version strings changed, no array reformatting.

Gitleaks: clean, no secrets detected (delegated to a haiku agent, verbatim "No secrets detected").

## Found but not fixed

- `beads/beads:anti_fab`, `qa/qa:ref_depth`, `ui/daisyui:anti_fab` remain in `test/quality-baseline.json`'s waiver list — unrelated to sources.toml (different check categories), out of scope for this PR.
- `rig-core` (0.40.0 documented → 0.41.0 live) and `docker-sandboxes` (0.30.0 documented → 0.37.1 live) both have newer upstream releases than what the skill content was verified against. Recorded in `notes`; re-verifying the skill bodies against the newer releases is a follow-up, not this PR's scope.

## Suggested tracker writes (read-only on bees per instructions — not applied)

- `bees close claude-skills-182` is NOT appropriate yet — the parent issue covers all 18 wave-A plugins; this PR is only the first batch of 8 (`ui, beads, linear, playwright, proxmox, qa, rig, sbx`). Suggest a bees comment on claude-skills-182 noting batch 1 (8/18) is done via this PR, with the remaining 10 (`core, design, elixir, rust, pm, wasm, ansible, dagu, graphify, tweag`) left for a follow-up batch/PR.
- No baseline-shrink `bees close`/label changes needed — waiver count unchanged at 65.
