### PR TITLE
docs(skills-quality): document the ref_depth order requirement and surface nested filenames

### DIFF
--- a/test/validate-skills-quality.nu
+++ b/test/validate-skills-quality.nu
@@ -133,6 +133,8 @@ def cross-skill-qualified [prefix_line: string, dir_name: string, path: string, 
 
 # Text preceding the first occurrence of `path` in `content`, truncated to
 # just its own line (so cross-skill-qualified only sees same-line context).
+# The same truncation makes the exemption order-sensitive for checks 14 and
+# Pass-2 too — see has-unqualified-references-token's header for the rationale.
 def preceding-line [content: string, path: string]: nothing -> string {
     let idx = ($content | str index-of $path)
     if $idx < 0 {
@@ -261,6 +263,25 @@ def pass2-dir-in-scope [top: string, own_dir: string, plugin_dir: string]: nothi
 #   concrete sibling file. Accepted residual: a sibling pointer written
 #   without a file extension escapes (check 14's link regex shares this
 #   extension requirement).
+# - The cross-skill exemption is evaluated against the text BEFORE the
+#   `references/` token only (the prefix/rest split just below), so it
+#   fires only when the `/ns:skill` (or `plugins/<...>/skills/<other>/`)
+#   qualifier PRECEDES the path on the same line. This residual differs in
+#   kind from the two above: those silently PASS things that should fail;
+#   this one silently FAILS something legitimate. Flagged:
+#   ``Per `references/x.md` in `/core:tdd`: ...``. Exempt:
+#   ``Per `/core:tdd`'s `references/x.md`: ...``. Both name the same real
+#   file — fix by reordering the sentence. Not widened to whole-line
+#   matching: measured against this corpus (claude-skills-195 plan), that
+#   breaks the `plugins/<...>/skills/<other>/` qualifier form (its regex is
+#   `$`-anchored, so it can only match a line-ending prefix), costing 1
+#   corpus exemption, while a later mention of an unknown namespace or of a
+#   sibling skill sharing the same reference basename (19 such basenames in
+#   this corpus) would silently exempt a genuine same-skill link — against
+#   0 current false positives from the order requirement. A gated design
+#   (prefix-first, whole-line fallback only when the citing skill does not
+#   own the cited path) was evaluated and deferred until a real instance
+#   needs it.
 def has-unqualified-references-token [content: string, dir_name: string, skill_dir_map: list, known_plugins: list]: nothing -> bool {
     ($content | lines | any {|line|
         if not ($line | str contains "references/") {
@@ -2314,7 +2335,7 @@ def main [--update-baseline, --self-test] {
                 score: $"($score)/($check_count)"
                 failed: ($failed | str join " ")
                 new: ($new_failures | each {|k| $k | split row ":" | last} | str join " ")
-                details: ($broken_links | append $bad_invocations | append $stale_pins | append ($orphans | each {|f| $f | path basename}) | append ($fm_unknown | each {|k| $"frontmatter:($k)"}) | str join " ")
+                details: ($broken_links | append $bad_invocations | append $stale_pins | append ($orphans | each {|f| $f | path basename}) | append ($fm_unknown | each {|k| $"frontmatter:($k)"}) | append ($nested | each {|r| $"nested:($r.name)"}) | str join " ")
             })
 
             if ($failed | is-empty) {

--- a/test/validate-skills-quality.nu
+++ b/test/validate-skills-quality.nu
@@ -1033,6 +1033,50 @@ def run-check-fixes-self-test [] {
         $failed = true
     }
 
+    # --- ref_depth cross-skill exemption is word-order sensitive (claude-skills-195) ---
+    # These three cases pin the documented residual on
+    # has-unqualified-references-token's header comment (accepted-residual
+    # bullet three): the exemption fires only when the /ns:skill qualifier
+    # PRECEDES the references/ path on the same line. Unlike the cases
+    # above, they build a REAL skill_dir_map fixture — the existing ref_depth
+    # cases all pass `[] []`, which makes every qualifier resolve as
+    # "unknown -> exempt" and would make an order check vacuous. This
+    # fixture (a synthetic mktemp tree, never a real corpus skill, so a
+    # future reference-file rename in this repo can't break it) makes the
+    # `path exists` branch of cross-skill-qualified genuinely fire.
+    let rd_root = (mktemp -d)
+    mkdir ($rd_root | path join "otherns" "skills" "otherskill" "references")
+    "content" | save ($rd_root | path join "otherns" "skills" "otherskill" "references" "foo.md")
+    let rd_map = [{skill: "otherskill", dir: ($rd_root | path join "otherns" "skills" "otherskill"), plugin: "otherns"}]
+    let rd_plugins = ["otherns"]
+
+    # Case: qualifier BEFORE the path — a real cross-skill pointer whose
+    # target file exists in the other skill's own tree. NOT flagged.
+    if (has-unqualified-references-token "Per `/otherns:otherskill`'s `references/foo.md`: see there for detail." "myskill" $rd_map $rd_plugins) {
+        print $"(ansi red_bold)❌ check-fix self-test: qualifier-before cross-skill pointer wrongly flagged(ansi reset)"
+        $failed = true
+    }
+
+    # Case: the SAME pointer, reordered so the qualifier comes AFTER the
+    # path. This is the documented residual, not a bug — the test's purpose
+    # is to make a silent future widening (to whole-line matching)
+    # impossible without a failing test alerting the author.
+    if not (has-unqualified-references-token "Per `references/foo.md` in `/otherns:otherskill`: see there for detail." "myskill" $rd_map $rd_plugins) {
+        print $"(ansi red_bold)❌ check-fix self-test: qualifier-after cross-skill pointer no longer flagged \(documented residual regressed\)(ansi reset)"
+        $failed = true
+    }
+
+    # Case: a genuine SAME-skill link (no cross-skill qualifier applies to
+    # it at all) with an unrelated but real, resolvable plugin:skill mention
+    # AFTER the path on the line. Regression guard against widening to
+    # whole-line matching: the plan's adversarial measurement shows
+    # whole-line matching would wrongly treat the trailing mention as an
+    # exemption qualifier for the earlier, unrelated path. Must stay flagged.
+    if not (has-unqualified-references-token "See references/bar.md for detail, mirroring the layout in /otherns:otherskill." "myskill" $rd_map $rd_plugins) {
+        print $"(ansi red_bold)❌ check-fix self-test: same-skill link with trailing unrelated plugin mention wrongly exempted(ansi reset)"
+        $failed = true
+    }
+
     # --- invocations (enumerated upstream commands, no namespace exemption) ---
     let allium_cmds = ($UPSTREAM_COMMANDS | where ns == "allium" | first | get commands)
     let reg = [
@@ -1057,7 +1101,7 @@ def run-check-fixes-self-test [] {
     }
 
     if not $failed {
-        print $"(ansi green_bold)✅ Check-fix self-test passed \(19 cases\)(ansi reset)"
+        print $"(ansi green_bold)✅ Check-fix self-test passed \(22 cases\)(ansi reset)"
     }
     $failed
 }

--- a/test/validate-skills-quality.nu
+++ b/test/validate-skills-quality.nu
@@ -1055,7 +1055,7 @@ def run-check-fixes-self-test [] {
     }
 
     # --- ref_depth cross-skill exemption is word-order sensitive (claude-skills-195) ---
-    # These three cases pin the documented residual on
+    # These four cases pin the documented residual on
     # has-unqualified-references-token's header comment (accepted-residual
     # bullet three): the exemption fires only when the /ns:skill qualifier
     # PRECEDES the references/ path on the same line. Unlike the cases
@@ -1064,10 +1064,13 @@ def run-check-fixes-self-test [] {
     # "unknown -> exempt" and would make an order check vacuous. This
     # fixture (a synthetic mktemp tree, never a real corpus skill, so a
     # future reference-file rename in this repo can't break it) makes the
-    # `path exists` branch of cross-skill-qualified genuinely fire.
+    # `path exists` branch of cross-skill-qualified genuinely fire. otherskill
+    # owns BOTH foo.md and bar.md — the bar.md duplicate basename is what
+    # makes case 3 below load-bearing (the 19-colliding-basenames shape).
     let rd_root = (mktemp -d)
     mkdir ($rd_root | path join "otherns" "skills" "otherskill" "references")
     "content" | save ($rd_root | path join "otherns" "skills" "otherskill" "references" "foo.md")
+    "content" | save ($rd_root | path join "otherns" "skills" "otherskill" "references" "bar.md")
     let rd_map = [{skill: "otherskill", dir: ($rd_root | path join "otherns" "skills" "otherskill"), plugin: "otherns"}]
     let rd_plugins = ["otherns"]
 
@@ -1087,16 +1090,39 @@ def run-check-fixes-self-test [] {
         $failed = true
     }
 
-    # Case: a genuine SAME-skill link (no cross-skill qualifier applies to
-    # it at all) with an unrelated but real, resolvable plugin:skill mention
-    # AFTER the path on the line. Regression guard against widening to
-    # whole-line matching: the plan's adversarial measurement shows
-    # whole-line matching would wrongly treat the trailing mention as an
-    # exemption qualifier for the earlier, unrelated path. Must stay flagged.
+    # Case: a genuine same-skill reference (references/bar.md, owned by
+    # THIS skill, "myskill") followed by an unrelated mention of a
+    # DIFFERENT, real sibling skill (otherskill) that happens to own a
+    # DIFFERENT file sharing the same basename bar.md — the 19-colliding-
+    # basenames shape the header comment cites. Under prefix-only matching
+    # (shipped) the trailing mention is irrelevant since it comes after the
+    # path — correctly flagged. This is the load-bearing regression guard
+    # against whole-line widening: gate-verified that widening resolves
+    # `otherskill` and finds ITS bar.md exists, flipping this to wrongly
+    # exempt even though the path never named otherskill at all.
     if not (has-unqualified-references-token "See references/bar.md for detail, mirroring the layout in /otherns:otherskill." "myskill" $rd_map $rd_plugins) {
-        print $"(ansi red_bold)❌ check-fix self-test: same-skill link with trailing unrelated plugin mention wrongly exempted(ansi reset)"
+        print $"(ansi red_bold)❌ check-fix self-test: same-skill link with trailing same-basename sibling mention wrongly exempted(ansi reset)"
         $failed = true
     }
+
+    # Case: a genuine same-skill reference (references/qux.md — no fixture
+    # file needed; the same-skill link never reaches the `path exists`
+    # branch since no qualifier precedes it) followed by a mention of a
+    # namespace/skill this marketplace does NOT know about at all
+    # (unknown skill "codex" under unknown plugin "openai" — neither is in
+    # rd_map/rd_plugins). Correctly flagged today: no qualifier precedes
+    # the path, so cross-skill-qualified never reaches the "unknown ->
+    # exempt" leniency branch. The second documented false-negative shape:
+    # gate-verified that whole-line widening resolves `codex` via
+    # lookup-skill-dir, gets "" back (truly unknown), and that empty-target
+    # branch (line ~128-130) returns true unconditionally — flipping this
+    # to wrongly exempt via a namespace that owns nothing at all.
+    if not (has-unqualified-references-token "See references/qux.md for detail; the equivalent for Codex lives in /openai:codex." "myskill" $rd_map $rd_plugins) {
+        print $"(ansi red_bold)❌ check-fix self-test: same-skill link with trailing unknown-namespace mention wrongly exempted(ansi reset)"
+        $failed = true
+    }
+
+    rm -rf $rd_root
 
     # --- invocations (enumerated upstream commands, no namespace exemption) ---
     let allium_cmds = ($UPSTREAM_COMMANDS | where ns == "allium" | first | get commands)
@@ -1122,7 +1148,7 @@ def run-check-fixes-self-test [] {
     }
 
     if not $failed {
-        print $"(ansi green_bold)✅ Check-fix self-test passed \(22 cases\)(ansi reset)"
+        print $"(ansi green_bold)✅ Check-fix self-test passed \(23 cases\)(ansi reset)"
     }
     $failed
 }


### PR DESCRIPTION
Closes claude-skills-195, filed during claude-skills-145 when a brief I wrote about this check turned out to be wrong.

## The residual

`ref_depth`'s cross-skill exemption is evaluated against the text **before** the `references/` token only, so it fires only when the qualifier precedes the path:

- ``Per `/core:tdd`'s `references/ci-discipline.md`:`` → exempt
- ``Per `references/ci-discipline.md` in `/core:tdd`:`` → **flagged**

Both name the same real file. This is a **false positive** — the check silently fails legitimate content — which differs in kind from the two residuals already documented on that function, since those silently *pass* things that should fail.

## The bee offered widening the check. Measurement says don't.

The plan measured four things before recommending, and the headline finding is that whole-line matching is **not a widening at all**:

`cross-skill-qualified`'s second qualifier form is `parse --regex 'skills/(?P<skill>[a-z][a-z0-9-]*)/$'` — **anchored to end-of-string**. It only ever matches because it is handed a prefix ending exactly at the token. Feed it the whole line and that anchor can never match, so the repo-path qualifier form stops working entirely. One corpus file (`pm/spec-harvest/references/user-story-format.md`) flips from exempt to **failing**.

Beyond that, whole-line matching converts a false positive into a false **negative**, in two corpus-plausible shapes:

- **Unknown namespace mentioned after the path.** `lookup-skill-dir` returns empty for a name outside the local marketplace and the function then returns `true` unconditionally — so any external plugin mention later on the line exempts a genuine same-skill link.
- **A sibling skill owning the same basename.** This corpus has **19** reference basenames owned by more than one skill — `examples.md` by three, `installation.md` by four, `commands.md` by three.

And the false positive it would fix bites **zero** corpus lines today; the 145 cleanup left no residue. In a lint, trading a false positive for a false negative is strictly worse: the false positive asks an author to reword, the false negative lets the violation land silently.

The helper is shared by four call sites (`ref_depth`, check 14 `links`, and two Pass-2 paths), so the blast radius was real — measurement found 2 further false-negative diffs in check 14 and 1 in Pass-2.

## What landed instead

- **A third accepted-residual bullet** on `has-unqualified-references-token`, giving both example forms, stating that the fix is to reorder the sentence, that this residual differs in kind from the other two, and why it is not widened — with the measured figures attached.
- **One sentence** on `preceding-line` noting the same truncation makes the exemption order-sensitive for checks 14 and Pass-2. Deliberately one sentence, not a copied block: the corpus-wide `duplicate_block` scan uses an 8-line window and the shrink-only baseline cannot accept a new key at all. Verified — still 4 groups, unchanged.
- **Four regression tests** — three committed first at `b4a5369`, a fourth added after review (see the Gate 3 section below): qualifier-before (exempt), qualifier-after (flagged), a same-skill link whose trailing sibling mention names a skill owning the same basename (flagged), and one naming an unknown external namespace (flagged). They pass on arrival — **they are regression guards, not red-first TDD**, and their purpose is to make a future silent widening impossible. The fixture is a real `skill_dir_map` built via `mktemp`, not the existing cases' `[] []`, which would have made every qualifier resolve as "unknown → exempt" and the cases vacuous.
- **The offending filename now reaches the author.** `ref_depth` previously reported only its own name; the `details` column now carries `nested:<filename>`, matching the existing `frontmatter:<key>` convention.

## One item cut from the plan

The plan also proposed printing an advisory line whenever a `ref_depth` failure occurs. **Dropped.** No skill currently fails that check, so it is an unexercisable print path, and the test author confirmed it cannot be unit-tested without extracting a new function from `main` or hand-breaking a skill. The ordering rule belongs in the documentation a maintainer reaches from the check's own source.

`details` survived the same cut because it earns its place differently: it fires for **every** `ref_depth` failure, not only the ordering case.

Since nothing in a clean corpus exercises it, it was proved by hand — a sibling link was temporarily added to `core/tdd/references/ci-discipline.md`, the run showed `ref_depth │ nested:ci-discipline.md` in the details column with the expected unbaselined failure, and reverting returned the corpus to 49 waivers with no FAIL line.

## Gates

`mise test` exit 0; all 8 skills-quality self-test suites green with check-fix at 23 cases; waivers **49 — unchanged**; duplicate blocks **4 groups — unchanged**; corpus 28 validated / 0 pending; `test/quality-baseline.json` diff empty; `test/` is not a plugin so no version bump; gitleaks clean.

## Gate 3 caught a decorative guard — the PR's own deliverable

The three regression cases pass on arrival by design, which makes them impossible to distinguish from decorative ones by looking. So the reviewer was asked to apply the widening they exist to prevent and see which actually go red. **Only one did.**

Case 3 claimed whole-line matching would wrongly exempt a same-skill path via a trailing sibling mention. It did not reproduce: under widening `lookup-skill-dir` resolved the sibling, but `path exists` then returned false because the fixture only ever created `foo.md`. The line stayed flagged **for a reason unrelated to the residual being pinned**. A true assertion, and not the guard its comment described.

The fixture was one line short of real. Adding `bar.md` to the sibling skill — the exact 19-colliding-basenames shape the header comment cites — makes it bite. A fourth case was added for the second documented false-negative shape (unknown namespace after the path), which had no coverage at all and which the reviewer confirmed is load-bearing. A leaked `mktemp -d` was also cleaned up (temp-dir count now holds across runs).

Re-verified independently by applying the widening to a scratch copy and running the suite:

```
                                     shipped        widened
case 1  qualifier-before             not flagged    not flagged   control, must survive either way
case 2  qualifier-after              flagged        NOT flagged   catches it
case 3  same-basename sibling        flagged        NOT flagged   catches it (was decorative)
case 4  unknown namespace            flagged        NOT flagged   catches it (was absent)
```

Three guards fire where one did before. A test that cannot fail under its own target change is worse than no test — it manufactures confidence that the behaviour is pinned.

Check-fix suite 19 → **23 cases**. Waivers **49**, dupe groups **4**, corpus 28/0 — all unchanged.
