### PR TITLE
fix(agent-sandboxing): use bare angle-bracket form for CLAUDE_PLUGIN_ROOT

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -166,7 +166,7 @@
       "source": "./plugins/tools/dagu",
       "strict": true,
       "description": "Dagu workflow orchestration: workflow authoring, web UI, and REST API",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "category": "tools",
       "keywords": [
         "dagu",
@@ -256,7 +256,7 @@
       "source": "./plugins/tools/agent-sandboxing",
       "strict": true,
       "description": "Agent sandboxing for AI coding agents: microVM and kernel-isolated execution environments. Index skill (sandbox) routes to substrate-specific paths. Currently covers the kubernetes-sigs/agent-sandbox path on kind, GKE, and kina (Kubernetes-in-Apple-Containers), with Kata, gVisor, and Apple Container microVM substrates. Ships 7 skills + 6 slash commands + nushell scripts. Designed to expand to non-k8s sandboxing paths.",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "category": "tools",
       "keywords": [
         "agent-sandbox",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.92",
+      "version": "0.4.93",
       "category": "meta",
       "keywords": [
         "skills",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.92",
+  "version": "0.4.93",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/agent-sandboxing/.claude-plugin/plugin.json
+++ b/plugins/tools/agent-sandboxing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sandboxing",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Agent sandboxing for AI coding agents: microVM and kernel-isolated execution environments. Index skill (sandbox) routes to substrate-specific paths. Currently covers the kubernetes-sigs/agent-sandbox path on kind, GKE, and kina (Kubernetes-in-Apple-Containers), with Kata, gVisor, and Apple Container microVM substrates. Ships 7 skills + 6 slash commands + nushell scripts. Designed to expand to non-k8s sandboxing paths.",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/agent-sandboxing/commands/bootstrap.md
+++ b/plugins/tools/agent-sandboxing/commands/bootstrap.md
@@ -87,7 +87,7 @@ Pick the template matching the substrate:
 Override the placeholder image:
 
 ```bash
-TEMPLATE=${CLAUDE_PLUGIN_ROOT}/templates/SandboxTemplate.kata.yaml
+TEMPLATE=<CLAUDE_PLUGIN_ROOT>/templates/SandboxTemplate.kata.yaml
 REGISTRY=${REGISTRY:-ghcr.io/$USER}
 TAG=${TAG:-latest}
 sed -e "s|REGISTRY/claude-code:TAG|${REGISTRY}/claude-code:${TAG}|" $TEMPLATE | kubectl apply -f -

--- a/plugins/tools/agent-sandboxing/commands/build-image.md
+++ b/plugins/tools/agent-sandboxing/commands/build-image.md
@@ -24,8 +24,8 @@ Stage them into a build context:
 
 ```bash
 BUILD_DIR=$(mktemp -d)
-cp ${CLAUDE_PLUGIN_ROOT}/templates/Dockerfile.claude-code $BUILD_DIR/Dockerfile
-cp ${CLAUDE_PLUGIN_ROOT}/templates/mise.toml.claude-code $BUILD_DIR/mise.toml
+cp <CLAUDE_PLUGIN_ROOT>/templates/Dockerfile.claude-code $BUILD_DIR/Dockerfile
+cp <CLAUDE_PLUGIN_ROOT>/templates/mise.toml.claude-code $BUILD_DIR/mise.toml
 ```
 
 ### 2. Build
@@ -65,7 +65,7 @@ Or re-apply from the plugin template with placeholders substituted:
 
 ```bash
 sed -e "s|REGISTRY/claude-code:TAG|${REGISTRY}/claude-code:${TAG}|" \
-  ${CLAUDE_PLUGIN_ROOT}/templates/SandboxTemplate.kata.yaml | kubectl apply -f -
+  <CLAUDE_PLUGIN_ROOT>/templates/SandboxTemplate.kata.yaml | kubectl apply -f -
 ```
 
 ### 5. Clean up

--- a/plugins/tools/agent-sandboxing/commands/provision.md
+++ b/plugins/tools/agent-sandboxing/commands/provision.md
@@ -35,7 +35,7 @@ Typical names: `claude-code-kata`, `claude-code-gvisor`, `claude-code-kina`.
 ### 3. Render the claim
 
 ```bash
-nu ${CLAUDE_PLUGIN_ROOT}/scripts/render-claim.nu \
+nu <CLAUDE_PLUGIN_ROOT>/scripts/render-claim.nu \
   --session-id $SESSION_ID \
   --template $TEMPLATE_NAME \
   ${SHUTDOWN_TIME:+--shutdown-time $SHUTDOWN_TIME} \
@@ -47,7 +47,7 @@ The script reads `templates/SandboxClaim.session.yaml`, substitutes placeholders
 ### 4. Wait for Bound
 
 ```bash
-nu ${CLAUDE_PLUGIN_ROOT}/scripts/wait-bound.nu --session-id $SESSION_ID --timeout 120
+nu <CLAUDE_PLUGIN_ROOT>/scripts/wait-bound.nu --session-id $SESSION_ID --timeout 120
 ```
 
 The script polls `kubectl get sandboxclaim` every 2 seconds until `status.phase == Bound` or the timeout elapses. Reports the bound pod name on success; reports controller log excerpts on timeout.

--- a/plugins/tools/agent-sandboxing/commands/status.md
+++ b/plugins/tools/agent-sandboxing/commands/status.md
@@ -16,7 +16,7 @@ Show the live state of all SandboxClaims for at-a-glance triage.
 ### 1. Render the table
 
 ```bash
-nu ${CLAUDE_PLUGIN_ROOT}/scripts/list-claims.nu ${NAMESPACE:+--namespace $NAMESPACE}
+nu <CLAUDE_PLUGIN_ROOT>/scripts/list-claims.nu ${NAMESPACE:+--namespace $NAMESPACE}
 ```
 
 The script wraps `kubectl get sandboxclaim -o json`, extracts session id, phase, template ref, bound pod, age, and shutdown policy, and emits a nushell table.
@@ -43,7 +43,7 @@ Surface the actual condition text, not a guess.
 If `--watch` was passed:
 
 ```bash
-watch -n 2 "nu ${CLAUDE_PLUGIN_ROOT}/scripts/list-claims.nu"
+watch -n 2 "nu <CLAUDE_PLUGIN_ROOT>/scripts/list-claims.nu"
 ```
 
 Or with kubectl directly:

--- a/plugins/tools/agent-sandboxing/skills/sandbox/SKILL.md
+++ b/plugins/tools/agent-sandboxing/skills/sandbox/SKILL.md
@@ -82,12 +82,12 @@ Both isolate untrusted agent code from the host. Both are valid; pick the one wh
 
 ## Substrate-specific files in this plugin
 
-- `templates/Dockerfile.claude-code` — mise-driven OCI image (uses `claude-code = "latest"` mise registry short name).
-- `templates/SandboxTemplate.{kata,gvisor,kina}.yaml` — three variants; pick by substrate.
-- `templates/SandboxClaim.session.yaml` — per-session claim with `shutdownPolicy: Delete`.
-- `templates/NetworkPolicy.anthropic.yaml` — standalone default-deny + Anthropic egress allowlist (when `networkPolicyManagement: Unmanaged`).
-- `CLAUDE_PLUGIN_ROOT/scripts/render-claim.nu`, `wait-bound.nu`, `list-claims.nu` — nushell scripts at the plugin root (not inside this skill directory), invoked by the slash commands. Shown as a bare path here, not the brace-expansion form, because the braced form itself expands to an absolute path when this skill loads.
-- `mise.toml` — plugin-root mise.toml pinning `nu` + `jq`; exposes `mise run render-claim` / `wait-bound` / `list-claims` / `install-controller` for direct operator use without Claude.
+- `<CLAUDE_PLUGIN_ROOT>/templates/Dockerfile.claude-code` — mise-driven OCI image (uses `claude-code = "latest"` mise registry short name).
+- `<CLAUDE_PLUGIN_ROOT>/templates/SandboxTemplate.{kata,gvisor,kina}.yaml` — three variants; pick by substrate.
+- `<CLAUDE_PLUGIN_ROOT>/templates/SandboxClaim.session.yaml` — per-session claim with `shutdownPolicy: Delete`.
+- `<CLAUDE_PLUGIN_ROOT>/templates/NetworkPolicy.anthropic.yaml` — standalone default-deny + Anthropic egress allowlist (when `networkPolicyManagement: Unmanaged`).
+- `<CLAUDE_PLUGIN_ROOT>/scripts/render-claim.nu`, `wait-bound.nu`, `list-claims.nu` — nushell scripts, invoked by the slash commands.
+- `<CLAUDE_PLUGIN_ROOT>/mise.toml` — plugin-root mise.toml pinning `nu` + `jq`; exposes `mise run render-claim` / `wait-bound` / `list-claims` / `install-controller` for direct operator use without Claude.
 
 ## Anti-fabrication
 

--- a/plugins/tools/dagu/.claude-plugin/plugin.json
+++ b/plugins/tools/dagu/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dagu",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Dagu workflow orchestration: workflow authoring, web UI, and REST API",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/dagu/skills/webui/SKILL.md
+++ b/plugins/tools/dagu/skills/webui/SKILL.md
@@ -57,7 +57,7 @@ For detailed information on a running workflow, consult `references/monitoring.m
 
 ### View History
 
-All executions are preserved; open a workflow's history to review past runs, find failed executions, and retry them (see Common Tasks).
+History retention is configurable, not unconditional — see `references/monitoring.md` "Archive old executions" for pruning old runs. Open a workflow's history to review past runs, find failed executions, and retry them (see Common Tasks).
 
 ### Workflow Visualization
 
@@ -96,7 +96,7 @@ For advanced log analysis, consult `references/monitoring.md`.
 
 - **Real-time visibility**: Web UI provides live updates of workflow execution
 - **Click-based operations**: No CLI needed for basic workflow management
-- **History preservation**: All executions are logged and accessible
+- **History preservation**: Executions are logged and accessible, subject to configurable retention
 - **Visual feedback**: Status indicators show current state at a glance
 - **Log accessibility**: Detailed logs available for debugging
 

--- a/plugins/tools/dagu/skills/webui/SKILL.md
+++ b/plugins/tools/dagu/skills/webui/SKILL.md
@@ -57,7 +57,7 @@ For detailed information on a running workflow, consult `references/monitoring.m
 
 ### View History
 
-History retention is configurable, not unconditional — see `references/monitoring.md` "Archive old executions" for pruning old runs. Open a workflow's history to review past runs, find failed executions, and retry them (see Common Tasks).
+Execution history is not unconditionally preserved — the REST API supports deleting individual records (`DELETE /dags/{dagName}/history/{requestId}`, see `/dagu:rest-api` `references/api-endpoints.md` "Delete Execution History"). Open a workflow's history to review past runs, find failed executions, and retry them (see Common Tasks).
 
 ### Workflow Visualization
 
@@ -96,7 +96,7 @@ For advanced log analysis, consult `references/monitoring.md`.
 
 - **Real-time visibility**: Web UI provides live updates of workflow execution
 - **Click-based operations**: No CLI needed for basic workflow management
-- **History preservation**: Executions are logged and accessible, subject to configurable retention
+- **History preservation**: Executions are logged and accessible; individual records can be deleted via the REST API
 - **Visual feedback**: Status indicators show current state at a glance
 - **Log accessibility**: Detailed logs available for debugging
 


### PR DESCRIPTION
Closes claude-skills-178 and claude-skills-137.

## 178 — braced `CLAUDE_PLUGIN_ROOT` expanded at load time in four command bodies

Eight occurrences of the braced form sat in the BODY of four agent-sandboxing command files (`bootstrap.md`, `build-image.md`, `provision.md`, `status.md`). Command files load as skill content, so the braced form is substituted before the model sees it — replacing each with one machine's absolute cache path, pinned to whatever plugin version happens to be installed. Same defect class as claude-skills-169 and 172, hand-fixed for the third time here.

Fixed to the bare angle-bracket form, which is safe by construction: there is no dollar sign, so there is nothing to expand.

All eight sites verified to want `CLAUDE_PLUGIN_ROOT` rather than `CLAUDE_SKILL_DIR` — `scripts/` and `templates/` live at the plugin root, and `skills/sandbox/` contains only SKILL.md. All referenced artifacts confirmed to exist, so the second-order defect from claude-skills-128 (a path naming a `scripts/` dir that did not exist) is not repeated.

The braced form is deliberately left alone in two places where it is correct: YAML frontmatter, where the harness expands it at hook runtime, and reference files, which `Read` returns as raw bytes.

**Correction, per Gate 3:** an earlier draft of this body claimed the angle-bracket form is "the house style already used elsewhere in the claude-code plugin." That is false. `git grep -c '<CLAUDE_PLUGIN_ROOT>' -- plugins/tools/claude-code/` returns **zero** matches. That plugin uses `CLAUDE_PLUGIN_ROOT` **bare**, and documents the choice twice (`skills/claude-hooks/SKILL.md:37`, `skills/claude-plugins/SKILL.md:71`). Angle brackets ARE house style there — for `CLAUDE_SKILL_DIR`, a different variable. The code is safe either way, so the notation is not being churned; the justification was simply wrong. Settling `CLAUDE_PLUGIN_ROOT` notation repo-wide is filed as a follow-up.

## 137 — two follow-up nits from the PR #132 / #134 reviews

The `skills/sandbox/SKILL.md` bullet list wrote `templates/SandboxTemplate.*.yaml` and `mise.toml` skill-relative, though both are plugin-root artifacts — the same ambiguity PR #132 fixed one line above. Now consistent with the rest of the list.

`skills/webui/SKILL.md` asserted "All executions are preserved" and "History preservation: All executions are logged and accessible". Dagu can delete history, so the absolute was wrong.

**The first attempt at this fix replaced one unverified absolute with another** — it said retention is "configurable", but nothing in the repo evidences a retention setting. Grep across the whole dagu plugin returns only the lines this PR adds; `references/monitoring.md:179` is a bare bullet ("Archive old executions: Keep history manageable") with no mechanism. Both lines now claim only what the evidence supports: history is not unconditionally preserved, because `DELETE /dags/{dagName}/history/{requestId}` exists. Deletable, not configurable.

## Gates

Gate 1 `mise test` exit 0, 49 pre-existing debt entries, no new baseline key. `mise run test:version-bumps origin/main` exit 0 (agent-sandboxing 0.2.8→0.2.9, dagu 0.1.8→0.1.9). gitleaks clean via the native binary.

Gate 2 both remote checks pass; `mergeStateStatus` CLEAN after rebasing onto `e56823f`.

Gate 3 APPROVE — https://github.com/vinnie357/claude-skills/pull/190#issuecomment-5152798062. The reviewer's sharpest attack was that `<...>` inside a bash fence is a redirect pair, so `nu <CLAUDE_PLUGIN_ROOT>/scripts/x.nu` might input-redirect and create a file at an absolute path; tested, bash hits the failing input redirect first, exits 1, and creates nothing. It also confirmed `CLAUDE_PLUGIN_ROOT` is not in the Bash tool environment at all, so the old braced form was expanding to a bare `/templates/...` — this change is a net improvement, not a notation preference. Repo-wide completeness sweep found zero missed sites.

## Follow-ups filed rather than widened into this PR

- Settle `CLAUDE_PLUGIN_ROOT` notation repo-wide; bare vs angle is currently split across plugins.
- Add a lint catching braced `CLAUDE_*` in SKILL.md and `commands/*.md` bodies, allowed in frontmatter, `references/`, `templates/` and manifests. Three hand-fixes of one defect class with no check guarding it; the reviewer hand-classified that exact rule over 614 files with zero false positives.
- Upstream documents `outputStyles`, `lspServers` and `experimental` as plugin.json fields; the `claude-plugins` skill mentions none of them.
