### PR TITLE
fix(pm,beads,rust): correct bees prime data claim, beads package identity, rust gate naming

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.91",
+      "version": "0.4.92",
       "category": "meta",
       "keywords": [
         "skills",
@@ -104,7 +104,7 @@
       "source": "./plugins/tools/beads",
       "strict": true,
       "description": "Beads (bd) distributed git-backed graph issue tracker: task management, dependency tracking, AI agent workflows",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "category": "tools",
       "keywords": [
         "beads",
@@ -311,7 +311,7 @@
       "source": "./plugins/pm",
       "strict": true,
       "description": "Product management toolkit: harvest implementation-agnostic feature specs from prototypes with SDLC guardrails and author PRDs as implementation contracts",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "category": "tools",
       "keywords": [
         "pm",
@@ -401,7 +401,7 @@
       "source": "./plugins/languages/rust",
       "strict": true,
       "description": "Rust programming skills: ownership, borrowing, lifetimes, async, best practices, anti-patterns, CLI apps, and adversarial-TDD worker agents",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "category": "language",
       "keywords": [
         "rust",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.91",
+  "version": "0.4.92",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/languages/rust/.claude-plugin/plugin.json
+++ b/plugins/languages/rust/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Rust programming skills: ownership, borrowing, lifetimes, async, best practices, anti-patterns, CLI apps, and adversarial-TDD worker agents",
   "author": {
     "name": "vinnie357"

--- a/plugins/languages/rust/agents/rust-implementer.md
+++ b/plugins/languages/rust/agents/rust-implementer.md
@@ -34,8 +34,8 @@ Invoke the Skill tool for `/rust:ownership`, `/rust:async`, or `/rust:troublesho
 
 1. **Sync.** `git fetch`, checkout the feature branch, pull. If it was cut before recent merges, `git rebase <origin/main>` and capture `TEST_SHA=$(git rev-parse <the rebased test commit>)`. Read the frozen test file(s) — they are your binding spec.
 2. **Implement the smallest change.** Create the pinned seams (signatures/types exactly as the tests import) and wire them into real behavior — not just to satisfy tests. Idiomatic error handling: propagate with `Result`/`?`, no `unwrap()`/`expect()`/`panic!` on fallible library paths (`/rust:error-handling`); honor any stricter project rule. Match surrounding style.
-3. **Gate 1 — frozen tests untouched.** `git diff <TEST_SHA>..HEAD -- <test-files>` MUST be empty — paste it. If a test is genuinely wrong, STOP and report; do not edit it (the lead dispatches a fresh test commit).
-4. **Gate 2 — full CI green.** Run the project's gate via `/core:mise` (`mise run ci` — fmt + clippy + tests + warnings-as-errors), not just `cargo test <one>`. Paste the verbatim summary. Iterate until clean.
+3. **Check 1 — frozen tests untouched.** `git diff <TEST_SHA>..HEAD -- <test-files>` MUST be empty — paste it. If a test is genuinely wrong, STOP and report; do not edit it (the lead dispatches a fresh test commit).
+4. **Check 2 — full CI green.** Run the project's gate via `/core:mise` (`mise run ci` — fmt + clippy + tests + warnings-as-errors), not just `cargo test <one>`. Paste the verbatim summary. Iterate until clean.
 5. **Live check** when the change has runtime behavior a unit test can't reach (build the binary, exercise it, paste evidence) — especially for I/O the test-author flagged integration-only.
 6. **Commit & PR.** Conventional commit, NO attribution. Push. Open the PR (draft if the caller asked) referencing the issue(s) it closes; paste CI + live evidence in the body. Watch remote CI to green. Never merge — report the PR URL to the caller.
 

--- a/plugins/pm/.claude-plugin/plugin.json
+++ b/plugins/pm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pm",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Product management toolkit: harvest implementation-agnostic feature specs from prototypes with SDLC guardrails and author PRDs as implementation contracts",
   "author": {
     "name": "vinnie357"

--- a/plugins/pm/agents/pm-discovery.md
+++ b/plugins/pm/agents/pm-discovery.md
@@ -37,7 +37,7 @@ The lead passes:
 
 **`integrations-deps-stack`**: Read the manifest file(s) present (`package.json`, `mix.exs`, `Cargo.toml`, `requirements.txt`, `go.mod`, or equivalent). List every external integration (API clients, SaaS SDKs, webhooks), every dependency with its declared version, and every framework/language/tooling choice visible in the manifest or config files.
 
-**`bees-map`**: Skip entirely and report `BEES ABSENT` if `PROTOTYPE_ROOT/.bees` does not exist — never fabricate a roadmap. When present, use only: `bees list --status open|closed [--json]`, `bees show <id> [--json]`, `bees ready --json`, `bees dep list <id>`, `bees comment list <id>`, `bees prime`. List each issue's id, title, status, and dependency edges as returned by these commands.
+**`bees-map`**: Skip entirely and report `BEES ABSENT` if `PROTOTYPE_ROOT/.bees` does not exist — never fabricate a roadmap. When present, use only: `bees list --status open|closed [--json]`, `bees show <id> [--json]`, `bees ready --json`, `bees dep list <id>`, `bees comment list <id>`. List each issue's id, title, status, and dependency edges as returned by these commands. `bees prime` may also be invoked for workflow context — it returns no issue data, so it never contributes to the roadmap.
 
 ## Phase 2: Evidence tagging
 

--- a/plugins/pm/agents/pm-lead.md
+++ b/plugins/pm/agents/pm-lead.md
@@ -91,7 +91,7 @@ Next: <review artifacts under OUTPUT_DIR / no action needed>
 
 - Never writes files — that is `pm-spec-writer`'s job alone.
 - Never reads prototype source beyond existence probes (`test -d`, `.bees/` presence). Source reading belongs to the workers.
-- Bees interaction is read-only end to end: only pass through what a worker's `bees-map` shard reported via `bees list`, `bees show`, `bees ready --json`, `bees dep list`, `bees comment list`, `bees prime`. Never issue a write command yourself or instruct a worker to.
+- Bees interaction is read-only end to end: only pass through what a worker's `bees-map` shard reported via `bees list`, `bees show`, `bees ready --json`, `bees dep list`, `bees comment list` (`bees prime` may also run for workflow context, but it returns no issue data to pass through). Never issue a write command yourself or instruct a worker to.
 - Require proof-of-loading skill quotes from every worker before accepting its report as final — a report without them is incomplete, re-spawn.
 - Aggregate confidence tags without upgrading them: an `[inferred — needs verification]` claim from a worker stays `[inferred — needs verification]` in your own report, never becomes `[seen-in-code: ...]` because it appeared alongside verified claims.
 - Never commit, push, or open a PR. This is a read/report pipeline; only `pm-spec-writer` writes, and only inside `OUTPUT_DIR`.

--- a/plugins/tools/beads/.claude-plugin/plugin.json
+++ b/plugins/tools/beads/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "beads",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Beads (bd) distributed git-backed graph issue tracker: task management, dependency tracking, AI agent workflows",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/beads/skills/beads/SKILL.md
+++ b/plugins/tools/beads/skills/beads/SKILL.md
@@ -34,7 +34,7 @@ See `references/installation.md` for npm, Homebrew, Go install, and mise
 (multi-architecture) methods:
 
 ```bash
-npm install -g @anthropic/beads
+npm install -g @beads/bd
 ```
 
 ## Getting Started

--- a/plugins/tools/beads/skills/beads/references/installation.md
+++ b/plugins/tools/beads/skills/beads/references/installation.md
@@ -6,14 +6,16 @@ Installation methods for the `bd` binary: npm, Homebrew, Go install, and mise
 ### npm (Recommended)
 
 ```bash
-npm install -g @anthropic/beads
+npm install -g @beads/bd
 ```
 
-### Homebrew (macOS)
+### Homebrew (macOS/Linux)
 
 ```bash
-brew install anthropic/tap/beads
+brew install beads
 ```
+
+This is the `homebrew-core` formula (no tap needed).
 
 ### Go Install
 


### PR DESCRIPTION
Closes claude-skills-160, claude-skills-168, claude-skills-147 — three one-liners in three plugins, batched into one PR and one CI cycle.

- beads installation.md / SKILL.md: correct `npm install -g @anthropic/beads` → `npm install -g @beads/bd` and `brew install anthropic/tap/beads` → `brew install beads` (homebrew-core formula, no tap). `@anthropic/beads` is a 404 — it never existed — and `anthropic/homebrew-tap` does not exist either. Verified via `npm view @beads/bd` (real package v1.1.2, maintainer steveyegge, repo gastownhall/beads) and `brew info beads` (homebrew-core, v1.1.2). The repo moved: `steveyegge/beads` 301-redirects to `gastownhall/beads`.

- The Go install line's **module path** is correct and was left unchanged: released Go modules still declare `github.com/steveyegge/beads`, `proxy.golang.org` resolves `steveyegge@latest` to v1.1.2, and `go.mod` on gastownhall main declares the steveyegge module path. That compatibility rationale is stated verbatim in upstream's installation doc.

  **Correction, per Gate 3:** an earlier draft of this body claimed the Go install line "was already correct." The module path is; the **command shape is not**. Upstream documents exactly two supported go-install modes, both requiring an env prefix — `CGO_ENABLED=0 go install ...` (server-mode only, no embedded Dolt) and `CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go install ...` (embedded-capable). `installation.md:21` ships a bare `go install github.com/steveyegge/beads/cmd/bd@latest`, which is neither. Upstream also advises using Homebrew, npm, or the install script unless you specifically need `go install`. That defect is pre-existing and outside bee 168's scope, so it is **not fixed here** — it is recorded so the claim entering main is accurate. Filed as a follow-up.

- pm agents: drop `bees prime` from the "as returned by these commands" enumeration in `pm-discovery.md` and `pm-lead.md`. `prime` returns a static workflow cheatsheet with zero issue data; the sibling commands in that list do supply it.

- rust: rename `rust-implementer.md`'s "Gate 1"/"Gate 2" step names to "Check 1"/"Check 2" so they stop colliding with `/core:git`'s Three-Gate Merge Policy, where those numbers mean local and remote CI. Repo-wide grep confirms nothing cites rust's old numbering.

## Gates

Gate 1 `mise test` exit 0; `mise run test:version-bumps origin/main` exit 0 (rust 0.1.10→0.1.11, pm 0.1.2→0.1.3, beads 0.1.2→0.1.3); gitleaks clean; `test/quality-baseline.json` untouched.

Gate 2 both remote checks pass.

Gate 3 APPROVE — https://github.com/vinnie357/claude-skills/pull/191#issuecomment-5152790971. Reviewer independently reproduced every registry claim, confirmed zero surviving `@anthropic/` references repo-wide, and ran `mise test` on both main and the branch to confirm the debt summary is byte-identical (49 debt entries, 4 dupe groups) rather than trusting the reported number.

## Follow-ups filed rather than widened into this PR

- The bare `go install` command shape above.
- The mise github backend `github:steveyegge/beads` names the repo holding release assets, which is now `gastownhall/beads`; it resolves only via the 301. Three sites, one of them outside the beads plugin (`plugins/core/skills/mise/templates/multi-arch.md`).
- `beads/skills/sources.toml` and `sources.md` cite `steveyegge.github.io/beads/`, which 404s; the live successor is `gastownhall.github.io/beads/`.
