### PR TITLE
feat(sources): author sources.toml for wave B, completing the migration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.89",
+      "version": "0.4.90",
       "category": "meta",
       "keywords": [
         "skills",
@@ -33,7 +33,7 @@
       "source": "./plugins/tools/allium",
       "strict": true,
       "description": "Opinionated Allium integration for /core:agent-loop: attach behavioral specs to epics, propagate TDD tests, weed-check semantic divergence post-CI.",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "category": "tools",
       "keywords": [
         "allium",
@@ -66,7 +66,7 @@
       "source": "./plugins/tools/altana",
       "strict": true,
       "description": "altana CLI wrapper: delegate prompts to sandboxed AI harnesses, run council fan-outs for diverse perspectives, and distribute tasks across harness presets",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "category": "tools",
       "keywords": [
         "altana",
@@ -119,7 +119,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
-      "version": "0.2.38",
+      "version": "0.2.39",
       "category": "tools",
       "keywords": [
         "claude-code",
@@ -215,7 +215,7 @@
       "source": "./plugins/tools/github",
       "strict": true,
       "description": "GitHub Actions, Workflows, act local testing, community health files, Dependabot consolidation, and PR review",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "category": "tools",
       "keywords": [
         "github",
@@ -256,7 +256,7 @@
       "source": "./plugins/tools/agent-sandboxing",
       "strict": true,
       "description": "Agent sandboxing for AI coding agents: microVM and kernel-isolated execution environments. Index skill (sandbox) routes to substrate-specific paths. Currently covers the kubernetes-sigs/agent-sandbox path on kind, GKE, and kina (Kubernetes-in-Apple-Containers), with Kata, gVisor, and Apple Container microVM substrates. Ships 7 skills + 6 slash commands + nushell scripts. Designed to expand to non-k8s sandboxing paths.",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "category": "tools",
       "keywords": [
         "agent-sandbox",
@@ -385,7 +385,7 @@
       "source": "./plugins/tools/runex",
       "strict": true,
       "description": "Runex workflow engine: API, bundles, step logs, and debugging",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "category": "tools",
       "keywords": [
         "runex",
@@ -433,7 +433,7 @@
       "source": "./plugins/tools/slidev",
       "strict": true,
       "description": "Slidev presentation skills: strategy, branding, interactive demos, markdown slides, syntax, code blocks, export, and troubleshooting",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "category": "tools",
       "keywords": [
         "slidev",
@@ -501,7 +501,7 @@
       "source": "./plugins/tools/whamm",
       "strict": true,
       "description": "whamm! WebAssembly bytecode instrumentation: install via mise, the instr/info CLI, injection strategies, and the DTrace-inspired .mm monitor DSL",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "category": "tools",
       "keywords": [
         "whamm",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.89",
+  "version": "0.4.90",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/agent-sandboxing/.claude-plugin/plugin.json
+++ b/plugins/tools/agent-sandboxing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sandboxing",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Agent sandboxing for AI coding agents: microVM and kernel-isolated execution environments. Index skill (sandbox) routes to substrate-specific paths. Currently covers the kubernetes-sigs/agent-sandbox path on kind, GKE, and kina (Kubernetes-in-Apple-Containers), with Kata, gVisor, and Apple Container microVM substrates. Ships 7 skills + 6 slash commands + nushell scripts. Designed to expand to non-k8s sandboxing paths.",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/agent-sandboxing/skills/sources.md
+++ b/plugins/tools/agent-sandboxing/skills/sources.md
@@ -2,6 +2,8 @@
 
 Citations for the `agent-sandboxing` plugin skills. Each entry lists the upstream source, what was extracted from it, and the date of last verification.
 
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `kubernetes-sigs/agent-sandbox` (this section), `gke-agent-sandbox-docs` (the Google Cloud — GKE Agent Sandbox docs section), `kata-containers` (the Kata Containers section), `agent-substrate` (the agent-substrate/substrate section), `claude-code-devcontainer-docs` (the Claude Code section), `kina` (the kina section), `claude-code-devcontainer-reference` (the Anthropic devcontainer reference image section), `gcp-agent-sandbox-substrate-blog` (the Google Cloud blog section), `sandbox-index-skill` (the `sandbox` routing/index skill, which has no external upstream).
+
 ## kubernetes-sigs/agent-sandbox
 
 - **URL**: https://github.com/kubernetes-sigs/agent-sandbox

--- a/plugins/tools/agent-sandboxing/skills/sources.toml
+++ b/plugins/tools/agent-sandboxing/skills/sources.toml
@@ -1,0 +1,163 @@
+# sources.toml - Machine-readable version tracking for skill dependencies
+# Run `mise sources:check` to compare against the latest upstream release.
+
+[meta]
+plugin = "agent-sandboxing"
+reviewed_at_plugin_version = "0.2.3"
+last_full_check = "2026-07-30"
+
+# ----------------------------------------------------------------------------
+# kubernetes-sigs/agent-sandbox — the upstream CRD project (Sandbox,
+# SandboxTemplate, SandboxClaim, SandboxWarmPool) that k8s-agent-sandbox,
+# kata-on-kind, kata-on-gke, kina-microvm, and claude-code-on-sandbox all
+# build on.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["k8s-agent-sandbox", "kata-on-kind", "kata-on-gke", "kina-microvm", "claude-code-on-sandbox"]
+name = "kubernetes-sigs/agent-sandbox"
+url = "https://github.com/kubernetes-sigs/agent-sandbox"
+releases_url = "https://github.com/kubernetes-sigs/agent-sandbox/releases"
+check_method = "github-releases"
+github_repo = "kubernetes-sigs/agent-sandbox"
+current_version = "v0.4.6"
+version_constraint = "pre-1.0"
+last_checked = "2026-07-30"
+update_priority = "high"
+breaking_changes_likely = true
+notes = "sources.md pins v0.4.6 (Date accessed 2026-05-23): CRD shapes, install manifest URLs, SandboxTemplateSpec.networkPolicy semantics, the examples/kata-gke-sandbox/ recipe. Live GitHub API check 2026-07-30 shows tag_name v0.5.4 published 2026-07-30 — real drift, skill content not yet re-verified against it; current_version stays pinned to the sources.md-verified value per the no-silent-advance rule."
+
+# ----------------------------------------------------------------------------
+# Google Cloud — GKE Agent Sandbox docs. Five pages under docs.cloud.google.com
+# with no independent release/version feed; content updates alongside the GKE
+# product.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["k8s-agent-sandbox", "kata-on-gke"]
+name = "gke-agent-sandbox-docs"
+url = "https://docs.cloud.google.com/kubernetes-engine/docs/concepts/machine-learning/agent-sandbox"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-05-23"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "sources.md Date accessed 2026-05-23; not re-verified live in this pass. Five pages cited: concepts/machine-learning/agent-sandbox, how-to/how-install-agent-sandbox, how-to/agent-sandbox, reference/crds/agentsandbox, how-to/sandbox-pods. Extracted: managed GKE Agent Sandbox supports gVisor only (Kata is community-supported via the upstream kata-gke-sandbox example), GKE version 1.35.2-gke.1269000 minimum, --enable-agent-sandbox flag, roles/serviceusage.serviceUsageAdmin, Artifact Registry + GKE API enablement."
+
+# ----------------------------------------------------------------------------
+# Kata Containers — kata-deploy, RuntimeClass names, node-label gating. No
+# specific release was pinned in sources.md; content is docs/behavior, not
+# tied to one tag.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["kata-on-kind", "kata-on-gke"]
+name = "kata-containers"
+url = "https://github.com/kata-containers/kata-containers"
+releases_url = "https://github.com/kata-containers/kata-containers/releases"
+check_method = "github-releases"
+github_repo = "kata-containers/kata-containers"
+current_version = "unknown"
+version_constraint = "stable"
+last_checked = "2026-07-30"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "sources.md (Date accessed 2026-05-23) never pinned a specific Kata release — extracted content is kata-deploy DaemonSet behavior, RuntimeClass names (kata-qemu, kata-clh, kata-fc), node-label gating (katacontainers.io/kata-runtime=true), nested-virtualization requirement, none of which is tag-specific. Also cites docs/install/README.md, docs/how-to/how-to-use-k8s-with-containerd-and-kata.md, and tools/packaging/kata-deploy/ from the same repo — not tracked as separate sources. Live GitHub API check 2026-07-30 shows tag_name 4.0.0 published 2026-07-20; current_version stays 'unknown' since no prior pin exists to compare against."
+
+# ----------------------------------------------------------------------------
+# agent-substrate/substrate — alpha-stage CRDs (WorkerPool, ActorTemplate)
+# behind the agent-substrate-overview skill.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["agent-substrate-overview"]
+name = "agent-substrate"
+url = "https://github.com/agent-substrate/substrate"
+releases_url = "https://github.com/agent-substrate/substrate/releases"
+check_method = "github-releases"
+github_repo = "agent-substrate/substrate"
+current_version = "v0.0.0"
+version_constraint = "pre-1.0"
+last_checked = "2026-07-30"
+update_priority = "high"
+breaking_changes_likely = true
+notes = "sources.md pins v0.0.0 (2026-05-19) — alpha, maturity caveat 'VERY early development'. Extracted: component list (ateapi, atelet, atecontroller, atenet, kubectl-ate), WorkerPool + ActorTemplate CRDs, kind + GKE install recipes, demos/claude-code-multiplex/. Live GitHub API check 2026-07-30 confirms tag_name v0.0.0 published 2026-05-19 is still the latest release — no drift."
+
+# ----------------------------------------------------------------------------
+# Claude Code devcontainer docs — env vars, headless mode, permission flags,
+# firewall pattern used by claude-code-on-sandbox.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["claude-code-on-sandbox"]
+name = "claude-code-devcontainer-docs"
+url = "https://code.claude.com/docs/en/devcontainer"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-05-23"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "sources.md Date accessed 2026-05-23; not re-verified live in this pass. Extracted: ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN env vars, ~/.claude named volume + CLAUDE_CONFIG_DIR, --print --output-format json headless mode, --dangerously-skip-permissions non-root requirement, init-firewall.sh egress allowlist pattern."
+
+# ----------------------------------------------------------------------------
+# kina — vinnie357/kina, the Rust CLI wrapping Apple Container into a
+# kind-style microVM cluster. Sources.md documents an Apple-Container version
+# it tracks ("0.5.0+"), not a kina release itself.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["kina-microvm"]
+name = "kina"
+url = "https://github.com/vinnie357/kina"
+releases_url = "https://github.com/vinnie357/kina/releases"
+check_method = "github-releases"
+github_repo = "vinnie357/kina"
+current_version = "unknown"
+version_constraint = "pre-1.0"
+last_checked = "2026-07-30"
+update_priority = "high"
+breaking_changes_likely = true
+notes = "sources.md (Date accessed 2026-06-10) describes kina as 'in active development; tracks Apple Container 0.5.0+' — no kina-specific version was pinned, so current_version stays 'unknown' rather than guessed. Extracted: Rust CLI commands (kina create|delete|list|status), cluster-as-microVM model (no per-pod runtimeClassName), mise tasks shape, dependency on Apple Container runtime. sources.md separately flags that the LATEST Apple Container release is 1.0.0 (major, breaking CLI changes) against kina's documented 0.5.0+ floor — that drift caveat is already carried in the kina-microvm skill body. Live GitHub API check 2026-07-30 confirms vinnie357/kina is public with tag_name v0.2.0 published 2026-07-10 as its latest kina release; skill content not verified against that tag specifically."
+
+# ----------------------------------------------------------------------------
+# Anthropic devcontainer reference image — the .devcontainer example directory
+# in anthropics/claude-code, used as the Dockerfile/firewall-pattern source
+# for claude-code-on-sandbox and templates/Dockerfile.claude-code.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["claude-code-on-sandbox"]
+name = "claude-code-devcontainer-reference"
+url = "https://github.com/anthropics/claude-code/tree/main/.devcontainer"
+check_method = "manual"
+github_repo = "anthropics/claude-code"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-07-30"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date accessed 2026-05-23 for the extracted content (Dockerfile structure, non-root user pattern UID 1000, ~/.claude named volume, init-firewall.sh NET_ADMIN/NET_RAW egress allowlist); this plugin's own templates/Dockerfile.claude-code is mise-driven rather than copying Anthropic's npm-driven setup, per feedback-mise-first + feedback-mise-registry-short-names. check_method is 'manual' rather than github-releases because the cited content is a specific example directory, not something versioned by CLI release tags. Live GitHub API check 2026-07-30 confirms anthropics/claude-code still resolves (full_name unchanged) — repo-reachability verified only, directory contents not re-diffed."
+
+# ----------------------------------------------------------------------------
+# Google Cloud blog — GKE Agent Sandbox GA announcement and Sandbox-vs-
+# Substrate positioning. Static blog post, no version to track.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["k8s-agent-sandbox", "agent-substrate-overview"]
+name = "gcp-agent-sandbox-substrate-blog"
+url = "https://cloud.google.com/blog/products/containers-kubernetes/bringing-you-agent-sandbox-on-gke-and-agent-substrate"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-05-23"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md dates this post 2026-05-20, Date accessed 2026-05-23; not re-verified live in this pass. Extracted: GKE Agent Sandbox GA announcement, positioning of Substrate vs Sandbox ('ultra-scale control plane' vs 'k8s-native GA tier'), the fact that they share runtime/snapshot primitives."
+
+# ----------------------------------------------------------------------------
+# sandbox — the plugin's index/router skill. Per plugin.json: "Index skill
+# (sandbox) routes to substrate-specific paths." It has no external upstream
+# of its own; it dispatches to the other six skills, each already tracked
+# above.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["sandbox"]
+name = "sandbox-index-skill"
+check_method = "none"
+last_checked = "2026-07-30"
+notes = "First-party routing/index skill — it has no external upstream to check. It dispatches to substrate-specific skills (k8s-agent-sandbox, kata-on-kind, kata-on-gke, kina-microvm, claude-code-on-sandbox, agent-substrate-overview), each of which carries its own sources.toml entry above."

--- a/plugins/tools/allium/.claude-plugin/plugin.json
+++ b/plugins/tools/allium/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "allium",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Opinionated Allium integration for /core:agent-loop: attach behavioral specs to epics, propagate TDD tests, weed-check semantic divergence post-CI.",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/allium/skills/sources.md
+++ b/plugins/tools/allium/skills/sources.md
@@ -1,5 +1,7 @@
 # Sources
 
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `juxt-allium` (the juxt/allium section below), `allium-tools` (the juxt/allium-tools section below).
+
 ## juxt/allium
 
 - **Repo:** https://github.com/juxt/allium

--- a/plugins/tools/allium/skills/sources.toml
+++ b/plugins/tools/allium/skills/sources.toml
@@ -1,0 +1,45 @@
+# sources.toml - Machine-readable version tracking for skill dependencies
+# Run `mise sources:check` to compare against the latest upstream release.
+
+[meta]
+plugin = "allium"
+reviewed_at_plugin_version = "0.1.0"
+last_full_check = "2026-07-30"
+
+# ----------------------------------------------------------------------------
+# juxt/allium — the behavioral-spec DSL itself (entity/rule/config/use
+# syntax). No GitHub Releases object exists (releases/latest 404s, confirmed
+# live 2026-07-30) but real version TAGS do (v3.8.0 latest as of that check).
+# SKILL.md documents "Spec Syntax (v3)" as an informal major-version label,
+# not a pinned patch version, so current_version stays "unknown" rather than
+# overclaiming precision.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["allium"]
+name = "juxt-allium"
+url = "https://github.com/juxt/allium"
+check_method = "manual"
+github_repo = "juxt/allium"
+current_version = "unknown"
+version_constraint = "semver"
+last_checked = "2026-04-17"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "DSL spec language (entity, rule, config, use, transitions, invariant, when/requires/ensures) — README + skill docs accessed 2026-04-17 per sources.md. SKILL.md documents 'Spec Syntax (v3)' as a major-version label, not a specific tag. Live check 2026-07-30: GET /repos/juxt/allium/releases/latest returns 404 (no formal GitHub Release published) but /repos/juxt/allium/tags lists real tags through v3.8.0 — a github-releases check_method would falsely report 'no releases' forever, so manual with github_repo retained for identity. Distinct from the allium-tools CLI entry below: this is the spec language/grammar, that is the binary distribution."
+
+# ----------------------------------------------------------------------------
+# juxt/allium-tools — the CLI binary (`allium-tools`) installed via mise.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["allium"]
+name = "allium-tools"
+url = "https://github.com/juxt/allium-tools"
+releases_url = "https://github.com/juxt/allium-tools/releases"
+check_method = "github-releases"
+github_repo = "juxt/allium-tools"
+current_version = "3.0.4"
+version_constraint = "semver"
+last_checked = "2026-07-30"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "Content pinned to 3.0.4 in references/installation.md (mise github backend), documented 2026-04-17 as 'available versions 3.0.0-3.0.4, pinned to 3.0.4 for supply-chain hygiene.' Live check 2026-07-30 (GET /repos/juxt/allium-tools/releases/latest) returns 200 with tag v3.5.0 — this repo DOES publish formal GitHub Releases (contra an earlier assumption that it had none; that 404 belongs to the juxt/allium entry above, not this one). Releases run through v3.5.0 and tags through v3.8.0 as of this check. current_version intentionally left at the content-verified 3.0.4 per migration discipline, not advanced to today's live value — drift recorded here for the next update pass."

--- a/plugins/tools/altana/.claude-plugin/plugin.json
+++ b/plugins/tools/altana/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "altana",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "altana CLI wrapper: delegate prompts to sandboxed AI harnesses, run council fan-outs for diverse perspectives, and distribute tasks across harness presets",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/altana/skills/sources.md
+++ b/plugins/tools/altana/skills/sources.md
@@ -1,5 +1,7 @@
 # Sources
 
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `altana` (the altana section below).
+
 ## altana
 
 - **Repo:** https://github.com/vinnie357/altana (private)

--- a/plugins/tools/altana/skills/sources.toml
+++ b/plugins/tools/altana/skills/sources.toml
@@ -1,0 +1,24 @@
+# sources.toml - Machine-readable version tracking for skill dependencies
+# Run `mise sources:check` to compare against the latest upstream release.
+
+[meta]
+plugin = "altana"
+reviewed_at_plugin_version = "0.1.0"
+last_full_check = "2026-07-30"
+
+# ----------------------------------------------------------------------------
+# altana — first-party CLI this workspace builds and dogfoods (operator's
+# global CLAUDE.md: "it's our own product surface, like runex/vantageex").
+# The skill documents live protocol behavior (JSON contract, status codes,
+# config schema) read directly from the private repo's own source/docs, not
+# an external dependency with a release cadence to track. No version pin or
+# mise install section exists anywhere in this skill's content —
+# check_method = "none" is the honest representation, following the
+# internal-composition precedent set for the qa plugin (claude-skills-182).
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["altana"]
+name = "altana"
+check_method = "none"
+last_checked = "2026-06-13"
+notes = "Private first-party repo (vinnie357/altana, per sources.md) documented by reading its own source and docs directly: subcommand shapes (delegate/council/harness/models/list/doctor), JSON result contract, status codes, response protocol (## Answer/## Evidence/## Confidence + ALTANA DONE sentinel), config discovery order, harness TOML schema, op:// secret resolution, model picker behavior — all accessed 2026-06-13 per sources.md. Also read docs/usage.md and harnesses.example.toml from the local altana checkout, same date. No version number, release tag, or mise install instruction appears anywhere in SKILL.md or references/ — unlike runex (which documents 'Current documented version: 0.0.7' and a mise pin), altana's skill content tracks CLI protocol behavior of a tool this same team ships, not a pinned dependency version. The operator's CLAUDE.md explicitly frames altana as workspace-owned product surface, exempting it from external-dependency version tracking."

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.38",
+  "version": "0.2.39",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/sources.md
+++ b/plugins/tools/claude-code/skills/sources.md
@@ -2,6 +2,8 @@
 
 This file documents the sources used to create the claude-code plugin skills.
 
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `agent-skills-concept`, `example-skills-repository`, `skill-creator-guide`, `skills-cookbook`, `agent-skills-specification`, `agent-skills-overview`, `agent-skills-best-practices` (the Agent Skills Documentation section below), `claude-code-plugins-docs`, `claude-code-commands-docs`, `claude-code-agents-docs`, `claude-code-hooks-docs`, `claude-code-output-styles-docs` (the Claude Code Plugin Development section below), `claude-code-plugin-marketplaces-docs` (the Plugin Marketplace Skill section below), `agent-teams-docs`, `subagents-docs`, `agent-sdk-docs`, `agent-sdk-subagents-docs`, `building-c-compiler-blog`, `addyosmani-agent-teams-blog`, `tasks-to-swarms-blog`, `agent-teams-switch-flipped-blog` (the Claude Teams Skill section below), `claude-code-statusline-docs`, `ccstatusline` (the Claude Statusline Skill section below), `claude-code-workflows-docs`, `dynamic-workflows-blog`, `claude-code-workflow-tool-contract` (the Claude Workflows Skill section below), `skills-building-guide-pdf`, `improving-skill-creator-blog` (the Skill Building Guide (PDF) section below), `github-rest-api-releases`, `hexpm-api`, `cratesio-api`, `toml-spec` (the Skill Update Skill section below), `context-engineering-claude-5-blog`, `claude-code-changelog` (the Context Engineering for Claude 5 Models section below).
+
 ## Agent Skills Documentation
 
 ### Agent Skills Concept
@@ -389,26 +391,6 @@ Create a modular Claude Code plugin marketplace that:
 - **claude-agents/templates/write-capable-agent.md**: added a `skills:` frontmatter field demonstrating skill preloading.
 - **claude-teams/references/subagents.md**: corrected background-execution framing — subagents default to background as of v2.1.198 (Claude runs foreground only when it needs the result before continuing), not foreground-by-default. Renamed `Task` references to `Agent` (Task tool renamed to Agent in v2.1.63; `Task` remains a deprecated alias).
 - **Task→Agent deprecation fixes (v2.1.63)**: Updated commands/benchmark-skills.md and commands/research-skill.md to reference Agent tool instead of Task tool. Updated claude-teams references/agent-sdk.md line 109 to document the Agent tool with parenthetical note that Task is a deprecated alias, and updated line 128 to reference Agent tool in the constraint about subagents. Audited via bee claude-skills-114. Source: https://code.claude.com/docs/en/sub-agents
-
-## Plugin Information
-
-- **Name**: claude-code
-- **Version**: 0.1.8
-- **Description**: Claude Code-specific skills for plugin marketplace management, validation, and component creation
-- **Skills**: 9 skills covering all aspects of Claude Code plugin development
-  - plugin-marketplace: Marketplace.json validation and management
-  - claude-plugins: Plugin.json validation and management
-  - claude-commands: Creating custom slash commands
-  - claude-agents: Creating specialized agents
-  - claude-skills: Creating Agent Skills (general guide)
-  - claude-hooks: Creating event-driven hooks
-- **Created**: 2025-11-15
-- **Key Capabilities**:
-  - Complete Claude Code plugin development guide
-  - Marketplace and plugin validation
-  - Schema compliance checking
-  - Automated template generation
-  - Nushell-based validation scripts
 
 ## Context Engineering for Claude 5 Models
 

--- a/plugins/tools/claude-code/skills/sources.toml
+++ b/plugins/tools/claude-code/skills/sources.toml
@@ -1,0 +1,450 @@
+# sources.toml - Machine-readable version tracking for skill dependencies
+# Run `mise sources:check` to compare against the latest upstream release.
+
+[meta]
+plugin = "claude-code"
+reviewed_at_plugin_version = "0.2.23"
+last_full_check = "2026-07-30"
+
+# ----------------------------------------------------------------------------
+# "Agent Skills Documentation" section of sources.md — seven distinct
+# upstreams, all attributed to skills/claude-skills/SKILL.md. Each is a
+# separate URL (not the same source repeated), so each gets its own entry
+# per the "don't duplicate one upstream" rule read the other way: these are
+# genuinely different sources that happen to share one skills=["claude-skills"]
+# list, not one source split across many entries.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["claude-skills"]
+name = "agent-skills-concept"
+url = "https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2025-11-15"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2025-11-15. Purpose: understanding what Claude skills are, how they work, and best practices for creating them."
+
+[[sources]]
+skills = ["claude-skills"]
+name = "example-skills-repository"
+url = "https://github.com/anthropics/skills/tree/main"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-07-30"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "No Date Accessed in sources.md for this entry. Live GitHub API check 2026-07-30 confirms anthropics/skills still resolves (full_name unchanged, id 1061953414, no redirect/rename); the repo has no releases (404 on /releases/latest) so check_method stays manual — this is a reachability check, not a re-diff of the example catalog."
+
+[[sources]]
+skills = ["claude-skills"]
+name = "skill-creator-guide"
+url = "https://github.com/anthropics/skills/blob/main/skill-creator/SKILL.md"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "unknown"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "No Date Accessed in sources.md. Same repo as example-skills-repository (confirmed reachable 2026-07-30), but this entry cites one specific file path not independently re-fetched, so last_checked is honestly 'unknown' rather than borrowed from the sibling entry."
+
+[[sources]]
+skills = ["claude-skills"]
+name = "skills-cookbook"
+url = "https://github.com/anthropics/claude-cookbooks/tree/main/skills"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-07-30"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "No Date Accessed in sources.md. Live GitHub API check 2026-07-30 confirms anthropics/claude-cookbooks still resolves (full_name unchanged, id 678973052); no releases feed (404) so check_method stays manual."
+
+[[sources]]
+skills = ["claude-skills"]
+name = "agent-skills-specification"
+url = "https://github.com/anthropics/skills/blob/main/agent_skills_spec.md"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2025-11-15"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2025-11-15. Official specification for the Agent Skills format and structure; same repo as example-skills-repository (confirmed reachable 2026-07-30)."
+
+[[sources]]
+skills = ["claude-skills"]
+name = "agent-skills-overview"
+url = "https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2025-01-23"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2025-01-23. Key finding recorded: description field must contain a 'Use when [trigger conditions]' pattern since it is the only metadata Claude sees during skill discovery."
+
+[[sources]]
+skills = ["claude-skills"]
+name = "agent-skills-best-practices"
+url = "https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2025-01-23"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2025-01-23. Also cited in sources.md as a source for scripts/validate-plugin.nu (description max 1024 chars, name max 64 chars, third-person constraints) — that script is marketplace-wide, not a skill directory, so it is not modeled as a separate skills entry here."
+
+# ----------------------------------------------------------------------------
+# "Claude Code Plugin Development" section of sources.md.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["claude-plugins"]
+name = "claude-code-plugins-docs"
+url = "https://code.claude.com/docs/en/plugins"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2025-11-15"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2025-11-15. Plugin architecture, commands/agents/skills/hooks structure, plugin.json format, installation and distribution."
+
+[[sources]]
+skills = ["claude-commands"]
+name = "claude-code-commands-docs"
+url = "https://code.claude.com/docs/en/commands"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2025-11-15"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2025-11-15. Command file structure, argument handling, command workflows."
+
+[[sources]]
+skills = ["claude-agents"]
+name = "claude-code-agents-docs"
+url = "https://code.claude.com/docs/en/agents"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2025-11-15"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2025-11-15. Agent configuration, tool restrictions, model selection, task delegation. Priority raised to medium: the Update History entries (2026-07-15) record two real frontmatter/tool-naming refreshes to claude-agents already, driven by subagents-docs below rather than this page directly, so this doc plausibly has unreviewed drift too."
+
+[[sources]]
+skills = ["claude-hooks"]
+name = "claude-code-hooks-docs"
+url = "https://code.claude.com/docs/en/hooks"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2025-11-15"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2025-11-15. Hook types and configuration, tool call hooks, lifecycle hooks, variable substitution."
+
+[[sources]]
+skills = ["claude-output-styles", "claude-plugins"]
+name = "claude-code-output-styles-docs"
+url = "https://code.claude.com/docs/en/output-styles"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-04-17"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-04-17. Used In both skills/claude-output-styles/SKILL.md and skills/claude-plugins/SKILL.md per sources.md. Newer Claude Code feature area (session-start scoping, subagent inheritance caveats) judged more likely to drift than the older plugin/commands docs above."
+
+# ----------------------------------------------------------------------------
+# "Plugin Marketplace Skill" section of sources.md. The two sources.md
+# headings here ("Plugin Marketplace Schema" and "Advanced Plugin Entry
+# Features") are the same doc page — the second is the #advanced-plugin-
+# entries anchor on the first's URL — so they are merged into one entry
+# rather than duplicated per the "don't split one upstream" rule.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["plugin-marketplace"]
+name = "claude-code-plugin-marketplaces-docs"
+url = "https://code.claude.com/docs/en/plugin-marketplaces"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2025-11-15"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2025-11-15 for both the base 'Claude Code Plugin Marketplace Schema' entry and the 'Advanced Plugin Entry Features' entry, which cites the #advanced-plugin-entries anchor on this exact same URL — merged into one sources.toml row rather than duplicated."
+
+# ----------------------------------------------------------------------------
+# "Claude Teams Skill" section of sources.md — eight distinct upstreams.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["claude-teams"]
+name = "agent-teams-docs"
+url = "https://code.claude.com/docs/en/agent-teams"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. Documents the experimental Agent Teams feature (team lead/teammate architecture, shared task list, display modes) — sources.md itself calls this 'experimental', hence medium priority."
+
+[[sources]]
+skills = ["claude-teams", "claude-agents"]
+name = "subagents-docs"
+url = "https://code.claude.com/docs/en/sub-agents"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-07-15"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21 for the original claude-teams/references/subagents.md citation; the Update History entry for 2026-07-15 records this same URL re-fetched to drive the claude-agents frontmatter refresh (background-default correction, Task-to-Agent tool rename) — last_checked uses the more recent 2026-07-15 verification. Covers both claude-teams and claude-agents per that update-history cross-use."
+
+[[sources]]
+skills = ["claude-teams"]
+name = "agent-sdk-docs"
+url = "https://platform.claude.com/docs/en/agent-sdk/overview"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. Programmatic multi-agent orchestration (AgentDefinition, session management, dynamic agent configuration)."
+
+[[sources]]
+skills = ["claude-teams"]
+name = "agent-sdk-subagents-docs"
+url = "https://platform.claude.com/docs/en/agent-sdk/subagents"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. SDK-specific subagent configuration and invocation."
+
+[[sources]]
+skills = ["claude-teams"]
+name = "building-c-compiler-blog"
+url = "https://www.anthropic.com/engineering/building-c-compiler"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. Static blog post (case study of 16 parallel Claude Code agents); low priority — published content does not change."
+
+[[sources]]
+skills = ["claude-teams"]
+name = "addyosmani-agent-teams-blog"
+url = "https://addyosmani.com/blog/claude-code-agent-teams/"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. Third-party community analysis, static blog post."
+
+[[sources]]
+skills = ["claude-teams"]
+name = "tasks-to-swarms-blog"
+url = "https://alexop.dev/posts/from-tasks-to-swarms-agent-teams-in-claude-code/"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. Third-party community analysis, static blog post."
+
+[[sources]]
+skills = ["claude-teams"]
+name = "agent-teams-switch-flipped-blog"
+url = "https://paddo.dev/blog/agent-teams-the-switch-got-flipped/"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. Third-party discovery/analysis of TeammateTool internals, static blog post."
+
+# ----------------------------------------------------------------------------
+# "Claude Statusline Skill" section of sources.md.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["claude-statusline"]
+name = "claude-code-statusline-docs"
+url = "https://code.claude.com/docs/en/statusline"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-04-18"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-04-18. statusLine settings block, stdin JSON schema, update cadence, caching guidance."
+
+[[sources]]
+skills = ["claude-statusline"]
+name = "ccstatusline"
+url = "https://github.com/sirmalloc/ccstatusline"
+check_method = "github-releases"
+github_repo = "sirmalloc/ccstatusline"
+current_version = "unknown"
+version_constraint = "semver"
+last_checked = "2026-07-30"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-06-26; the skill documents 'npx -y ccstatusline@latest' (always-latest), so no specific version is pinned as verified-against — current_version stays 'unknown' rather than guessed. Live GitHub API check 2026-07-30: full_name unchanged (sirmalloc/ccstatusline, id 1034425196), latest release tag_name v2.2.27 published 2026-07-25T22:51:51Z — genuine semver releases exist, unlike the anthropics/skills and anthropics/claude-cookbooks example repos above, so github-releases is used here instead of manual."
+
+# ----------------------------------------------------------------------------
+# "Claude Workflows Skill" section of sources.md.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["claude-workflows"]
+name = "claude-code-workflows-docs"
+url = "https://code.claude.com/docs/en/workflows"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-05-30"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-05-30. Trigger paths, TUI keybindings, concurrency caps, availability and disabling."
+
+[[sources]]
+skills = ["claude-workflows"]
+name = "dynamic-workflows-blog"
+url = "https://claude.com/blog/introducing-dynamic-workflows-in-claude-code"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-05-30"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-05-30. Static blog post motivating the dynamic-workflows feature."
+
+[[sources]]
+skills = ["claude-workflows"]
+name = "claude-code-workflow-tool-contract"
+check_method = "none"
+last_checked = "2026-05-30"
+notes = "sources.md records this source's URL literally as '(internal tool definition surfaced in the Claude Code session)' — the authoritative script API (meta block; agent()/pipeline()/parallel()/phase()/log()/workflow() hooks; args/budget globals; schema, isolation, model overrides, resume) has no stable fetchable URL. sources.md states the public docs page (claude-code-workflows-docs, tracked above) is 'deliberately light on these internals'. Date noted in sources.md: 2026-05-30. No url/version fields per check_method=none."
+
+# ----------------------------------------------------------------------------
+# "Skill Building Guide (PDF)" section of sources.md.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["claude-skills", "claude-skills-benchmark"]
+name = "skills-building-guide-pdf"
+url = "https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-03-07"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-03-07. Skill categories (Capability Uplift vs Encoded Preference), Degree of Freedom framework, context window discipline, validation loop pattern."
+
+[[sources]]
+skills = ["claude-skills", "claude-skills-benchmark"]
+name = "improving-skill-creator-blog"
+url = "https://claude.com/blog/improving-skill-creator-test-measure-and-refine-agent-skills"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-03-07"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-03-07. Evaluation-driven development methodology: Test → Measure → Analyze → Refine → Verify."
+
+# ----------------------------------------------------------------------------
+# "Skill Update Skill" section of sources.md. No explicit per-entry 'Used In'
+# line in sources.md — the whole section is titled 'Skill Update Skill', so
+# skill-update is inferred directly from the section heading rather than a
+# 'Used In' bullet.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["skill-update"]
+name = "github-rest-api-releases"
+url = "https://docs.github.com/en/rest/releases/releases"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-03-25"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-03-25. API reference for querying GitHub repository releases programmatically — describes the github-releases check_method, does not itself get version-pinned."
+
+[[sources]]
+skills = ["skill-update"]
+name = "hexpm-api"
+url = "https://github.com/hexpm/hexpm/blob/main/guides/API.md"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-03-25"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-03-25. API reference for querying Hex package versions — describes the hex-pm check_method."
+
+[[sources]]
+skills = ["skill-update"]
+name = "cratesio-api"
+url = "https://crates.io/policies"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-03-25"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-03-25. API reference for querying Rust crate versions — describes the crates-io check_method."
+
+[[sources]]
+skills = ["skill-update"]
+name = "toml-spec"
+url = "https://toml.io/en/v1.0.0"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-03-25"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-03-25. TOML format specification underlying the sources.toml schema itself (array of tables, inline tables, key-value pairs)."
+
+# ----------------------------------------------------------------------------
+# "Context Engineering for Claude 5 Models" section of sources.md.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["claude-skills"]
+name = "context-engineering-claude-5-blog"
+url = "https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-07-25"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-07-25. Basis for skills/claude-skills/references/context-engineering-claude-5.md — judgment-over-rules, tool-design-over-examples, progressive disclosure, single statements, code/schema over prose. Static blog post; low priority."
+
+[[sources]]
+skills = ["claude-skills"]
+name = "claude-code-changelog"
+url = "https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-07-30"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-07-25. Live GitHub API check 2026-07-30 confirms anthropics/claude-code still resolves (full_name unchanged, id 937253475) — reachability only, the CHANGELOG content itself was not re-diffed. Medium priority: a CHANGELOG is a continuously-appended rolling file, more likely to have unreviewed new entries than a frozen blog post. sources.md notes that third-party claims about /checkup finding unused skills or duplicate CLAUDE.md content were NOT found in the primary changelog and were excluded."

--- a/plugins/tools/github/.claude-plugin/plugin.json
+++ b/plugins/tools/github/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "GitHub Actions, Workflows, act local testing, community health files, Dependabot consolidation, and PR review",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/github/skills/sources.md
+++ b/plugins/tools/github/skills/sources.md
@@ -2,6 +2,8 @@
 
 This file documents all sources used to create the skills in this plugin.
 
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `actions-primary-docs`, `actions-toolkit`, `action-metadata`, `marketplace-publishing` (GitHub Actions section below); `workflows-primary-docs`, `workflow-syntax`, `contexts`, `expressions`, `events` (GitHub Workflows section below); `nektos-act` (the five act subsections below, collapsed to one upstream); `github-cli`, `docker`, `mise-tool`, `nushell-tool` (Additional References section below); `dependabot-docs` (Dependabot Consolidation section below); `gh-pr-review-recipe` (PR Review section below); `community-health-setup`, `repo-settings-features`, `contributor-covenant`, `security-policy` (Community Health Files section below).
+
 ## GitHub Actions
 
 ### Primary Documentation

--- a/plugins/tools/github/skills/sources.toml
+++ b/plugins/tools/github/skills/sources.toml
@@ -31,7 +31,7 @@ version_constraint = "rolling"
 last_checked = "2026-07-30"
 update_priority = "low"
 breaking_changes_likely = false
-notes = "actions/toolkit is a real, live repo (GitHub API confirms full_name unchanged, no rename), but is a monorepo of independently-versioned npm packages (@actions/core, @actions/github, @actions/exec, @actions/cache, @actions/artifact) with no single repo-level release: GET /repos/actions/toolkit/releases/latest returns a null tag_name/published_at (empty result), so github-releases would silently never fire — same failure class as two other renamed/unreleased upstreams already caught this migration. check_method=manual is deliberate, not an oversight."
+notes = "actions/toolkit is a real, live repo (GitHub API confirms full_name unchanged, no rename), but is a monorepo of independently-versioned npm packages (@actions/core, @actions/github, @actions/exec, @actions/cache, @actions/artifact) with no single repo-level release: GET /repos/actions/toolkit/releases/latest returns HTTP 404 with a Not Found error object (its tag_name is null because it is an error body, not an empty release), so github-releases would silently never fire — same failure class as two other renamed/unreleased upstreams already caught this migration. check_method=manual is deliberate, not an oversight."
 
 [[sources]]
 skills = ["actions"]
@@ -160,7 +160,7 @@ version_constraint = "semver"
 last_checked = "2026-07-30"
 update_priority = "low"
 breaking_changes_likely = false
-notes = "sources.md gives no Date Accessed for this entry. Grep of skill directories for 'gh pr'/'gh api'/'gh CLI'/cli.github.com confirms usage in workflows, act, community-health, dependabot-consolidator, and pr-review (not actions). Live GitHub API check 2026-07-30: cli/cli full_name unchanged, releases/latest resolves to v2.96.0 — sources.md never pinned a version, current_version stays 'unknown'."
+notes = "sources.md gives no Date Accessed for this entry. Grep of skill directories for gh subcommands confirms usage in workflows, act, community-health, dependabot-consolidator, and pr-review (not actions). The subcommand varies by skill — workflows uses 'gh workflow'/'gh run' (SKILL.md:196-199), not the 'gh pr'/'gh api' forms the other four use. Live GitHub API check 2026-07-30: cli/cli full_name unchanged, releases/latest resolves to v2.96.0 — sources.md never pinned a version, current_version stays 'unknown'."
 
 [[sources]]
 skills = ["actions", "act", "workflows"]

--- a/plugins/tools/github/skills/sources.toml
+++ b/plugins/tools/github/skills/sources.toml
@@ -1,0 +1,280 @@
+# sources.toml - Machine-readable version tracking for skill dependencies
+# Run `mise sources:check` to compare against the latest upstream release.
+
+[meta]
+plugin = "github"
+reviewed_at_plugin_version = "0.3.0"
+last_full_check = "2026-07-30"
+
+# ----------------------------------------------------------------------------
+# GitHub Actions — core concepts documentation.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["actions"]
+name = "actions-primary-docs"
+url = "https://docs.github.com/en/actions"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2025-11-15"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Accessed 2025-11-15. Action types, workflow triggers, runners, security (secrets/GITHUB_TOKEN/OIDC), workflow organization, monitoring. Not re-verified live in this pass."
+
+[[sources]]
+skills = ["actions"]
+name = "actions-toolkit"
+url = "https://github.com/actions/toolkit"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-07-30"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "actions/toolkit is a real, live repo (GitHub API confirms full_name unchanged, no rename), but is a monorepo of independently-versioned npm packages (@actions/core, @actions/github, @actions/exec, @actions/cache, @actions/artifact) with no single repo-level release: GET /repos/actions/toolkit/releases/latest returns a null tag_name/published_at (empty result), so github-releases would silently never fire — same failure class as two other renamed/unreleased upstreams already caught this migration. check_method=manual is deliberate, not an oversight."
+
+[[sources]]
+skills = ["actions"]
+name = "action-metadata"
+url = "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "unknown"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "No Date Accessed given in sources.md for this entry. action.yml schema, required/optional fields, input/output definitions, branding, runs configuration."
+
+[[sources]]
+skills = ["actions"]
+name = "marketplace-publishing"
+url = "https://docs.github.com/en/actions/creating-actions/publishing-actions-in-github-marketplace"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "unknown"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "No Date Accessed given in sources.md for this entry. Marketplace requirements, release process, semantic versioning, major version tags."
+
+# ----------------------------------------------------------------------------
+# GitHub Workflows — syntax, contexts, expressions, events.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["workflows"]
+name = "workflows-primary-docs"
+url = "https://docs.github.com/en/actions/how-tos/write-workflows"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2025-11-15"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Accessed 2025-11-15. Workflow syntax/structure, triggers, jobs/steps, contexts/expressions, secrets/env vars, artifacts/caching, reusable workflows, concurrency. Not re-verified live in this pass."
+
+[[sources]]
+skills = ["workflows"]
+name = "workflow-syntax"
+url = "https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "unknown"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "No Date Accessed given in sources.md for this entry. on/jobs/runs-on/steps/env/if/strategy.matrix YAML reference."
+
+[[sources]]
+skills = ["workflows"]
+name = "contexts"
+url = "https://docs.github.com/en/actions/learn-github-actions/contexts"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "unknown"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "No Date Accessed given in sources.md for this entry. github/env/job/steps/runner/secrets/matrix context objects."
+
+[[sources]]
+skills = ["workflows"]
+name = "expressions"
+url = "https://docs.github.com/en/actions/learn-github-actions/expressions"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "unknown"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "No Date Accessed given in sources.md for this entry. Operators, status functions, string/object functions, hashFiles."
+
+[[sources]]
+skills = ["workflows"]
+name = "events"
+url = "https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "unknown"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "No Date Accessed given in sources.md for this entry. push/pull_request/workflow_dispatch/schedule/release/issues/repository_dispatch."
+
+# ----------------------------------------------------------------------------
+# act (local testing) — sources.md gives nektos/act five separate subsection
+# citations (Primary Repository, Installation, Runner Images, Configuration,
+# Limitations), all pointing at the same github.com/nektos/act repo (four of
+# the five URLs are just anchors on the repo README). Collapsed to ONE entry
+# per the 'do not duplicate one upstream into N near-identical entries' rule —
+# these are facets of a single upstream, unlike slidev's 28 genuinely distinct
+# citations.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["act"]
+name = "nektos-act"
+url = "https://github.com/nektos/act"
+releases_url = "https://github.com/nektos/act/releases"
+check_method = "github-releases"
+github_repo = "nektos/act"
+current_version = "unknown"
+version_constraint = "pre-1.0"
+last_checked = "2026-07-30"
+update_priority = "medium"
+breaking_changes_likely = true
+notes = "sources.md Accessed 2025-11-15 (Primary Repository subsection); the four sibling subsections (Installation, Runner Images, Configuration, Limitations) are README anchors on the same repo with no separate date, collapsed into this one entry. Live GitHub API check 2026-07-30: full_name still nektos/act (no rename), releases/latest resolves to tag_name v0.2.89 (published 2026-06-01) — repo reachable and the releases feed works, but sources.md never pinned a specific version the skill content was verified against, so current_version stays 'unknown' rather than silently advancing to the live tag. pre-1.0 versioning (0.2.x) justifies breaking_changes_likely=true."
+
+# ----------------------------------------------------------------------------
+# Additional References — general tooling cited across multiple skills.
+# Coverage is grounded in a grep of each skill directory for gh/docker/mise/nu
+# usage, not assumed from the 'Additional References' heading alone.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["workflows", "act", "community-health", "dependabot-consolidator", "pr-review"]
+name = "github-cli"
+url = "https://cli.github.com/"
+releases_url = "https://github.com/cli/cli/releases"
+check_method = "github-releases"
+github_repo = "cli/cli"
+current_version = "unknown"
+version_constraint = "semver"
+last_checked = "2026-07-30"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md gives no Date Accessed for this entry. Grep of skill directories for 'gh pr'/'gh api'/'gh CLI'/cli.github.com confirms usage in workflows, act, community-health, dependabot-consolidator, and pr-review (not actions). Live GitHub API check 2026-07-30: cli/cli full_name unchanged, releases/latest resolves to v2.96.0 — sources.md never pinned a version, current_version stays 'unknown'."
+
+[[sources]]
+skills = ["actions", "act", "workflows"]
+name = "docker"
+url = "https://www.docker.com/"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "unknown"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "No Date Accessed given in sources.md for this entry. Container runtime required by act; sources.md cites installation/Docker Desktop/daemon management. Grep confirms Docker mentions in actions, act, and workflows skill content — not attached to community-health/dependabot-consolidator/pr-review, which do not mention it."
+
+[[sources]]
+skills = ["act", "dependabot-consolidator", "pr-review"]
+name = "mise-tool"
+url = "https://mise.jdx.dev/"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "unknown"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "No Date Accessed given in sources.md for this entry. Tool version management, used for installing/managing act versions per sources.md. Grep confirms mise mentions in act, dependabot-consolidator, and pr-review skill content only."
+
+[[sources]]
+skills = ["act", "dependabot-consolidator", "pr-review"]
+name = "nushell-tool"
+url = "https://www.nushell.sh/"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "unknown"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "No Date Accessed given in sources.md for this entry. Cross-platform shell used for installation scripts per sources.md. Grep confirms nushell/.nu mentions in act, dependabot-consolidator, and pr-review skill content only. Distinct entry from the core plugin's own nushell version tracking — this citation's scope is this plugin's sources.md only."
+
+# ----------------------------------------------------------------------------
+# Dependabot Consolidation.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["dependabot-consolidator"]
+name = "dependabot-docs"
+url = "https://docs.github.com/en/code-security/dependabot"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "unknown"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "No Date Accessed given in sources.md for this entry. Dependabot version-update config (dependabot.yml), app/dependabot PR author, pin styles, auto-close behavior. sources.md also cites a 'Recipe Origin' (kina PR #36, github.com/vinnie357/kina/pull/36) proving the baseline-diff gate discipline — folded into this entry's notes rather than a separate source, since it is an internal design precedent with no independent version to track, not a second external upstream."
+
+# ----------------------------------------------------------------------------
+# PR Review.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["pr-review"]
+name = "gh-pr-review-recipe"
+url = "https://cli.github.com/manual/gh_pr"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "unknown"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "No Date Accessed given in sources.md for this entry. `gh pr list/view/checks/merge` — the API surface pr-review drives for listing, inspecting, gating, and squash-merging PRs. A distinct doc page from the general github-cli entry above (this one is pr-review-specific gh-pr-subcommand usage). sources.md also cites a 'Recipe Origin' (kina github.com/vinnie357/kina external-collaborator PRs #37/#38/#39) proving the per-PR stack-aware review pattern with local baseline-diff gates — folded into this entry's notes as an internal design precedent, not a separate external upstream."
+
+# ----------------------------------------------------------------------------
+# Community Health Files.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["community-health"]
+name = "community-health-setup"
+url = "https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-03-01"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Accessed 2026-03-01. CODE_OF_CONDUCT.md, CONTRIBUTING.md, issue/PR templates, SECURITY.md, CODEOWNERS, FUNDING.yml — GitHub's Community Standards profile checks. Not re-verified live in this pass."
+
+[[sources]]
+skills = ["community-health"]
+name = "repo-settings-features"
+url = "https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "unknown"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "No Date Accessed given in sources.md for this entry. Merge strategies, branch protection rules, topics/description, feature toggles."
+
+[[sources]]
+skills = ["community-health"]
+name = "contributor-covenant"
+url = "https://www.contributor-covenant.org/"
+check_method = "manual"
+current_version = "3.0"
+version_constraint = "semver"
+last_checked = "unknown"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "No Date Accessed given in sources.md, but sources.md explicitly names 'Latest version (v3.0)' in its Key Topics — current_version=3.0 is traceable to that literal text, not a live query. Live GitHub API check 2026-07-30 (not used as this entry's check_method) found the upstream repo has moved to EthicalSource/contributor_covenant (contributor-covenant/contributor_covenant no longer resolves) — noted for awareness; this entry tracks the contributor-covenant.org site cited in sources.md, not a GitHub repo, so the rename does not change check_method or url here."
+
+[[sources]]
+skills = ["community-health"]
+name = "security-policy"
+url = "https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "unknown"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "No Date Accessed given in sources.md for this entry. SECURITY.md placement, GitHub Security Advisories, coordinated disclosure."

--- a/plugins/tools/runex/.claude-plugin/plugin.json
+++ b/plugins/tools/runex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "runex",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Runex workflow engine: API, bundles, step logs, and debugging",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/runex/skills/sources.md
+++ b/plugins/tools/runex/skills/sources.md
@@ -1,5 +1,7 @@
 # Sources
 
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `runex` (the Runex Source Code section below).
+
 ## runex skill
 
 ### Runex Source Code

--- a/plugins/tools/runex/skills/sources.toml
+++ b/plugins/tools/runex/skills/sources.toml
@@ -1,0 +1,30 @@
+# sources.toml - Machine-readable version tracking for skill dependencies
+# Run `mise sources:check` to compare against the latest upstream release.
+
+[meta]
+plugin = "runex"
+reviewed_at_plugin_version = "0.1.3"
+last_full_check = "2026-07-30"
+
+# ----------------------------------------------------------------------------
+# Runex — the private first-party workflow-engine repo this skill documents.
+# Not a "no upstream" case: there is a real, versioned upstream
+# (vinnie357/runex, mix.exs @version), but it is a PRIVATE GitHub repo — an
+# unauthenticated github-releases check would 404 forever and misreport as
+# "source missing" rather than "needs a token." check_method stays manual
+# until a token-aware check path exists. Per the operator's global CLAUDE.md,
+# runex is a workspace-owned strategic surface (a dogfooded product this
+# team ships, not an external dependency).
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["runex"]
+name = "runex"
+url = "https://github.com/vinnie357/runex"
+check_method = "manual"
+github_repo = "vinnie357/runex"
+current_version = "0.0.7"
+version_constraint = "pre-1.0"
+last_checked = "2026-05-17"
+update_priority = "high"
+breaking_changes_likely = true
+notes = "Private repo (vinnie357/runex) — confirmed 2026-07-30 via unauthenticated `curl api.github.com/repos/vinnie357/runex` returning 404. An unauthenticated `git ls-remote` against the same repo DID succeed in this environment (likely a cached local credential helper), which is not proof that an unauthenticated CI check would work — github-releases stays manual. Content is sourced by reading the actual runex source tree directly (mix.exs, lib/runex_web/**, lib/runex/**, config/runtime.exs, docs/*.md, CLAUDE.md) rather than release notes — see sources.md for the full file list. current_version 0.0.7 matches mix.exs @version per SKILL.md's 'Current documented version' line and the 2026-05-17 Update History entry (bumped from 0.0.6, which deleted the agent_runs subsystem — a real breaking change, hence breaking_changes_likely=true). Auxiliary local docs also consulted while authoring, not separately version-tracked: ~/github/vantage_ex/AUTONOMOUS-LOOP.md (usage patterns) and ~/github/runex-workflows/bundles/ (bundle structure examples)."

--- a/plugins/tools/slidev/.claude-plugin/plugin.json
+++ b/plugins/tools/slidev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slidev",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Slidev presentation skills: strategy, branding, interactive demos, markdown slides, syntax, code blocks, export, and troubleshooting",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/slidev/skills/sources.md
+++ b/plugins/tools/slidev/skills/sources.md
@@ -2,6 +2,10 @@
 
 This file documents the sources used to create the slidev plugin skills.
 
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `slidev-syntax-guide`, `slidev-builtin-layouts`, `slidev-slot-sugar`, `slidev-block-frontmatter`, `slidev-draggable-elements` (Slidev Syntax section below); `slidev-code-blocks`, `slidev-code-line-numbers`, `slidev-code-max-height`, `slidev-code-groups`, `slidev-monaco-editor`, `slidev-import-snippets`, `slidev-latex`, `slidev-mermaid`, `slidev-plantuml` (Slidev Code Blocks section below); `slidev-exporting-guide`, `slidev-cli-reference` (Slidev Export section below); `pyramid-principle`, `kawasaki-10-20-30`, `assertion-evidence-design`, `duarte-resonate`, `presentation-zen`, `rule-of-three` (Presentation Strategy section below); `playwright-mcp-browser-tools`, `wcag-contrast-requirements`, `slidev-unocss-theming` (Brand Discovery and Styles section below); `vue3-composition-api`, `slidev-custom-components`, `slidev-iframe-layouts` (Interactive Demos section below).
+
+Two skills have no section of their own because they draw on sources cited elsewhere in this file. The `slidev` overview skill uses `slidev-syntax-guide` (frontmatter quick start) and `slidev-cli-reference` (the `npm init slidev@latest` / `npx slidev` commands). The `troubleshooting` skill uses `slidev-syntax-guide`, `slidev-code-groups`, `slidev-monaco-editor`, `slidev-exporting-guide`, and `slidev-cli-reference` — the export flags (`--timeout`, `--wait`, `--omit-background`), the `mdc: true` code-group requirement, and the Monaco-not-appearing case each trace back to those pages. `sources.toml` records both attributions in its `skills` arrays.
+
 ## Slidev Syntax
 
 ### Slidev Syntax Guide
@@ -181,13 +185,3 @@ This file documents the sources used to create the slidev plugin skills.
 - **Purpose**: Embedding external content in slides
 - **Date Accessed**: 2026-04-04
 - **Key Topics**: iframe, iframe-left, iframe-right layouts, URL property
-
-## Plugin Information
-
-- **Name**: slidev
-- **Version**: 0.2.0
-- **Description**: Slidev presentation skills: strategy, branding, interactive demos, markdown slides, syntax, code blocks, export, and troubleshooting
-- **Skills**: 8 (slidev, syntax, code, export, troubleshooting, presentations, styles, interactive)
-- **Agents**: 3 (content-strategist, brand-discoverer, slide-builder)
-- **Created**: 2026-02-21
-- **Updated**: 2026-04-04

--- a/plugins/tools/slidev/skills/sources.toml
+++ b/plugins/tools/slidev/skills/sources.toml
@@ -1,0 +1,388 @@
+# sources.toml - Machine-readable version tracking for skill dependencies
+# Run `mise sources:check` to compare against the latest upstream release.
+
+[meta]
+plugin = "slidev"
+reviewed_at_plugin_version = "0.2.0"
+last_full_check = "2026-07-30"
+
+# ----------------------------------------------------------------------------
+# Slidev Syntax Guide — slide separators, frontmatter, headmatter, block
+# frontmatter. Also underpins the main `slidev` overview skill's Quick Start
+# (frontmatter example) and troubleshooting's "Frontmatter Not Recognized" /
+# "MDC Syntax Not Working" entries (verified: troubleshooting/references/
+# troubleshooting.md lines 144-162 cite frontmatter separators and `mdc: true`
+# headmatter directly).
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["syntax", "slidev", "troubleshooting"]
+name = "slidev-syntax-guide"
+url = "https://sli.dev/guide/syntax"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. Key Topics: slide structure, YAML frontmatter, headmatter configuration, block frontmatter. Not re-verified live in this pass (doc site, no version feed)."
+
+[[sources]]
+skills = ["syntax"]
+name = "slidev-builtin-layouts"
+url = "https://sli.dev/builtin/layouts"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. Catalog of 19 built-in layouts with props/slots. Not re-verified live in this pass."
+
+[[sources]]
+skills = ["syntax"]
+name = "slidev-slot-sugar"
+url = "https://sli.dev/features/slot-sugar"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. ::name:: named-slot syntax for layouts. Not re-verified live in this pass."
+
+[[sources]]
+skills = ["syntax"]
+name = "slidev-block-frontmatter"
+url = "https://sli.dev/features/block-frontmatter"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. Alternative YAML code-fence frontmatter syntax. Not re-verified live in this pass."
+
+# ----------------------------------------------------------------------------
+# Slidev Draggable Elements — v-drag directive/component. sources.md files this
+# under the '## Slidev Export' heading, but the actual content lives in the
+# syntax skill: `syntax/references/syntax.md` lines 376-391 document
+# `v-drag="'square'"` and `<v-drag>` directly, with no mention in export's own
+# references. Heading-slugging would mis-attribute this to export; grep
+# confirmed the real skill home is syntax.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["syntax"]
+name = "slidev-draggable-elements"
+url = "https://sli.dev/features/draggable"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21, filed under the Export heading in sources.md's own structure, but its content (v-drag directive/component) is verified present only in syntax/references/syntax.md:376-391, not in the export skill — attributed to syntax per actual content location, not per sources.md heading placement."
+
+# ----------------------------------------------------------------------------
+# Slidev Code Blocks family — Shiki highlighting, line highlighting/numbers,
+# max-height, code groups, Monaco editor, import snippets, LaTeX, Mermaid,
+# PlantUML. Code Groups and Monaco Editor are also cited by troubleshooting
+# (verified: troubleshooting/references/troubleshooting.md lines 164-179 cover
+# "Code Groups Not Rendering" and "Monaco Editor Not Appearing").
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["code"]
+name = "slidev-code-blocks"
+url = "https://sli.dev/features/code-blocks"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. Line ranges, click animations, at/finally, placeholder syntax. Not re-verified live in this pass."
+
+[[sources]]
+skills = ["code"]
+name = "slidev-code-line-numbers"
+url = "https://sli.dev/features/code-block-line-numbers"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. Not re-verified live in this pass."
+
+[[sources]]
+skills = ["code"]
+name = "slidev-code-max-height"
+url = "https://sli.dev/features/code-block-max-height"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. maxHeight property, scroll behavior. Not re-verified live in this pass."
+
+[[sources]]
+skills = ["code", "troubleshooting"]
+name = "slidev-code-groups"
+url = "https://sli.dev/features/code-groups"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. MDC syntax, tab labels. troubleshooting/references/troubleshooting.md:164-173 ('Code Groups Not Rendering') requires mdc: true — verified direct dependency."
+
+[[sources]]
+skills = ["code", "troubleshooting"]
+name = "slidev-monaco-editor"
+url = "https://sli.dev/features/monaco-editor"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. Monaco syntax, diff mode, height configuration. troubleshooting/references/troubleshooting.md:175-179 ('Monaco Editor Not Appearing') — verified direct dependency."
+
+[[sources]]
+skills = ["code"]
+name = "slidev-import-snippets"
+url = "https://sli.dev/features/import-snippet"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. <<< syntax, VS Code regions, language override. Not re-verified live in this pass."
+
+[[sources]]
+skills = ["code"]
+name = "slidev-latex"
+url = "https://sli.dev/features/latex"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. KaTeX, inline/block math, chemical equations. Not re-verified live in this pass."
+
+[[sources]]
+skills = ["code"]
+name = "slidev-mermaid"
+url = "https://sli.dev/features/mermaid"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. Mermaid syntax, theme configuration. Not re-verified live in this pass."
+
+[[sources]]
+skills = ["code"]
+name = "slidev-plantuml"
+url = "https://sli.dev/features/plantuml"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. PlantUML syntax, server configuration. Not re-verified live in this pass."
+
+# ----------------------------------------------------------------------------
+# Slidev Export family — export CLI (PDF/PPTX/PNG/SPA) and the full CLI
+# reference. Both are cited heavily by troubleshooting's Export Issues section
+# (verified: troubleshooting/references/troubleshooting.md lines 1-73 use
+# --timeout, --wait, --wait-until, --omit-background — all Exporting Guide/CLI
+# Reference flags). CLI Reference also underpins the main `slidev` overview
+# skill's Quick Start (`npm init slidev@latest`, `npx slidev slides.md`).
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["export", "troubleshooting"]
+name = "slidev-exporting-guide"
+url = "https://sli.dev/guide/exporting"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. Export formats, CLI flags, Playwright dependency, dark mode, click animations. troubleshooting/references/troubleshooting.md:1-73 (Export Issues section) verified as direct dependent."
+
+[[sources]]
+skills = ["export", "slidev", "troubleshooting"]
+name = "slidev-cli-reference"
+url = "https://sli.dev/builtin/cli"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-02-21"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-02-21. dev, build, export, format commands with all flags and defaults. slidev/SKILL.md Quick Start section (npm init slidev@latest, npx slidev) and troubleshooting's --port / --force flags both verified as direct dependents."
+
+# ----------------------------------------------------------------------------
+# Presentation Strategy frameworks — six distinct authors/methodologies, each
+# its own citation in sources.md; not collapsed, since each is a genuinely
+# separate upstream (not facets of one product, unlike act's five anchors in
+# the github plugin).
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["presentations"]
+name = "pyramid-principle"
+url = "https://www.barbaraminto.com/"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-04-04"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-04-04. SCQA (Situation-Complication-Question-Answer), top-down communication. Not re-verified live in this pass."
+
+[[sources]]
+skills = ["presentations"]
+name = "kawasaki-10-20-30"
+url = "https://guykawasaki.com/the_102030_rule/"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-04-04"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-04-04. 10 slides maximum, 20 minutes, 30pt minimum font. Not re-verified live in this pass."
+
+[[sources]]
+skills = ["presentations"]
+name = "assertion-evidence-design"
+url = "https://www.assertion-evidence.com/"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-04-04"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-04-04. Assertion headers, visual evidence bodies, ~20 words per slide. Not re-verified live in this pass."
+
+[[sources]]
+skills = ["presentations"]
+name = "duarte-resonate"
+url = "https://www.duarte.com/resources/books/resonate/"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-04-04"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-04-04. Sparkline narrative arc, 'what is' vs 'what could be', audience as hero. Not re-verified live in this pass."
+
+[[sources]]
+skills = ["presentations"]
+name = "presentation-zen"
+url = "https://presentationzen.com/"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-04-04"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-04-04. Simplicity, clarity, restraint, harmony, connection. Not re-verified live in this pass."
+
+[[sources]]
+skills = ["presentations"]
+name = "rule-of-three"
+url = "https://ethos3.com/the-rule-of-three-for-presentations/"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-04-04"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-04-04. Three key messages, three-act narrative, audience retention. Not re-verified live in this pass."
+
+# ----------------------------------------------------------------------------
+# Brand Discovery and Styles — Playwright MCP for brand-token extraction, WCAG
+# contrast requirements, Slidev UnoCSS theming.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["styles"]
+name = "playwright-mcp-browser-tools"
+url = "https://github.com/anthropics/claude-code/tree/main/packages/mcp-server-playwright"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-04-04"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-04-04. browser_navigate, browser_evaluate, browser_take_screenshot, CSS extraction. This is a directory path within the claude-code monorepo, not an independently releasable package — check_method=manual rather than github-releases (a repo-level release check would not track this subpackage specifically). Not re-verified live in this pass."
+
+[[sources]]
+skills = ["styles"]
+name = "wcag-contrast-requirements"
+url = "https://www.w3.org/WAI/WCAG21/quickref/#contrast-minimum"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-04-04"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-04-04. 4.5:1 normal text, 3:1 large text, 3:1 UI components. WCAG 2.1 is a finalized W3C recommendation — not re-verified live in this pass, but stable by nature (superseded by 2.2/3.0 rather than revised in place)."
+
+[[sources]]
+skills = ["styles"]
+name = "slidev-unocss-theming"
+url = "https://sli.dev/custom/config-unocss"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-04-04"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-04-04. Theme shortcuts, CSS variables, custom rules. Not re-verified live in this pass."
+
+# ----------------------------------------------------------------------------
+# Interactive Demos — Vue 3 reactivity, Slidev custom component integration,
+# iframe layouts.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["interactive"]
+name = "vue3-composition-api"
+url = "https://vuejs.org/api/composition-api-setup.html"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-04-04"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-04-04. ref(), reactive(), computed(), watch(), lifecycle hooks. Not re-verified live in this pass."
+
+[[sources]]
+skills = ["interactive"]
+name = "slidev-custom-components"
+url = "https://sli.dev/custom/vue-context"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-04-04"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-04-04. $slidev context, useSlideContext(), v-click integration, auto-import from components/. Not re-verified live in this pass."
+
+[[sources]]
+skills = ["interactive"]
+name = "slidev-iframe-layouts"
+url = "https://sli.dev/builtin/layouts#iframe"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-04-04"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-04-04. iframe, iframe-left, iframe-right layouts, URL property. Not re-verified live in this pass."

--- a/plugins/tools/whamm/.claude-plugin/plugin.json
+++ b/plugins/tools/whamm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "whamm",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "whamm! WebAssembly bytecode instrumentation: install via mise, the instr/info CLI, injection strategies, and the DTrace-inspired .mm monitor DSL",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/whamm/skills/sources.md
+++ b/plugins/tools/whamm/skills/sources.md
@@ -2,6 +2,8 @@
 
 This document tracks the sources used to develop skills in the whamm plugin.
 
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `whamm` (the whamm Tool Skill section below), `whamm-docs-book` (the mdBook site cited across both the whamm Tool Skill and whamm-dsl Skill sections below).
+
 ## whamm Tool Skill
 
 - **URL:** https://github.com/ejrgilbert/whamm
@@ -45,10 +47,3 @@ This document tracks the sources used to develop skills in the whamm plugin.
   - **Purpose:** Detailed syntax documentation pages
   - **Date Accessed:** 2026-06-18
   - **Key Topics:** Syntax reference, grammar, code examples
-
-## Plugin Information
-
-- **Name:** whamm
-- **Version:** 0.1.0
-- **Skills:** 2 (whamm, whamm-dsl)
-- **Created:** 2026-06-18

--- a/plugins/tools/whamm/skills/sources.toml
+++ b/plugins/tools/whamm/skills/sources.toml
@@ -1,0 +1,44 @@
+# sources.toml - Machine-readable version tracking for skill dependencies
+# Run `mise sources:check` to compare against the latest upstream release.
+
+[meta]
+plugin = "whamm"
+reviewed_at_plugin_version = "0.1.0"
+last_full_check = "2026-07-30"
+
+# ----------------------------------------------------------------------------
+# ejrgilbert/whamm — the whamm! WebAssembly bytecode instrumentation tool
+# itself: README, CLI, release binaries. Backs the whamm skill.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["whamm"]
+name = "whamm"
+url = "https://github.com/ejrgilbert/whamm"
+releases_url = "https://github.com/ejrgilbert/whamm/releases"
+check_method = "github-releases"
+github_repo = "ejrgilbert/whamm"
+current_version = "v0.1.0"
+version_constraint = "pre-1.0"
+last_checked = "2026-07-30"
+update_priority = "high"
+breaking_changes_likely = true
+notes = "sources.md pins release v0.1.0 (2026-03-04, Date Accessed 2026-06-18): whamm tool overview, install, CLI usage. The /releases page (linux-x86_64 and macos-x86_64 binary assets) is the same repo's release feed, not tracked as a separate source. Live GitHub API check 2026-07-30 shows tag_name v1.0.0 published 2026-06-26 — a major version jump from the documented 0.1.0; skill content has not been re-verified against 1.0.0, so current_version stays pinned to the sources.md-verified value per the no-silent-advance rule. Given the 0.x -> 1.0 jump, this is flagged high priority / breaking_changes_likely."
+
+# ----------------------------------------------------------------------------
+# whamm docs book (ejrgilbert.github.io/whamm) — the mdBook site. Root page is
+# cited by the whamm skill ("Getting started"); the whamm-dsl skill cites five
+# subpages of the same book (language, events, libraries, injection
+# strategies, syntax reference). One upstream, no independent release/version
+# feed of its own — it tracks the whamm tool above.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["whamm", "whamm-dsl"]
+name = "whamm-docs-book"
+url = "https://ejrgilbert.github.io/whamm/"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-06-18"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "sources.md Date Accessed 2026-06-18 for all six pages; not re-verified live in this pass. Root page (Getting started, language reference, events, libraries, injection strategies) backs the whamm skill. Five subpages back whamm-dsl: intro/language.html (syntax, operators, expressions, program structure), intro/events.html (event types, matching, callback patterns), intro/libraries.html (available functions, data types, stdlib reference), intro/injection_strategies.html (injection approaches, optimization, performance), intro/syntax/ (syntax reference, grammar, code examples). Given the whamm repo itself jumped 0.1.0 -> v1.0.0 (see the whamm entry above), this doc content should be re-verified against the new major version — flagged medium priority pending that check, though the docs site was not independently re-checked live in this pass."

--- a/test/quality-baseline.json
+++ b/test/quality-baseline.json
@@ -268,13 +268,6 @@
       "detail_count": null
     },
     {
-      "key": "github/community-health:source",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
       "key": "qa/qa:ref_depth",
       "class": "DEBT",
       "issue": "claude-skills-145",


### PR DESCRIPTION
Closes claude-skills-183. **This completes the migration: all 28 plugins now have a conforming `sources.toml`, 206 entries, 0 pending.**

Wave B is the 8 plugins whose sources.md is organised *by source* rather than by skill, plus the oddballs: agent-sandboxing (7 skills), claude-code (12), github (6), slidev (8), whamm (2), allium, altana, runex.

## The by-source files needed reading, not slugging

`claude-code` is the inverse of everything migrated so far — 441 lines organised by source, with multi-skill "Used In" bullets. The attribution that a heading-slugger would have lost: **`subagents-docs` covers both `claude-teams` and `claude-agents`**, a link visible nowhere in the Used In bullets. It only surfaces in the Update History section, where the same URL was re-fetched in July to drive a `claude-agents` frontmatter refresh.

`slidev` produced the mirror-image case: sources.md files "Draggable Elements" under the **Export** heading, but `v-drag` is documented only in `syntax/references/syntax.md:376-391` and nowhere in `export/`. Attributed to `syntax` — the one entry where the file's own section placement disagrees with where the content actually lives.

## runex: zero URLs, and no URL invented

`runex`'s sources.md has **no URL at all across 47 lines**, so there was nothing to convert mechanically. It resolved as neither "sources never recorded" nor a `none` entry: it is a first-party **private** repo whose skill is authored by reading the source tree directly (`mix.exs`, `lib/**`, `config/runtime.exs`). The `vinnie357/runex` identifier is transcribed from sources.md line 6 and the `https://github.com/` prefix constructed around it — a derivation from recorded data, not an invention, and worth stating precisely rather than as "transcribed". `current_version = "0.0.7"` traces to the skill's own "Current documented version" line at SKILL.md:11.

It stayed `check_method = "manual"` even though an unauthenticated `git ls-remote` unexpectedly succeeded locally — correctly reasoned as a cached credential helper rather than proof that an unauthenticated CI check would resolve. The unauthenticated API call returns 404, as expected for a private repo.

## A brief I gave was wrong, and the agent overruled it

I told the wave-B agent that "allium's upstream has zero published GitHub Releases." That is true of **`juxt/allium`** (the spec DSL — 404 confirmed) and false of **`juxt/allium-tools`** (the CLI binary the skill actually installs — `releases/latest` returns v3.5.0, with 18+ releases). The agent tested both rather than following me and split them into two honest entries.

The already-merged `core` entry from batch 2 names `juxt/allium` specifically, so its "no published releases" claim is accurate and needs no correction — my summary of it was what over-generalised.

## Format quirks handled

- **whamm** writes `- **Version:**` with the colon *inside* the bold, which is why naive extraction misses it — and why `c3_md_version_bullet` (matching `^\s*-\s*\*\*Version\*\*:`) does not trip on it today. The whole stale `## Plugin Information` block was deleted anyway; a second copy of a version nobody maintains is the drift this epic removes.
- **agent-sandboxing** carries `- **Version verified against**:` lines. Those are upstream *tool* versions and map to each entry's `current_version` — not to `[meta].reviewed_at_plugin_version`, which must hold a plugin.json semver.

## A third dead release feed

`actions/toolkit` returns **HTTP 404** from `releases/latest` (monorepo of independently-versioned npm packages, no repo-level release), so `github-releases` would have produced a check that silently never fires. It is `manual`, with the reason recorded. That is the third such upstream this migration has caught, after `allium` and `json-schema-to-nickel`.

Also noted without acting: `contributor-covenant/contributor_covenant` no longer resolves (now `EthicalSource/contributor_covenant`), but that entry targets the docs *site* cited in sources.md, not the repo, so `url` and `check_method` are unchanged.

## Discipline held from earlier waves

No pin was advanced during migration. Real drift recorded in `notes` only, including `whamm` 0.1.0 → live 1.0.0 (major, flagged high priority + `breaking_changes_likely`) and `kubernetes-sigs/agent-sandbox` v0.4.6 → live v0.5.4.

Entry names follow the tightened `c2` from #177: every name appears in sources.md **prose**, verified by computing the scheme-stripped containment per entry rather than eyeballing, and no entry is named after a URL fragment.

## Deleting stale metadata tripped a check that was reading it as evidence

Gate 1 caught this, and the diagnosis is worth keeping. Deleting slidev's `## Plugin Information` block removed the **only** two mentions of the word "troubleshooting" from its sources.md, so the legacy `source` quality check — a naive substring test for the skill name — went from passing to failing. The block deserved deleting: it claimed version 0.2.0 against an actual 0.2.3 and listed a stale skill inventory.

Fixed with real index content rather than a lint-dodge: a paragraph recording that the `slidev` and `troubleshooting` skills have no section of their own because they draw on sources cited elsewhere, naming which ones and why (the export flags, the `mdc: true` code-group requirement, the Monaco case). `sources.toml` already carries both attributions in its `skills` arrays.

This is the concrete argument for **claude-skills-184**, which retires that substring check: it infers coverage from prose that happens to contain a skill's name, while `sources.toml` now states coverage exactly and is verified by set difference.

## Gates

`mise test` exit 0; `mise run test:version-bumps origin/main` exit 0 for all 8 plugins; `nu test/validate-sources.nu` clean at **28 validated / 0 pending**; self-test 48 cases; gitleaks clean.

**Waivers 65 → 64** — down, not flat. `github/community-health:source` began passing once its `Entries:` sentence gave it a genuine prose mention, and the shrink-only baseline requires removing a fixed entry to lock the fix in (7 deletions, 0 insertions).

Coverage verified by set difference per plugin: union of `skills` arrays equals the plugin.json skill set for all 28, zero uncovered and zero phantom.
