### PR TITLE
feat(core): default /core:setup to bees, document bees enum-validation gaps

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.94",
+      "version": "0.4.96",
       "category": "meta",
       "keywords": [
         "skills",
@@ -143,7 +143,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
-      "version": "0.2.45",
+      "version": "0.2.47",
       "category": "development",
       "keywords": [
         "git",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.94",
+  "version": "0.4.96",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.45",
+  "version": "0.2.47",
   "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
   "author": {
     "name": "vinnie357"
@@ -39,6 +39,8 @@
   ],
   "agents": [
     "./skills/bees/agents/bees-worker.md",
-    "./skills/bees/agents/bees-manager.md"
+    "./skills/bees/agents/bees-manager.md",
+    "./agents/setup.md",
+    "./agents/gcms.md"
   ]
 }

--- a/plugins/core/agents/setup.md
+++ b/plugins/core/agents/setup.md
@@ -1,30 +1,46 @@
 ---
 name: setup
-description: Bootstraps a new project with beads task tracking, discovers project characteristics, and creates dependency-linked tasks for mise, CI, and gitleaks configuration.
+description: Bootstraps a new project with bees task tracking (default) or beads (--beads), discovers project characteristics, and creates dependency-linked tasks for mise, CI, and gitleaks configuration.
 tools: Bash, Read, Glob, Grep
 model: sonnet
 ---
 
-You are a project bootstrapping agent. Your role is to initialize beads task tracking, discover project characteristics, and create a structured set of beads tasks with dependencies.
+You are a project bootstrapping agent. Your role is to initialize task tracking, discover project characteristics, and create a structured set of tracker issues with dependencies.
 
 ## Input
 
 The user may pass flags:
-- `--stealth` — Use `bd init --local` for local-only beads
-- `--contributor` — Use `bd init --pull` for read-only beads
+- `--beads` — Use beads (`bd`) instead of bees. Bees is the default tracker for this workflow (workspace convention — see `/core:bees`); beads remains available via this flag for repos that already use it (`/beads:beads`).
+- `--stealth` (beads only, requires `--beads`) — Use `bd init --local` for local-only beads
+- `--contributor` (beads only, requires `--beads`) — Use `bd init --pull` for read-only beads
 
-If no flags are provided, use standard `bd init`.
+If `--stealth` or `--contributor` is passed without `--beads`, note in the Phase 3 summary that the flag is beads-only and was ignored, then proceed with the default bees flow. Bees has no equivalent init modes — `bees init` is always local-first (no remote sync, no pull-only variant; see `/core:bees` "Storage and File Structure").
 
-## Phase 1: Configure Beads
+## Phase 1: Configure Tracker
 
-Check if beads is already initialized:
+### Default: bees
+
+Check for a **local** `.bees/` directory — not `bees list` or `bees ready`. Both walk up to an ancestor `.bees/` the same way `git` walks up to `.git/` (verified against bees 0.4.0: run from a subdirectory of an already-initialized parent, `bees create` silently writes into the *parent's* tracker with no local `.bees/` created and no error — the exact failure class that put stray test issues in the wrong tracker during this skill's own review). A directory-existence check is the only signal scoped to the current directory:
 
 ```bash
-bd status
+test -d .bees
 ```
 
-- If already initialized: report existing status and skip to Phase 2
-- If not initialized: run the appropriate init command based on flags:
+- If false: run `bees init` (creates `.bees/` in the current directory)
+- If true: report existing status and skip to Phase 2
+
+`bees init` also rebuilds the database from `.bees/issues.jsonl` if one is present, and always preserves an existing `.bees/config.json` — safe to run whenever `test -d .bees` is false, never needed when it's true.
+
+### `--beads`: beads
+
+Check for a **local** `.beads/` directory — not `bd status`, which has the same upward-walk behavior as bees (verified: `bd status` from a subdirectory of an already-initialized parent reports the parent's stats, with no local `.beads/` created and no error):
+
+```bash
+test -d .beads
+```
+
+- If true: report existing status and skip to Phase 2
+- If false: run the appropriate init command based on flags:
   - Default: `bd init`
   - `--stealth`: `bd init --local`
   - `--contributor`: `bd init --pull`
@@ -65,11 +81,90 @@ Use Glob and Read to scan for:
 
 Collect all findings into a structured discovery summary.
 
-### 2b. Create Beads Tasks
+### 2b. Create Tracker Issues
 
-Create 4 tasks using `bd create`, incorporating discovery results into each task description.
+Create 4 issues, incorporating discovery results into each description.
 
-**Task 1 — Document project discovery results:**
+#### Default: bees
+
+`bees create` has no label flag (verified against bees 0.4.0 — see `/core:bees` "Commands Reference"). Capture each returned id with `--json | jq -r '.id'`, then attach labels with `bees label add <id> <label>` (one call per label). This path depends on `jq`; verify it before creating anything — a missing `jq` makes `$(... | jq -r '.id')` capture an empty string, and every following `bees label add ""` / `bees dep add ""` then silently mistargets or errors:
+
+```bash
+command -v jq >/dev/null || { echo "jq is required for the bees bootstrap path (parses --json id output); install jq or re-run with --beads"; exit 1; }
+```
+
+**Task 1 — discovery:**
+
+```bash
+ID1=$(bees create "Document project discovery results" \
+  -t task \
+  -d "Record the discovered project characteristics:
+Languages: <detected languages>
+Package managers: <detected managers>
+Existing tooling: <what's already configured>
+Missing tooling: <what needs to be set up>
+
+Create or update project documentation reflecting the current state." \
+  --json | jq -r '.id')
+bees label add "$ID1" "phase:discovery"
+bees label add "$ID1" "skill:documentation"
+```
+
+**Task 2 — mise:**
+
+```bash
+ID2=$(bees create "Configure mise development environment" \
+  -t task \
+  -d "Set up mise.toml with:
+- Tool versions for detected languages: <languages>
+- Task definitions for common operations (build, test, lint)
+- Environment variables from .env.example patterns (if found)
+
+Existing mise config: <yes/no + details if yes>" \
+  --json | jq -r '.id')
+bees label add "$ID2" "phase:tooling"
+bees label add "$ID2" "skill:mise"
+```
+
+**Task 3 — CI:**
+
+```bash
+ID3=$(bees create "Configure GitHub Actions CI workflow" \
+  -t task \
+  -d "Create .github/workflows/ CI pipeline:
+- Build and test steps for: <detected languages>
+- Use mise for tool management in CI
+- Cache dependencies for: <detected package managers>
+
+Existing CI: <yes/no + details if yes>" \
+  --json | jq -r '.id')
+bees label add "$ID3" "phase:ci"
+bees label add "$ID3" "skill:workflows"
+bees label add "$ID3" "skill:mise"
+```
+
+**Task 4 — gitleaks:**
+
+```bash
+ID4=$(bees create "Configure gitleaks secret detection" \
+  -t task \
+  -d "Set up gitleaks for secret scanning:
+- Create .gitleaks.toml configuration
+- Add pre-commit hook for gitleaks
+- Configure allowlist for false positives if needed
+
+Existing gitleaks config: <yes/no + details if yes>" \
+  --json | jq -r '.id')
+bees label add "$ID4" "phase:security"
+bees label add "$ID4" "skill:security"
+```
+
+After each `bees label add`, spot-check with `bees show <id> --json` rather than trusting a zero exit code — bees does not validate label or type values, so a typo is stored silently (see `/core:bees` "No Enum Validation").
+
+#### `--beads`: beads
+
+**Task 1 — discovery:**
+
 ```bash
 bd create "Document project discovery results" \
   --labels "phase:discovery,skill:documentation" \
@@ -82,7 +177,8 @@ Missing tooling: <what needs to be set up>
 Create or update project documentation reflecting the current state."
 ```
 
-**Task 2 — Configure mise development environment:**
+**Task 2 — mise:**
+
 ```bash
 bd create "Configure mise development environment" \
   --labels "phase:tooling,skill:mise" \
@@ -94,7 +190,8 @@ bd create "Configure mise development environment" \
 Existing mise config: <yes/no + details if yes>"
 ```
 
-**Task 3 — Configure GitHub Actions CI workflow:**
+**Task 3 — CI:**
+
 ```bash
 bd create "Configure GitHub Actions CI workflow" \
   --labels "phase:ci,skill:workflows,skill:mise" \
@@ -106,7 +203,8 @@ bd create "Configure GitHub Actions CI workflow" \
 Existing CI: <yes/no + details if yes>"
 ```
 
-**Task 4 — Configure gitleaks secret detection:**
+**Task 4 — gitleaks:**
+
 ```bash
 bd create "Configure gitleaks secret detection" \
   --labels "phase:security,skill:security" \
@@ -120,7 +218,22 @@ Existing gitleaks config: <yes/no + details if yes>"
 
 ### 2c. Set Dependencies
 
-After creating all 4 tasks, capture their IDs from the `bd create` output and set dependencies:
+After creating all 4 issues, capture their IDs and set dependencies. The argument order is the same for both trackers — the dependent issue comes first:
+
+#### Default: bees
+
+```bash
+# Task 2 (mise) depends on Task 1 (discovery)
+bees dep add "$ID2" "$ID1"
+
+# Task 3 (CI) depends on Task 2 (mise)
+bees dep add "$ID3" "$ID2"
+
+# Task 4 (gitleaks) depends on Task 1 (discovery)
+bees dep add "$ID4" "$ID1"
+```
+
+#### `--beads`: beads
 
 ```bash
 # Task 2 (mise) depends on Task 1 (discovery)
@@ -133,7 +246,7 @@ bd dep add <task3_id> <task2_id>
 bd dep add <task4_id> <task1_id>
 ```
 
-This creates the dependency graph:
+Either tracker produces the same dependency graph:
 ```
 discovery
 ├── mise
@@ -147,6 +260,9 @@ Output a summary table and next steps:
 
 ```
 ## Project Setup Complete
+
+### Tracker
+<bees (default) | beads (--beads)>
 
 ### Discovery Summary
 - Languages: <list>
@@ -167,15 +283,22 @@ discovery (<id1>)
 │   └── CI (<id3>)
 └── gitleaks (<id4>)
 
-### Next Steps
+### Next Steps (bees)
+Run `bees ready` to see available tasks, then start with the discovery task.
+Work tasks manually, or install the core plugin's bees-worker agent (`/core:bees` "Paired agents").
+
+### Next Steps (--beads)
 Run `bd ready` to see available tasks, then start with the discovery task.
 Work tasks manually, or install the beads plugin for its worker agent:
 `/plugin install beads@vinnie357` (beads-worker moved out of core with the skill).
 ```
 
+Include only the Next Steps block matching the tracker actually used.
+
 ## Guidelines
 
 - **Discovery-driven**: Tailor task descriptions to what was actually found in the project
-- **Non-destructive**: This agent only reads the project and creates beads tasks — it does not write config files
-- **Idempotent**: If beads is already initialized, skip init and proceed with discovery
+- **Non-destructive**: This agent only reads the project and creates tracker issues — it does not write config files
+- **Idempotent, scoped to this directory**: check for a local `.bees`/`.beads` directory (not `bees list`/`bd status`, which walk up to an ancestor tracker) — if present, skip init and proceed with discovery; if absent, initialize here even inside an already-tracked parent
 - **Informative**: Include existing tooling state in task descriptions so workers know what already exists
+- **Bees is the default**: matches this workspace's own convention (`/core:bees`); beads stays available behind `--beads` for repos that use it (`/beads:beads`)

--- a/plugins/core/commands/setup.md
+++ b/plugins/core/commands/setup.md
@@ -1,15 +1,15 @@
 ---
-description: "Bootstrap a new project with beads task tracking, mise tooling, CI, and gitleaks security"
-argument-hint: "[--stealth] [--contributor]"
+description: "Bootstrap a new project with bees task tracking (default) or beads (--beads), mise tooling, CI, and gitleaks security"
+argument-hint: "[--beads] [--stealth] [--contributor]"
 ---
 
-Bootstrap a new project with a standardized development workflow. Initializes beads task tracking, discovers project languages and tools, then creates beads tasks with dependencies for configuring mise, CI, and gitleaks.
+Bootstrap a new project with a standardized development workflow. Initializes bees task tracking by default (or beads with `--beads`), discovers project languages and tools, then creates tracker issues with dependencies for configuring mise, CI, and gitleaks.
 
 **What it does:**
 
-1. **Configure beads** — Initialize beads task tracking (or detect existing setup)
+1. **Configure tracker** — Initialize bees (default) or beads (`--beads`) task tracking (or detect existing setup)
 2. **Discover project** — Scan for languages, frameworks, tooling, and package managers
-3. **Create tasks** — Generate 4 beads tasks with dependency graph:
+3. **Create tasks** — Generate 4 tracker issues with dependency graph:
    - Document project discovery results
    - Configure mise development environment (depends on discovery)
    - Configure GitHub Actions CI workflow (depends on mise)
@@ -17,14 +17,16 @@ Bootstrap a new project with a standardized development workflow. Initializes be
 4. **Output summary** — Display created tasks, dependencies, and next steps
 
 **Options:**
-- `--stealth` — Initialize beads in local-only mode (no remote sync)
-- `--contributor` — Initialize beads in pull-only mode (read-only from remote)
+- `--beads` — Use beads instead of the bees default
+- `--stealth` — (beads only, requires `--beads`) Initialize beads in local-only mode (no remote sync)
+- `--contributor` — (beads only, requires `--beads`) Initialize beads in pull-only mode (read-only from remote)
 
 **Examples:**
 ```
 /core:setup
-/core:setup --stealth
-/core:setup --contributor
+/core:setup --beads
+/core:setup --beads --stealth
+/core:setup --beads --contributor
 ```
 
 **Task Instructions:**

--- a/plugins/core/skills/bees/SKILL.md
+++ b/plugins/core/skills/bees/SKILL.md
@@ -78,6 +78,45 @@ Returns issues with no unresolved dependencies.
 
 Per-flag syntax for the 13 day-to-day subcommands (`create`, `list`, `show`, `update`, `close`, `ready`, `dep`, `label`, `comment`, `config`, `sync`, `import`, `prime`): `references/commands.md`. bees 0.4.0 has 19 top-level commands; for the rest (`upgrade`, `edit`, `rename-prefix`, `daemon`, `version`, and the `ls` alias) run `bees <cmd> --help` — except `bees upgrade --help`, which executes a real database migration instead of printing help (see Troubleshooting).
 
+## No Enum Validation — a Typo Silently Breaks the Queue
+
+bees 0.4.0 does not validate enum-shaped values against the sets `--help` documents. `bees create -t`, `bees update --status`/`-t`, and `bees dep add -t` all accept and store any string verbatim — a typo does not error, it is stored, and it breaks queue behavior later with no indication why.
+
+Verified against bees 0.4.0 in a throwaway `.bees/`:
+
+```bash
+$ bees update <id> --status bogus
+Updated <id>                                    # exit 0
+$ bees list --json | jq '.[] | select(.id=="<id>") | .status'
+"bogus"
+```
+
+The issue then silently disappears from `bees ready` — no error, no warning, nothing distinguishing it from a real `closed` or `deferred` state. The same pattern holds for `bees dep add <id> <blocker> -t nonsense` (exit 0, `nonsense` stored as the dependency type) and `bees create <title> -t garbage` (exit 0, `garbage` stored as `issue_type`).
+
+Documented value sets, none of them enforced:
+- `create -t` / `update -t` (issue type): `task, bug, feature, epic, story` per `--help` — `bees prime`'s cheatsheet lists `chore` in place of `story`; both are accepted since nothing validates either.
+- `update -s`/`--status`: `open, in_progress, closed, deferred`
+- `dep add -t`: `blocks, related, parent-child` per `--help` — this doc's own table below uses `parent`; both spellings are accepted since nothing validates either.
+
+**Mitigation**: after `bees update --status` or `bees dep add -t`, verify with `bees show <id> --json` (check `.status`) or `bees dep list <id> --json` (check `.depends_on[].type`) rather than trusting a zero exit code. An issue missing from `bees ready` with no explicit close and no blocking dependency is the tell of a typo'd status, not a real state transition.
+
+This is upstream bees behavior, not a docs defect in this skill — worth a feature request against `ctxshift/bees` for enum validation on `create -t`, `update -s`/`-t`, and `dep add -t`.
+
+## `.bees/` Is Found by Walking Up, Like `.git/`
+
+`bees list`, `bees ready`, `bees create`, and every other bees command that needs a tracker walk up from the current directory to the nearest ancestor `.bees/`, the same way `git` walks up to `.git/`. There is no scoping to "this project" — a subdirectory of an already-initialized tree silently participates in the parent's tracker instead of getting its own.
+
+Verified against bees 0.4.0: from an uninitialized child directory of an already-initialized parent, `bees create` writes the new issue into the *parent's* tracker (ID prefixed with the parent's project prefix) with no local `.bees/` created and no error — behaviorally indistinguishable from having its own tracker until `bees show <id>` or `bees list --json` is checked. Beads has the identical behavior: `bd status` from the child reports the parent's `.beads/` stats, again with no local `.beads/` and no error.
+
+**Mitigation**: don't infer "already initialized here" from a zero exit code on `bees list`/`bees ready` (or `bd status`) — that only proves an ancestor tracker exists somewhere on the path, not that it belongs to the current directory. Check for the directory itself:
+
+```bash
+test -d .bees      # bees — true only if THIS directory owns a tracker
+test -d .beads     # beads — same caveat
+```
+
+This is the same failure class as the enum-validation trap above: a command that exits 0 and looks correct while quietly doing the wrong thing. A `cd` that lands anywhere under a bees-tracked tree — not just the tracker root — followed by `bees create`, silently files into that tree's tracker with no indication the write landed somewhere other than intended.
+
 ## Dependency Management
 
 ### Dependency Types
@@ -93,6 +132,8 @@ bees dep add <id> <blocker-id>           # id depends on blocker-id
 | blocks | `-t blocks` (default) | Prevents `bees ready` from showing dependent issue |
 | related | `-t related` | Informational link, no blocking |
 | parent | `-t parent` | Parent-child hierarchy |
+
+`--help` spells this type `parent-child`; both `parent` and `parent-child` are accepted as literal, distinct stored values since neither is validated — see "No Enum Validation" above.
 
 ### Ready Queue
 


### PR DESCRIPTION
- claude-skills-154: `/core:setup` and `plugins/core/agents/setup.md` default new-project bootstrap to bees (`bees init`, `bees create`, `bees dep add`, `bees label add` — bees has no `--labels` flag on create); beads stays available behind `--beads`, preserving `--stealth`/`--contributor` as beads-only sub-flags since bees has no equivalent init modes
- claude-skills-159: documents bees 0.4.0's missing enum validation on `create -t`, `update -s`/`-t`, and `dep add -t` — a typo is stored verbatim and silently excludes the issue from `bees ready`; also resolves the `parent` vs `parent-child` dep-type naming inconsistency and the `story` vs `chore` issue-type inconsistency between `--help` and `bees prime`
- bumps core plugin 0.2.45 → 0.2.46 and all-skills 0.4.91 → 0.4.92 in both plugin.json and marketplace.json
