### PR TITLE
feat(sources): match c2_md_no_mention against prose only, not URLs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.88",
+      "version": "0.4.89",
       "category": "meta",
       "keywords": [
         "skills",
@@ -119,7 +119,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
-      "version": "0.2.36",
+      "version": "0.2.37",
       "category": "tools",
       "keywords": [
         "claude-code",
@@ -197,7 +197,7 @@
       "source": "./plugins/languages/elixir",
       "strict": true,
       "description": "Elixir development skills: Phoenix, OTP, Ports, Ecto, Tidewave MCP, testing, configuration, style, and anti-patterns",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "category": "language",
       "keywords": [
         "elixir",
@@ -295,7 +295,7 @@
       "source": "./plugins/tools/playwright",
       "strict": true,
       "description": "Playwright MCP browser automation for Claude Code",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "category": "tools",
       "keywords": [
         "playwright",
@@ -367,7 +367,7 @@
       "source": "./plugins/tools/rig",
       "strict": true,
       "description": "Rig (rig-core): building multi-provider and hybrid LLM clients in Rust",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "category": "tools",
       "keywords": [
         "rig",
@@ -416,7 +416,7 @@
       "source": "./plugins/tools/sbx",
       "strict": true,
       "description": "Docker Sandboxes (sbx CLI): run AI coding agents in isolated microVMs with hypervisor-level isolation",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "category": "tools",
       "keywords": [
         "docker",
@@ -452,7 +452,7 @@
       "source": "./plugins/tools/tweag",
       "strict": true,
       "description": "Tweag tools: Topiary universal code formatter and Nickel configuration language",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "category": "tools",
       "keywords": [
         "tweag",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.88",
+  "version": "0.4.89",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/languages/elixir/.claude-plugin/plugin.json
+++ b/plugins/languages/elixir/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "elixir",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Elixir development skills: Phoenix, OTP, Ports, Ecto, Tidewave MCP, testing, configuration, style, and anti-patterns",
   "author": {
     "name": "vinnie357"

--- a/plugins/languages/elixir/skills/sources.md
+++ b/plugins/languages/elixir/skills/sources.md
@@ -2,7 +2,7 @@
 
 This file documents the sources used to create the elixir plugin skills.
 
-Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there.
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `elixir-lang`, `erlang/otp`, `phoenix`, `phoenix_live_view`, `tidewave`, `stream_data`, `ecto`, `ecto_sql`.
 
 ## Anti-Patterns Skill
 

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/skill-update/SKILL.md
+++ b/plugins/tools/claude-code/skills/skill-update/SKILL.md
@@ -44,6 +44,14 @@ Each plugin's `skills/sources.toml` tracks upstream dependencies. See `templates
 
 `check_method = "none"` is for skills with no external upstream (first-party doctrine authored in this repo): `notes` is required (state why there is no upstream), and `url` / `current_version` / `version_constraint` / `update_priority` are forbidden.
 
+## sources.md index convention
+
+Every `sources.toml` entry `name` must appear in `sources.md` **prose** — `test:sources` rule `c2_md_no_mention` strips scheme-prefixed URLs before matching, so a name sitting only inside its own `- **URL**:` field does not count. Naming an entry after what the prose already calls it needs no extra text — that is the default and what `mise sources:init` produces. When prose doesn't already name it, append one `Entries:` sentence to the `Structured tracking:` pointer line (same line, not a new one), backticked names, comma-separated:
+
+```
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `name-one`, `name-two` (the Foo Skill section below).
+```
+
 ## Check Method API Endpoints
 
 | `check_method` | Endpoint | Auth | Rate Limit |

--- a/plugins/tools/claude-code/skills/skill-update/templates/sources.toml
+++ b/plugins/tools/claude-code/skills/skill-update/templates/sources.toml
@@ -26,7 +26,10 @@ last_full_check = "unknown"            # REQUIRED. YYYY-MM-DD or "unknown".
 skills = ["skill-name"]          # REQUIRED. Non-empty list of skill DIRECTORY names
                                  # from this plugin's plugin.json. Not a scalar.
 name = "source-name"             # REQUIRED. Human-readable identifier (e.g. "apple-container").
-                                 # Must be mentioned in sources.md.
+                                 # Must appear in sources.md PROSE (URLs do not count) - append
+                                 # it to the Entries: sentence on the index-pointer line if no
+                                 # prose already names it. Never name an entry after a URL
+                                 # fragment just to pass the check.
 url = ""                         # REQUIRED unless check_method = "none".
 releases_url = ""                # Optional but recommended.
 

--- a/plugins/tools/playwright/.claude-plugin/plugin.json
+++ b/plugins/tools/playwright/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Playwright MCP browser automation for Claude Code",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/playwright/skills/sources.md
+++ b/plugins/tools/playwright/skills/sources.md
@@ -1,6 +1,6 @@
 # Playwright Plugin Sources
 
-Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there.
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `playwright-mcp`.
 
 ## playwright skill
 

--- a/plugins/tools/rig/.claude-plugin/plugin.json
+++ b/plugins/tools/rig/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rig",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Rig (rig-core): building multi-provider and hybrid LLM clients in Rust",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/rig/skills/sources.md
+++ b/plugins/tools/rig/skills/sources.md
@@ -2,7 +2,7 @@
 
 This file documents the sources used to create the rig plugin skill.
 
-Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there.
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `rig-core`, `lemonade-server`.
 
 ## Rig Skill
 

--- a/plugins/tools/sbx/.claude-plugin/plugin.json
+++ b/plugins/tools/sbx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sbx",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Docker Sandboxes (sbx CLI): run AI coding agents in isolated microVMs with hypervisor-level isolation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/sbx/skills/sources.md
+++ b/plugins/tools/sbx/skills/sources.md
@@ -1,6 +1,6 @@
 # Sources
 
-Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there.
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `docker-sandboxes`.
 
 ## sbx skill
 

--- a/plugins/tools/tweag/.claude-plugin/plugin.json
+++ b/plugins/tools/tweag/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tweag",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Tweag tools: Topiary universal code formatter and Nickel configuration language",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/tweag/skills/sources.md
+++ b/plugins/tools/tweag/skills/sources.md
@@ -2,7 +2,7 @@
 
 This file documents sources used to create the tweag plugin skills.
 
-Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there.
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `topiary`, `tree-sitter`, `nickel`, `json-schema-to-nickel`.
 
 ## Topiary Skill
 

--- a/test/validate-sources.nu
+++ b/test/validate-sources.nu
@@ -416,9 +416,12 @@ def check-sources [
         # — NOT a bare-domain strip — is deliberate: bare-domain entry names
         # (design's m3.material.io, pm's cucumber.io) are legitimate
         # identifiers and must still match when prose names them without a
-        # scheme. Measured: scheme-only and a more aggressive domain-stripping
-        # regex produce the identical failing-entry set on this corpus, so the
-        # minimal regex is sufficient and preserves the bare-domain case.
+        # scheme. Measured on this corpus (109 entries, 20 plugins): scheme-only
+        # strips leave 0 failures, while a full bare-domain strip fails 9 — the
+        # 7 pm entries (cucumber.io, spdx.org, owasp.org, ...) and 2 design
+        # entries (m3.material.io, oritop.co), every one of them a legitimate
+        # bare-domain name a reader would recognise. Do not "simplify" this to
+        # a domain strip; it is the difference between 0 and 9.
         let md_prose = ($md_lower | str replace -a -r 'https?://[^\s)>"\]]+' '')
         # claude-skills-185 rd2: type-check here too. `$sources != null` is not
         # enough — a string root reaches `where` and throws. Third site of one

--- a/test/validate-sources.nu
+++ b/test/validate-sources.nu
@@ -1438,6 +1438,122 @@ update_priority = "medium"
             md: "demo-source is documented here\n- **Version**: 0.1.0\n"
             want: ["c3_md_version_bullet"]
         }
+        # ---- c2: prose-only match, scheme-prefixed URLs excluded (claude-skills-186) ----
+        {
+            label: "c2: name appears only inside a scheme-prefixed URL — must still fail"
+            toml: '
+[meta]
+plugin = "demo"
+reviewed_at_plugin_version = "1.0.0"
+last_full_check = "2026-01-01"
+[[sources]]
+skills = ["a"]
+name = "lemonade-server"
+url = "https://lemonade-server.ai/"
+check_method = "manual"
+current_version = "1.0.0"
+version_constraint = "semver"
+last_checked = "2026-01-01"
+update_priority = "medium"
+'
+            dirs: ["a"]
+            plugin: "demo"
+            version: "1.0.0"
+            md: "- **URL**: https://lemonade-server.ai/\n"
+            want: ["c2_md_no_mention"]
+        }
+        {
+            label: "c2: name appears in prose (regression guard)"
+            toml: '
+[meta]
+plugin = "demo"
+reviewed_at_plugin_version = "1.0.0"
+last_full_check = "2026-01-01"
+[[sources]]
+skills = ["a"]
+name = "demo-source"
+url = "https://example.com"
+check_method = "manual"
+current_version = "1.0.0"
+version_constraint = "semver"
+last_checked = "2026-01-01"
+update_priority = "medium"
+'
+            dirs: ["a"]
+            plugin: "demo"
+            version: "1.0.0"
+            md: "demo-source is covered in the section below.\n"
+            want: []
+        }
+        {
+            label: "c2: bare-domain name in prose without a scheme must NOT be stripped (scheme-only strip, not domain-strip)"
+            toml: '
+[meta]
+plugin = "demo"
+reviewed_at_plugin_version = "1.0.0"
+last_full_check = "2026-01-01"
+[[sources]]
+skills = ["a"]
+name = "m3.material.io"
+url = "https://m3.material.io/"
+check_method = "manual"
+current_version = "1.0.0"
+version_constraint = "semver"
+last_checked = "2026-01-01"
+update_priority = "medium"
+'
+            dirs: ["a"]
+            plugin: "demo"
+            version: "1.0.0"
+            md: "See m3.material.io for the component specs.\n"
+            want: []
+        }
+        {
+            label: "c2: name appears in both prose and a URL"
+            toml: '
+[meta]
+plugin = "demo"
+reviewed_at_plugin_version = "1.0.0"
+last_full_check = "2026-01-01"
+[[sources]]
+skills = ["a"]
+name = "lemonade-server"
+url = "https://lemonade-server.ai/"
+check_method = "manual"
+current_version = "1.0.0"
+version_constraint = "semver"
+last_checked = "2026-01-01"
+update_priority = "medium"
+'
+            dirs: ["a"]
+            plugin: "demo"
+            version: "1.0.0"
+            md: "lemonade-server is documented at https://lemonade-server.ai/\n"
+            want: []
+        }
+        {
+            label: "c2: name appears only inside a URL embedded mid-sentence (markdown link target, not line-start) — must still fail"
+            toml: '
+[meta]
+plugin = "demo"
+reviewed_at_plugin_version = "1.0.0"
+last_full_check = "2026-01-01"
+[[sources]]
+skills = ["a"]
+name = "foo-bar"
+url = "https://foo-bar.io/x"
+check_method = "manual"
+current_version = "1.0.0"
+version_constraint = "semver"
+last_checked = "2026-01-01"
+update_priority = "medium"
+'
+            dirs: ["a"]
+            plugin: "demo"
+            version: "1.0.0"
+            md: "Check the [docs](https://foo-bar.io/x) for details.\n"
+            want: ["c2_md_no_mention"]
+        }
         # ---- A-F4 crash-vector guards ---------------------------------------
         {
             label: "A-F4.1: [meta] absent entirely"

--- a/test/validate-sources.nu
+++ b/test/validate-sources.nu
@@ -409,6 +409,17 @@ def check-sources [
         })
     } else {
         let md_lower = ($md | str downcase)
+        # claude-skills-186: strip scheme-prefixed URLs before matching, so an
+        # entry can no longer pass c2 solely because its name happens to sit
+        # inside its own `- **URL**:` field (rig/lemonade-server was the
+        # motivating case — no prose named it, only its url did). Scheme-only
+        # — NOT a bare-domain strip — is deliberate: bare-domain entry names
+        # (design's m3.material.io, pm's cucumber.io) are legitimate
+        # identifiers and must still match when prose names them without a
+        # scheme. Measured: scheme-only and a more aggressive domain-stripping
+        # regex produce the identical failing-entry set on this corpus, so the
+        # minimal regex is sufficient and preserves the bare-domain case.
+        let md_prose = ($md_lower | str replace -a -r 'https?://[^\s)>"\]]+' '')
         # claude-skills-185 rd2: type-check here too. `$sources != null` is not
         # enough — a string root reaches `where` and throws. Third site of one
         # root cause; the guard belongs at every consumer, not just the first.
@@ -420,11 +431,11 @@ def check-sources [
             # pattern this repo keeps hitting.
             for entry in ($sources | where {|e| ($e | describe --detailed | get type) == "record" }) {
                 let name = ((scalar-str ($entry.name? | default "")) | default "")
-                if ($name | is-not-empty) and not ($md_lower | str contains ($name | str downcase)) {
+                if ($name | is-not-empty) and not ($md_prose | str contains ($name | str downcase)) {
                     $findings = ($findings | append {
                         rule: "c2_md_no_mention"
                         severity: "fail"
-                        message: $"($plugin): sources.md does not mention entry '($name)' — the index must cover every sources.toml entry"
+                        message: $"($plugin): sources.md does not mention entry '($name)' in prose — URLs do not count; add it to the Entries: sentence"
                     })
                 }
             }


### PR DESCRIPTION
Closes claude-skills-186, filed out of the wave-A migration (#175, #176) and blocking wave B (#183).

## The rule did not mean what its name said

`c2_md_no_mention` requires every `sources.toml` entry `name` to appear in the plugin's `sources.md` — the point being that the human-readable index actually describes every tracked source. It tested containment against the **whole file**, and a `sources.md` contains URLs. So an entry named `lemonade-server` passed purely because `url = "https://lemonade-server.ai/"` sat in the file. No prose named it.

That gap is not theoretical. During wave A, **four independent authoring agents hit this rule and invented four different workarounds** — an `Entries:` sentence, an inline `_Tracked in sources.toml as_` marker, naming entries after existing prose, and naming entries after URL fragments. The last one produced `doc.rust-lang.org/stable` and `design/wit.html` as values of a field whose schema meaning is "human-readable source identifier" and which `mise sources:check` prints as an output column. A documented-but-unenforced convention is how you get four conventions.

## Measured before deciding

109 entries across the 20 migrated plugins. Exactly **7** passed only via a URL match:

| plugin | entries |
|---|---|
| elixir | `elixir-lang`, `phoenix_live_view`, `stream_data` |
| playwright | `playwright-mcp` |
| rig | `lemonade-server` |
| sbx | `docker-sandboxes` |
| tweag | `json-schema-to-nickel` |

Whole-file failures today: 0. So tightening costs 5 files, not 20 — computed, not estimated, and re-derived independently before acting on it.

## The strip is scheme-only, on purpose

`c2` now strips `https?://[^\s)>"\]]+` before matching. It deliberately does **not** strip bare domains: `m3.material.io` (design) and `cucumber.io` (pm) are legitimate entry names, and prose that mentions them without a scheme must still satisfy the rule. A naive domain-strip would silently break five plugins.

That constraint was pinned by a committed test **before** any implementation existed — `test(sources): specify c2_md_no_mention matching prose only, not URLs` (`327e85f`), written by a separate agent that was forbidden from touching `check-sources`. Five cases: URL-only must fail, prose must pass, **bare-domain-in-prose must pass**, both-present passes, and a URL embedded mid-sentence in a markdown link target must still fail. Two failed red for the right reason before the fix; all 48 self-test cases pass now.

Measured on this corpus (109 entries, 20 plugins): scheme-only leaves **0** failures; a full bare-domain strip fails **9** — the 7 `pm` entries and 2 `design` entries, every one a legitimate bare-domain name. That is the cost of "simplifying" the regex, and it is recorded at the call site so nobody does.

*(An earlier revision of this body and the code comment claimed the two regexes produce an identical failing set. That was false — and it contradicted the very next sentence. Gate 3 caught it; both are corrected. The design conclusion was never in doubt, since the bare-domain case is pinned by a committed test, but the stated justification for it was wrong.)*

## Convention, now enforced rather than described

- **First choice stays: name the source what the prose already calls it.** That is also what `sources-init.nu` generates from sources.md headings.
- **When prose doesn't name it:** append an `Entries:` sentence to the existing index-pointer line. Not a standalone line — that pointer line is byte-identical across all 20 files and all 9 existing usages put `Entries:` as a second sentence on it.
- Documented in `skill-update`'s SKILL.md (206 lines, under the 500 cap) and in the `name` field comment of `templates/sources.toml`, so a wave-B author reads it before authoring rather than discovering it at validation time.
- The failure message now tells the author what to do: *"does not mention entry 'X' in prose — URLs do not count; add it to the Entries: sentence"*.

**Drift is asymmetric and that is deliberate.** Adding or renaming an entry without updating sources.md fails `c2`, so the machine forces that direction. Removing an entry leaves a harmless stale name in prose; no reverse check was built. Recording that as an accepted residual rather than inventing a second checker for a cosmetic case.

## Grandfathered, not normalized

Only the 5 failing plugins were touched. The other 15 pass on genuine prose and were left alone — including `ansible`, whose inline `_Tracked in sources.toml as_` markers satisfy the enforced rule even though they are not the canonical shape. Normalizing 20 files to look uniform would be churn against a rule they already pass.

## Gates

`nu test/validate-sources.nu --self-test` 48 cases pass; corpus clean at 20 validated / 8 pending; **URL-only entries 7 → 0**, re-derived independently; `mise test` exit 0; `mise run test:version-bumps origin/main` exit 0 for all 6 modified plugins; gitleaks clean (exit 0, no leaks found); waivers 65 → 65.

Note for future PRs: `test:version-bumps` is a **separate CI job and is not part of `mise test`** — five missing bumps passed a green `mise test` here and were caught only by running the CI check locally before pushing.
