### PR TITLE
docs(tweag): make three reference files reachable from their SKILL.md

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -452,7 +452,7 @@
       "source": "./plugins/tools/tweag",
       "strict": true,
       "description": "Tweag tools: Topiary universal code formatter and Nickel configuration language",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "category": "tools",
       "keywords": [
         "tweag",

--- a/plugins/tools/tweag/.claude-plugin/plugin.json
+++ b/plugins/tools/tweag/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tweag",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Tweag tools: Topiary universal code formatter and Nickel configuration language",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/tweag/skills/nickel/SKILL.md
+++ b/plugins/tools/tweag/skills/nickel/SKILL.md
@@ -399,9 +399,14 @@ nickel export config.ncl --format toml --output config.toml
 """
 ```
 
+## References
+
+- `references/contract-patterns.md` — contract annotation syntax and the validation patterns used for configuration schemas. Read when writing or debugging a contract.
+- `references/import-export.md` — converting between config formats and validating imported data. Read when moving data in or out of Nickel.
+
 ## Additional Resources
 
 - [Nickel Official Documentation](https://nickel-lang.org)
 - [Contracts Guide](https://nickel-lang.org/user-manual/contracts/)
 - [Typing Guide](https://nickel-lang.org/user-manual/typing/)
-- [GitHub Repository](https://github.com/tweag/nickel)
+- [GitHub Repository](https://github.com/nickel-lang/nickel)

--- a/plugins/tools/tweag/skills/topiary/SKILL.md
+++ b/plugins/tools/tweag/skills/topiary/SKILL.md
@@ -366,6 +366,10 @@ mise run fmt:check
 mise run fmt:debug -- script.ncl
 ```
 
+## References
+
+- `references/query-syntax.md` — the S-expression query syntax Topiary uses to match code patterns and apply formatting rules. Read when writing or debugging a `.scm` query file.
+
 ## Anti-Fabrication Note
 
 Before claiming that Topiary formats a language or query correctly, verify behavior by running `topiary fmt` on actual code files and inspecting the output. Do not assume query behavior without testing; use `topiary visualise` to inspect the parse tree and confirm node names and structure match the query. Test idempotency by running the formatter twice and confirming output is identical.

--- a/test/quality-baseline.json
+++ b/test/quality-baseline.json
@@ -317,20 +317,6 @@
       "detail_count": null
     },
     {
-      "key": "tweag/nickel:orphans",
-      "class": "DEBT",
-      "issue": "claude-skills-140",
-      "first_seen": "migrated",
-      "detail_count": 2
-    },
-    {
-      "key": "tweag/topiary:orphans",
-      "class": "DEBT",
-      "issue": "claude-skills-140",
-      "first_seen": "migrated",
-      "detail_count": 1
-    },
-    {
       "key": "ui/daisyui:anti_fab",
       "class": "DEBT",
       "issue": "claude-skills-144",


### PR DESCRIPTION
Closes claude-skills-140. First of the two burn-down items the sources epic was clearing the way for.

## Three reference files nobody could reach

`tweag/nickel` and `tweag/topiary` carried three reference files that exist on disk but are mentioned nowhere in their SKILL.md — so under progressive disclosure an agent has no path to them. Neither SKILL.md contained the token `references/` at all.

They are not dead content: **383, 420, and 373 lines** respectively. So the fix is navigation, not deletion.

- `nickel` gains a `## References` section pointing at `references/contract-patterns.md` (contract syntax and schema-validation patterns) and `references/import-export.md` (format conversion and validating imported data).
- `topiary` gains one pointing at `references/query-syntax.md` (the S-expression query syntax for `.scm` files).

Each line says what the file contains **and when to read it**, so the pointer earns its place in a body that loads on every activation rather than just satisfying the `orphans` check.

## Waivers 57 → 55

Both `tweag/nickel:orphans` and `tweag/topiary:orphans` now pass, and the shrink-only baseline requires removing a fixed entry to lock the fix in. The diff is **removal-only: 0 insertions**.

These two entries were also load-bearing for **claude-skills-132**, which requires every waiver to carry a linked issue — they pointed here.

## One adjacent fix, disclosed

`nickel/SKILL.md:412` cited `https://github.com/tweag/nickel`. That repo **301-redirects to `nickel-lang/nickel`** — a rename this migration caught and verified (repo id 164738063), and one the plugin's own `sources.toml` already records. A skill body disagreeing with its plugin's structured source-of-truth is the exact drift this epic exists to remove, and it sat one line from an edit I was already making, so it is corrected here.

**Deliberately not touched:** `tweag/skills/sources.md` still shows `tweag/topiary` and `tweag/nickel` as the URLs accessed at the time. That is the intended division — `sources.md` records what was read and when, `sources.toml` records how to check the source now, carrying the current `github_repo` and the rename in its `notes`. Rewriting the historical record to match today's paths would erase the evidence that the rename happened.

## Gates

`mise test` exit 0; `mise run test:version-bumps origin/main` exit 0 with `tweag` bumped 0.1.2 → 0.1.3; corpus 28 validated / 0 pending; all 8 skills-quality self-test suites green; waivers **57 → 55**, baseline diff removal-only; gitleaks clean.
