### PR TITLE
refactor(claude-code): split claude-agents into references, sharpen benchmark-skills numbers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.93",
+      "version": "0.4.94",
       "category": "meta",
       "keywords": [
         "skills",
@@ -119,7 +119,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
-      "version": "0.2.45",
+      "version": "0.2.46",
       "category": "tools",
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.93",
+  "version": "0.4.94",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.45",
+  "version": "0.2.46",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/commands/benchmark-skills.md
+++ b/plugins/tools/claude-code/commands/benchmark-skills.md
@@ -16,13 +16,13 @@ Benchmark all Agent Skills in the marketplace, producing a quality scorecard wit
 A scorecard table showing quality metrics for each skill:
 
 ```
-Skill            | Plugin   | Desc | Lines   | Refs | Examples | Score
-─────────────────┼──────────┼──────┼─────────┼──────┼──────────┼──────
-git              | core     | Pass | 120/500 | Pass | Pass     | X/N
-claude-skills    | cl-code  | Pass | 380/500 | Pass | Pass     | X/N
+Skill            | Plugin   | Desc | Lines | Refs | Examples | Score
+─────────────────┼──────────┼──────┼───────┼──────┼──────────┼──────
+git              | core     | Pass | X/Y   | Pass | Pass     | X/N
+claude-skills    | cl-code  | Pass | X/Y   | Pass | Pass     | X/N
 ```
 
-`X/N` above is a placeholder. Copy the real score from the `mise run test:skills-quality` scorecard, which prints concrete values such as `17/17` — `N` is the validator's `check_count`, not a fixed number, so it will not go stale as the check list grows. The validator takes no `--plugin` filter, so run the full suite and read the rows you need.
+`X/Y` and `X/N` above are placeholders — copy the real line count and score from the `mise run test:skills-quality` scorecard. `Y` is the validator's line cap and `N` is its `check_count`; neither is a fixed number restated here, so this table will not go stale as either changes. The validator takes no `--plugin` filter, so run the full suite and read the rows you need.
 
 **Examples:**
 ```
@@ -38,13 +38,7 @@ Use Agent tool with subagent_type: "general-purpose" to:
 
 1. Read `.claude-plugin/marketplace.json` to discover all plugins
 2. For each local plugin, read its `.claude-plugin/plugin.json` to get skill paths
-3. For each skill, read `SKILL.md` and analyze:
-   - **Description quality**: Non-empty, ≤1024 chars, has "Use when", third person
-   - **Name compliance**: Kebab-case, ≤64 chars, no reserved words
-   - **Content quality**: ≤500 lines, has examples, imperative language
-   - **Progressive disclosure**: Has references/, no nested references
-   - **Anti-fabrication**: Contains anti-fab rules or references `core:anti-fabrication`
-   - **Source coverage**: Skill is listed in one of the plugin's `sources.toml` entries' `skills` array
+3. For each skill, read `SKILL.md` and note, as a reading aid for the narrative — not the authoritative check list (see step 5) — the trigger-quality of the description, name compliance, bounded body size, presence of examples, one-level reference depth, and anti-fabrication rules. Skill-to-`sources.toml` coverage is a separate check, owned by `test/validate-sources.nu`, not this validator.
 4. Classify each skill as Capability Uplift or Encoded Preference
 5. Read each skill's score from `mise run test:skills-quality` rather than computing one — `test/validate-skills-quality.nu` is the single source of truth for both the check list and `check_count`. Copy the printed value verbatim; do not hand-count checks or write a fixed denominator
 6. Present results as a formatted scorecard table

--- a/plugins/tools/claude-code/skills/claude-agents/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-agents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-agents
-description: Guide for creating custom agents for Claude Code. Use when creating specialized agents, configuring agent tools.
+description: Guide for creating custom agents (subagents) for Claude Code. Use when writing agents/*.md files, choosing agent frontmatter (tools, model, skills, permissionMode, maxTurns), restricting a subagent tool allowlist, preloading skills into an agent, or troubleshooting agent invocation.
 ---
 
 # Claude Code Agents
@@ -82,24 +82,7 @@ You are a code reviewer. Analyze code for quality, security, and best practices.
 - **Prioritized**: Critical issues first
 ```
 
-## Agent Writing Style
-
-Effective agents use direct, imperative language:
-
-### Opening Statement
-
-- **Do**: "You are a [role]. Your role is to [primary function]."
-- **Don't**: "I am a specialized [role] focused on..."
-
-### Workflow Steps
-
-- **Do**: Numbered steps with specific commands
-- **Don't**: Bullet lists describing capabilities
-
-### Guidelines Section
-
-- **Do**: Single-word bold labels with brief explanations
-- **Don't**: Verbose explanations of best practices
+Writing style: direct, imperative language. Open with "You are a [role]. Your role is to [primary function]" rather than "I am a specialized [role]...". Use numbered workflow steps with specific commands, not bullet lists describing capabilities. Full style guidance and worked best-practice examples: `references/patterns.md`.
 
 ## Agent Configuration
 
@@ -126,62 +109,7 @@ Complete field reference (source: https://code.claude.com/docs/en/sub-agents):
 | `color` | no | `red`, `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, `cyan`. |
 | `initialPrompt` | no | Auto-submitted first user turn when run as a main-session agent (`--agent`). |
 
-Example:
-
-```markdown
----
-name: agent-name                    # Required: kebab-case identifier
-description: Brief description      # Required: What this agent does
-tools:                             # Optional: tool allowlist, inherits all if omitted
-  - Read
-  - Write
-  - Bash
-model: sonnet                      # Optional: model to use, defaults to inherit
----
-```
-
-### Tool Allowlist
-
-Restrict agent to specific tools:
-
-- Can read files
-- Can search code
-- Can find files
-- Cannot use Write, Edit, Bash, etc.
-
-Example:
-
-```markdown
----
-tools: Read, Grep, Glob     
----
-```
-
-
-
-
-**No tool restrictions** (access to all tools):
-
-```markdown
----
-# Omit tools field entirely
----
-```
-
-### Model Selection
-
-Choose the model for the task, or inherit the parent session's model:
-
-```markdown
----
-model: haiku               # Fast, cost-effective for simple tasks
-# model: sonnet            # Balanced
-# model: opus              # Complex reasoning
-# model: fable             # Fable 5 tier
-# model: claude-opus-4-8   # Full model ID pins an exact version
-# model: inherit           # Default — matches the parent session's model
----
-```
+**Model selection**: match the model to task complexity — `haiku` for simple/repetitive tasks, `sonnet` for standard tasks, `opus`/`fable` for complex reasoning, `inherit` (default) to match the parent session's model.
 
 ### Preloading Skills
 
@@ -202,240 +130,27 @@ Skills not listed in `skills` remain invocable through the Skill tool during the
 
 ## Common Agent Patterns
 
-### Read-Only Analysis Agent
+Four recurring shapes, each with a runnable template:
 
-For security scans, code reviews, or audits. Restricted to Read, Grep, Glob.
+- **Read-only analysis** (security scans, code reviews, audits): restrict `tools` to `Read, Grep, Glob`. Template: `templates/read-only-analyzer.md`
+- **Write-capable** (generating tests, docs, code): add `Write`. Template: `templates/write-capable-agent.md`
+- **Full-access** (refactoring, migrations, complex modifications): omit `tools` entirely for no restrictions. Template: `templates/full-access-agent.md`
+- **MCP-enabled** (browser automation, external APIs): mix core tools with MCP tool names. Template: `templates/mcp-agent.md`
 
-See: `templates/read-only-analyzer.md`
+Minimal starting point: `templates/basic-agent.md`. Best-practice worked examples (clear purpose, appropriate tool access, explicit instructions): `references/patterns.md`. Plugin wiring, invocation mechanics, and troubleshooting: `references/plugin-config.md`.
 
-### Write-Capable Agent
+## Security
 
-For generating tests, documentation, or code. Includes Write tool.
-
-See: `templates/write-capable-agent.md`
-
-### Full-Access Agent
-
-For refactoring, migrations, or complex modifications. Omit tools field entirely for no restrictions.
-
-See: `templates/full-access-agent.md`
-
-### MCP-Enabled Agent
-
-For browser automation, external APIs, or specialized MCP server tools. Mix core tools with MCP tools.
-
-See: `templates/mcp-agent.md`
-
-## Agent Plugin Configuration
-
-### In plugin.json
-
-```json
-{
-  "agents": [
-    "./agents/code-reviewer.md",
-    "./agents/test-generator.md",
-    "./agents/security-analyzer.md"
-  ]
-}
-```
-
-### Directory-Based Loading
-
-```json
-{
-  "agents": "./agents"
-}
-```
-
-Loads all `.md` files in `agents/` directory.
-
-## Invoking Agents
-
-Agents are launched via the Agent tool (`Task` remains a deprecated alias, renamed in v2.1.63):
-
-```python
-# In parent Claude conversation
-Agent(
-    subagent_type="code-reviewer",
-    description="Review authentication module",
-    prompt="""
-    Review the authentication module for:
-    - Security vulnerabilities
-    - Error handling
-    - Input validation
-    - Best practices
-    """
-)
-```
-
-## Agent Communication
-
-### Input to Agent
-
-- Task description
-- Detailed prompt
-- Access to conversation history (if configured)
-
-### Output from Agent
-
-- Final report/result
-- No ongoing dialogue
-- One-time execution
-
-## Best Practices
-
-### Clear Purpose
-
-Each agent has a specific, well-defined purpose:
-
-```markdown
----
-name: migration-helper
-description: Assists with database schema migrations
----
-
-# Database Migration Agent
-
-Specialized in creating and validating database migrations.
-```
-
-### Appropriate Tool Access
-
-Only grant necessary tools:
-
-```markdown
----
-# Analysis agent - read-only
-tools: Read, Grep, Glob
----
-```
-
-```markdown
----
-# Implementation agent - can modify
-tools: Read, Write, Edit, Glob, Grep
----
-```
-
-### Model Selection
-
-Match model to task complexity:
-
-- **haiku**: Simple, repetitive tasks
-- **sonnet**: Standard tasks
-- **opus** / **fable**: Complex reasoning required
-- **inherit**: Default when `model` is omitted — matches the parent session
-
-### Turn Limits
-
-Set `maxTurns` for task complexity:
-
-```markdown
----
-maxTurns: 5    # Simple, focused task
-# maxTurns: 20 # Complex, multi-step workflow
----
-```
-
-### Clear Instructions
-
-Provide explicit behavior guidelines:
-
-```markdown
-# Testing Agent
-
-## Mandatory Requirements
-
-- Generate tests for ALL public methods
-- Achieve minimum 80% code coverage
-- Include edge cases and error scenarios
-- Use project's testing framework conventions
-
-## Constraints
-
-- Do not modify source code
-- Follow existing test file naming patterns
-- Use appropriate assertions
-```
-
-## Security Considerations
-
-### Tool Restrictions
-
-Limit dangerous operations:
-
-```markdown
----
-# Don't give Bash access to untrusted agents
-tools:
-  - Read
-  - Write  # Safer than arbitrary shell commands
----
-```
-
-### Input Validation
-
-Validate agent inputs:
-
-```markdown
-# Deployment Agent
-
-Before deploying:
-1. Verify target environment is valid
-2. Check deployment permissions
-3. Validate configuration
-4. Confirm destructive operations
-```
-
-### Sensitive Data
-
-Never hardcode:
-- Credentials
-- API keys
-- Private URLs
-- Access tokens
-
-## Agent Examples
-
-For complete, production-ready agent templates:
-
-- `templates/basic-agent.md` - Official minimal example
-- `templates/read-only-analyzer.md` - Security analyzer pattern
-- `templates/write-capable-agent.md` - Test generator pattern
-- `templates/full-access-agent.md` - Refactoring pattern (no tool restrictions)
-- `templates/mcp-agent.md` - Browser testing with MCP tools
-
-## Troubleshooting
-
-### Agent Not Found
-
-- Verify agent file location matches plugin.json
-- Check file naming (kebab-case, .md extension)
-- Ensure plugin is properly installed
-
-### Tool Access Denied
-
-- Check tools allowlist in frontmatter
-- Verify tool names match exactly
-- Ensure parent context permits delegation
-
-### Unexpected Behavior
-
-- Review agent instructions for clarity
-- Check model selection appropriateness
-- Verify iteration limits aren't too restrictive
-- Test with verbose output
+Grant only the tools an agent's task requires — a read-only analyzer never needs `Bash` or `Write`. Never hardcode credentials, API keys, private URLs, or access tokens in agent files; agent bodies are prompts checked into repos and plugins. Worked tool-restriction and input-validation examples: `references/patterns.md`.
 
 ## References
 
-Templates directory:
-- `templates/basic-agent.md` - Official minimal example
-- `templates/read-only-analyzer.md` - Security analysis pattern
-- `templates/write-capable-agent.md` - Test generation pattern
-- `templates/full-access-agent.md` - Refactoring pattern (no tool restrictions)
-- `templates/mcp-agent.md` - MCP tools pattern (browser automation)
-
-Documentation:
+- `templates/basic-agent.md` — official minimal example
+- `templates/read-only-analyzer.md` — security analysis pattern
+- `templates/write-capable-agent.md` — test generation pattern
+- `templates/full-access-agent.md` — refactoring pattern (no tool restrictions)
+- `templates/mcp-agent.md` — MCP tools pattern (browser automation)
+- `references/patterns.md` — writing style, common patterns, and worked best-practice/security examples
+- `references/plugin-config.md` — plugin.json wiring, invoking agents, agent communication, troubleshooting
 - Claude Code Agents: https://code.claude.com/docs/en/agents
 - Subagents (Agent Tool): https://code.claude.com/docs/en/sub-agents

--- a/plugins/tools/claude-code/skills/claude-agents/references/patterns.md
+++ b/plugins/tools/claude-code/skills/claude-agents/references/patterns.md
@@ -1,0 +1,116 @@
+# Agent Patterns and Best Practices
+
+Writing style, and worked examples for the patterns and security guidance summarized in `claude-agents`'s SKILL.md.
+
+## Agent Writing Style
+
+Effective agents use direct, imperative language.
+
+### Opening Statement
+
+- **Do**: "You are a [role]. Your role is to [primary function]."
+- **Don't**: "I am a specialized [role] focused on..."
+
+### Workflow Steps
+
+- **Do**: Numbered steps with specific commands
+- **Don't**: Bullet lists describing capabilities
+
+### Guidelines Section
+
+- **Do**: Single-word bold labels with brief explanations
+- **Don't**: Verbose explanations of best practices
+
+## Best Practices
+
+### Clear Purpose
+
+Each agent has a specific, well-defined purpose:
+
+```markdown
+---
+name: migration-helper
+description: Assists with database schema migrations
+---
+
+# Database Migration Agent
+
+Specialized in creating and validating database migrations.
+```
+
+### Appropriate Tool Access
+
+Only grant necessary tools:
+
+```markdown
+---
+# Analysis agent - read-only
+tools: Read, Grep, Glob
+---
+```
+
+```markdown
+---
+# Implementation agent - can modify
+tools: Read, Write, Edit, Glob, Grep
+---
+```
+
+### Clear Instructions
+
+Provide explicit behavior guidelines grounded in the project's own conventions rather than an invented number:
+
+```markdown
+# Testing Agent
+
+## Mandatory Requirements
+
+- Generate tests for ALL public methods
+- Match the project's existing coverage conventions — read its CI config
+  or test task rather than assuming a target percentage
+- Include edge cases and error scenarios
+- Use project's testing framework conventions
+
+## Constraints
+
+- Do not modify source code
+- Follow existing test file naming patterns
+- Use appropriate assertions
+```
+
+## Security Examples
+
+### Tool Restrictions
+
+Limit dangerous operations:
+
+```markdown
+---
+# Don't give Bash access to untrusted agents
+tools:
+  - Read
+  - Write  # Safer than arbitrary shell commands
+---
+```
+
+### Input Validation
+
+Validate agent inputs:
+
+```markdown
+# Deployment Agent
+
+Before deploying:
+1. Verify target environment is valid
+2. Check deployment permissions
+3. Validate configuration
+4. Confirm destructive operations
+```
+
+### Sensitive Data
+
+Never hardcode:
+- Credentials
+- API keys
+- Private URLs
+- Access tokens

--- a/plugins/tools/claude-code/skills/claude-agents/references/plugin-config.md
+++ b/plugins/tools/claude-code/skills/claude-agents/references/plugin-config.md
@@ -1,0 +1,81 @@
+# Plugin Wiring, Invocation, and Troubleshooting
+
+Plugin configuration, invocation mechanics, and diagnostic checklist for `claude-agents`.
+
+## Agent Plugin Configuration
+
+### In plugin.json
+
+```json
+{
+  "agents": [
+    "./agents/code-reviewer.md",
+    "./agents/test-generator.md",
+    "./agents/security-analyzer.md"
+  ]
+}
+```
+
+### Directory-Based Loading
+
+```json
+{
+  "agents": "./agents"
+}
+```
+
+Loads all `.md` files in `agents/` directory.
+
+## Invoking Agents
+
+Agents are launched via the Agent tool (`Task` remains a deprecated alias, renamed in v2.1.63):
+
+```python
+# In parent Claude conversation
+Agent(
+    subagent_type="code-reviewer",
+    description="Review authentication module",
+    prompt="""
+    Review the authentication module for:
+    - Security vulnerabilities
+    - Error handling
+    - Input validation
+    - Best practices
+    """
+)
+```
+
+## Agent Communication
+
+### Input to Agent
+
+- Task description
+- Detailed prompt
+- Access to conversation history (if configured)
+
+### Output from Agent
+
+- Final report/result
+- No ongoing dialogue
+- One-time execution
+
+## Troubleshooting
+
+### Agent Not Found
+
+- Verify agent file location matches plugin.json
+- Check file naming (kebab-case, .md extension)
+- Ensure plugin is properly installed
+
+### Tool Access Denied
+
+- Check tools allowlist in frontmatter
+- Verify tool names match exactly
+- Ensure parent context permits delegation
+
+### Unexpected Behavior
+
+- Review agent instructions for clarity
+- Check model selection appropriateness
+- Verify iteration limits aren't too restrictive
+- Test with verbose output


### PR DESCRIPTION
- claude-skills-129: split claude-agents/SKILL.md (441 -> 156 lines) into references/patterns.md (writing style, best-practice and security worked examples) and references/plugin-config.md (plugin.json wiring, invocation, troubleshooting) — deleted content that only restated the frontmatter field table (empty tool-allowlist example, duplicated model-selection block, turn-limits YAML comment, comment-form frontmatter example)
- Fixed a fabricated metric in the Clear Instructions example ("minimum 80% code coverage" -> match the project's own coverage conventions)
- Sharpened claude-agents' description for activation: names frontmatter fields, tool-allowlist restriction, skill preloading, and invocation troubleshooting
- claude-skills-199: removed the benchmark-skills.md example scorecard's hardcoded `120/500`/`380/500` line-count denominators (same drift risk PR #189 fixed for the score denominator) — both line cap and check_count are now copied verbatim from `mise run test:skills-quality` output
- Rewrote benchmark-skills.md step 3 to drop numeric literals (1024/64/500) and two claims the validator doesn't check (imperative language, "Has references/"), correctly attributes source coverage to `test/validate-sources.nu`, and states explicitly that the narration is a reading aid, not the authoritative check list
- Bumped claude-code plugin version 0.2.44 -> 0.2.45 (plugin.json + marketplace.json) and all-skills 0.4.91 -> 0.4.92 (no skill paths changed, confirmed via `update-all-skills --dry-run`)
