### PR TITLE
docs(nushell): document the read-and-rewrite-same-path truncation gotcha

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -143,7 +143,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
-      "version": "0.2.44",
+      "version": "0.2.45",
       "category": "development",
       "keywords": [
         "git",

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.44",
+  "version": "0.2.45",
   "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/nushell/SKILL.md
+++ b/plugins/core/skills/nushell/SKILL.md
@@ -174,6 +174,37 @@ let output = (^git status)
 
 `$"hello (world)"` tries to evaluate `world` as an expression. Escape the parens or lift the value into a variable first.
 
+### Read-and-rewrite-same-path truncates the file
+
+`open --raw` returns a stream. If a `save` back to that same path is still in the same pipeline, `save` opens the path for writing while the stream is still being read, and the file gets truncated. This zeroed `.claude-plugin/plugin.json` from 142 lines to 0 bytes during a real batch edit.
+
+```nu
+# WRONG — save races the still-reading open on the same path
+open --raw $f | lines | each {|l| ... } | str join "\n" | save --force --raw $f
+
+# CORRECT — force the read to finish before any save touches the path
+let content = (open --raw $f | lines | each {|l| ... })
+($content | str join "\n") + "\n" | save --force --raw $f
+```
+
+**Diagnostic tell:** a partial blast radius. In the incident, ten sibling files rewritten with `let lines = (open --raw $path | lines)` all survived; only the one file piped straight into `save` on its own path died. Same logic, one casualty — that split is the signature of this bug, not a logic error.
+
+Two more failures ride along with it:
+
+- `lines` drops the trailing newline and `str join` does not restore it, so a rewrite silently strips the final byte — check the target's existing convention with `xxd <file> | tail -1` first (not every file has one) and append `+ "\n"` only when it matches.
+- Do not verify a rewrite with `tail -c1`. Verified: on a zero-byte file it returns empty, same as a healthy file ending in a newline — `tail -c1` reported the destroyed file as fine. Verify against `git show HEAD:<path>` or a line count instead.
+
+**Detection**, with two caveats that matter more than the pattern:
+
+```
+grep -nE 'open .*\$([A-Za-z_][A-Za-z0-9_]*).*save .*\$\1' script.nu   # BSD grep
+grep -nP 'open .*\$([A-Za-z_][A-Za-z0-9_]*).*save .*\$\1' script.nu   # GNU grep, ugrep
+```
+
+The backreference is what makes this precise — it matches only when the same variable is read and written — and it is also why **no single invocation is portable**. Verified on this machine: `-E` with `\1` works under BSD `/usr/bin/grep` but ugrep's `-E` rejects it as an invalid escape, while `-P` works under ugrep and GNU grep but BSD grep has no `-P` option. Check which `grep` you actually have before trusting a clean run.
+
+Both forms are line-based, so both **miss a pipeline split across lines** — confirmed against a fixture. There is no reliable one-line detection for that case; read any pipeline containing both `open --raw` and `save` by eye when they are more than a line or two apart.
+
 ## Key principles
 
 - **Structured data first**: think in tables and records, not text; leverage `where`/`select`/`get` over regex

--- a/plugins/core/skills/nushell/SKILL.md
+++ b/plugins/core/skills/nushell/SKILL.md
@@ -176,7 +176,9 @@ let output = (^git status)
 
 ### Read-and-rewrite-same-path truncates the file
 
-`open --raw` returns a stream. If a `save` back to that same path is still in the same pipeline, `save` opens the path for writing while the stream is still being read, and the file gets truncated. This zeroed `.claude-plugin/plugin.json` from 142 lines to 0 bytes during a real batch edit.
+`open --raw` returns a stream. If a `save` back to that same path is still in the same pipeline, `save` can open the path for writing while the stream is still being read, and the file is truncated. This zeroed `.claude-plugin/plugin.json` from 142 lines to 0 bytes during a real batch edit.
+
+Whether it truncates depends on whether the pipeline streams or collects — `lines | each | str join` streams and destroys the file every time; a collecting stage such as `str replace` happens to survive. Do not rely on that distinction: treat any read-and-save of one path in a single pipeline as unsafe.
 
 ```nu
 # WRONG — save races the still-reading open on the same path
@@ -184,6 +186,7 @@ open --raw $f | lines | each {|l| ... } | str join "\n" | save --force --raw $f
 
 # CORRECT — force the read to finish before any save touches the path
 let content = (open --raw $f | lines | each {|l| ... })
+# append "\n" only if the target had one — see the trailing-newline bullet below
 ($content | str join "\n") + "\n" | save --force --raw $f
 ```
 
@@ -201,7 +204,7 @@ grep -nE 'open .*\$([A-Za-z_][A-Za-z0-9_]*).*save .*\$\1' script.nu   # BSD grep
 grep -nP 'open .*\$([A-Za-z_][A-Za-z0-9_]*).*save .*\$\1' script.nu   # GNU grep, ugrep
 ```
 
-The backreference is what makes this precise — it matches only when the same variable is read and written — and it is also why **no single invocation is portable**. Verified on this machine: `-E` with `\1` works under BSD `/usr/bin/grep` but ugrep's `-E` rejects it as an invalid escape, while `-P` works under ugrep and GNU grep but BSD grep has no `-P` option. Check which `grep` you actually have before trusting a clean run.
+The backreference is what narrows this to the same variable being read and written, and it is also why **no single invocation is portable**. Directly tested: `-E` with `\1` works under BSD `/usr/bin/grep`, which has no `-P` option at all; ugrep's `-E` rejects `\1` as an invalid escape but its `-P` works. GNU grep accepts `-P` where built with PCRE — documented, not tested here. Check which `grep` you actually have before trusting a clean run.
 
 Both forms are line-based, so both **miss a pipeline split across lines** — confirmed against a fixture. There is no reliable one-line detection for that case; read any pipeline containing both `open --raw` and `save` by eye when they are more than a line or two apart.
 


### PR DESCRIPTION
Closes claude-skills-188. Documents a nushell footgun that **destroyed a file in this repo this week** — I hit it myself while batch-editing plugin manifests, so the entry is written from the incident rather than from the manual.

## The bug

```nu
open --raw $f | lines | each {|l| ... } | str join "\n" | save --force --raw $f
```

`open --raw` returns a **stream**. `save` opens the same path for writing while that stream is still being read, and the file is truncated. This took `.claude-plugin/plugin.json` from 142 lines to **0 bytes**.

The fix is to force the read to complete before any save touches the path — materialize into a variable first.

## The diagnostic tell is the load-bearing part

In the incident a loop over ten `plugin.json` files bound its read to a variable (`let lines = (open --raw $path | lines)`) and every one survived; only the single file written as one unbroken pipeline died. **Same logic, one casualty.** That partial blast radius is the signature, and it is what distinguishes this from a logic error — which is exactly the reasoning that would have found it in minutes instead of after a `git checkout`.

## Two failures that ride along

- `lines` drops the trailing newline and `str join` does not restore it, so a rewrite silently strips the final byte — eleven files at once in the incident, surfacing as spurious `-}` / `+}` diff hunks. Check the target's existing convention with `xxd <file> | tail -1` first: this repo's root `plugin.json` ends `}` with no newline while the per-plugin manifests end `}\n`, so blanket-appending creates churn the generator immediately undoes.
- **Do not verify a rewrite with `tail -c1`.** On a zero-byte file it returns empty — identical to a healthy file ending in a newline. It reported the destroyed file as fine at the exact moment it had been destroyed.

## The detection command, and why it needed a second pass

The bee asked whether a detection grep is practical. The first draft shipped one bare:

```
grep -nE 'open .*\$([A-Za-z_][A-Za-z0-9_]*).*save .*\$\1' script.nu
```

Testing it against fixtures found it **errors on the default `grep` of the machine it was written on**. The backreference is what makes the pattern precise — it matches only when the same variable is read and written — and it is also what makes it unportable:

- `-E` with `\1` works under BSD `/usr/bin/grep`, but ugrep's `-E` rejects it as an invalid escape.
- `-P` works under ugrep and GNU grep, but BSD grep has no `-P` option at all.

Verified by running all four combinations against a broken fixture and a different-variable fixture that must not match. Both forms are now documented with which grep each needs, plus the instruction to check what `grep` you actually have before trusting a clean run.

Both are line-based, so both **miss a pipeline split across lines** — also confirmed against a fixture, and stated in the entry. A detection command that silently misses the real case would be worse than none, and the other three gotchas in that section carry commands that genuinely work.

## Gates

`mise test` exit 0; `mise run test:version-bumps origin/main` exit 0 with `core` bumped 0.2.44 → 0.2.45; corpus 28 validated / 0 pending; all 8 skills-quality self-test suites green; waivers **49 — unchanged**; baseline diff empty; gitleaks clean.

SKILL.md 193 → 227 lines, well under the 500 cap. `grep -c '\${'` returns 0 — no braced expansions, which would expand at skill load time.

## Gate 3 — approved, three findings folded in

The review reproduced every behavioural claim rather than reading them: truncation **5/5 on fresh fixtures** (390 B → 0 B), the fix surviving intact, the partial-blast-radius asymmetry side by side, all four grep combinations against match / must-not-match / multi-line fixtures, and `tail -c1` on both a zero-byte and a newline-terminated file.

Three findings were worth folding in rather than deferring, because this entry teaches behaviour and a reader acts on it:

- **The blanket claim had a counterexample.** `open --raw $f | str replace ... | save $f` does **not** truncate — `str replace` collects rather than streams (tested at 390 B and 2.2 MB). The shown WRONG form truncates every time, so the guidance erred safe, but "the file gets truncated" was too absolute. Now states that streaming stages destroy and collecting stages happen to survive, with the instruction not to rely on the distinction.
- **The CORRECT block contradicted the bullet below it.** It hard-codes `+ "\n"` while the next bullet says append only when the target already had one — copying it onto this repo's root `plugin.json` would create exactly the churn that bullet warns about. Now carries an inline comment pointing at the bullet.
- **I overreached on provenance.** I wrote "Verified on this machine" over a sentence that included GNU grep's behaviour — and **GNU grep is not installed here** (the reviewer checked `ggrep`, gnubin, and mise). The claim about GNU grep is true but was not something I tested. Now scoped: BSD and ugrep are marked directly tested, GNU is marked documented-not-tested.

Also corrected: this body said 194 → 224 lines; actual is **193 → 227**. That is the fourth wrong count an epic PR body has shipped, which is why the reviewers keep being asked to recompute them.

Left as noted, not fixed: the backreference matches prefix-sharing variable names (`$f` also matches `$frob`) — a false positive in the safe direction, which surfaces a pipeline for a human to read rather than hiding one.
