### PR TITLE
feat(typescript): add typescript language plugin with four skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "A curated collection of Claude skills for development workflows",
-    "version": "1.0.30"
+    "version": "1.0.31"
   },
   "plugins": [
     {
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.97",
+      "version": "0.4.98",
       "category": "meta",
       "keywords": [
         "skills",
@@ -463,6 +463,23 @@
         "tree-sitter"
       ],
       "license": "MIT"
+    },
+    {
+      "name": "typescript",
+      "source": "./plugins/languages/typescript",
+      "strict": true,
+      "description": "TypeScript development skills: language and type system, Vitest/Jest/Playwright testing, ESLint/typescript-eslint/Biome linting, and the Node.js runtime",
+      "version": "0.1.0",
+      "category": "language",
+      "keywords": [
+        "typescript",
+        "javascript",
+        "node",
+        "vitest",
+        "eslint",
+        "testing",
+        "linting"
+      ]
     },
     {
       "name": "ui",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.97",
+  "version": "0.4.98",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"
@@ -110,6 +110,10 @@
     "./plugins/tools/slidev/skills/interactive",
     "./plugins/tools/tweag/skills/topiary",
     "./plugins/tools/tweag/skills/nickel",
+    "./plugins/languages/typescript/skills/language",
+    "./plugins/languages/typescript/skills/testing",
+    "./plugins/languages/typescript/skills/linting",
+    "./plugins/languages/typescript/skills/node",
     "./plugins/ui/skills/daisyui",
     "./plugins/wasm/skills/wasmtime",
     "./plugins/wasm/skills/wit",

--- a/plugins/languages/typescript/.claude-plugin/plugin.json
+++ b/plugins/languages/typescript/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "typescript",
+  "version": "0.1.0",
+  "description": "TypeScript development skills: language and type system, Vitest/Jest/Playwright testing, ESLint/typescript-eslint/Biome linting, and the Node.js runtime",
+  "author": {
+    "name": "vinnie357"
+  },
+  "repository": "https://github.com/vinnie357/claude-skills",
+  "license": "MIT",
+  "keywords": ["typescript", "javascript", "node", "vitest", "eslint", "testing", "linting"],
+  "skills": [
+    "./skills/language",
+    "./skills/testing",
+    "./skills/linting",
+    "./skills/node"
+  ]
+}

--- a/plugins/languages/typescript/skills/language/SKILL.md
+++ b/plugins/languages/typescript/skills/language/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: language
+description: Guide for core TypeScript language features and the type system. Use when writing or reviewing TypeScript types, enabling strict mode, choosing a utility type, designing generics or conditional types, writing declaration files, or modeling data with discriminated unions.
+license: MIT
+---
+
+# TypeScript Language
+
+Core TypeScript: strict mode, the type system, utility types, declaration files, and discriminated unions.
+
+## When to Use This Skill
+
+Activate when:
+- Configuring `tsconfig.json`, especially `strict` and its component flags
+- Designing generic functions, classes, or constraints
+- Writing conditional types, mapped types, or template literal types
+- Choosing between the built-in utility types (`Partial`, `Pick`, `Omit`, `Record`, ...)
+- Writing or consuming `.d.ts` declaration files
+- Modeling variant data with discriminated unions and exhaustiveness checks
+- Deciding between `interface` and `type`, or between `enum` and a union of literals
+
+## Strict Mode
+
+`strict: true` in `tsconfig.json` is the floor for new TypeScript code in this workspace, not an opt-in extra. It is a single flag that enables a family of component flags — turn it on first, then reach for a component flag only when you need something `strict` doesn't cover.
+
+```json
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}
+```
+
+`strict` enables, among others:
+
+| Flag | What it catches |
+|---|---|
+| `noImplicitAny` | A variable or parameter would be inferred as `any` because no annotation is present |
+| `strictNullChecks` | `null`/`undefined` stop being implicitly assignable to every type |
+| `strictFunctionTypes` | Function parameter types are checked contravariantly instead of bivariantly |
+| `strictBindCallApply` | `.call`/`.bind`/`.apply` are checked against the underlying function's signature |
+| `strictPropertyInitialization` | A class field must be assigned in the constructor or have a definite-assignment marker |
+| `noImplicitThis` | `this` inside a function with unclear context is flagged instead of defaulting to `any` |
+| `alwaysStrict` | Every emitted file is parsed as, and emits, ECMAScript strict mode |
+| `useUnknownInCatchVariables` | `catch (e)` types `e` as `unknown`, not `any` — forces a type check before use |
+
+Two flags `strict` does **not** enable — turn them on explicitly when the codebase can bear the churn:
+
+- `exactOptionalPropertyTypes` — an optional property (`foo?: string`) rejects an explicit `undefined` assignment unless the type says `foo?: string | undefined`. Catches call sites that "clear" a field by writing `undefined` when the schema meant "omit it."
+- `noUncheckedIndexedAccess` — indexing into a `Record<string, T>` or array by a computed key returns `T | undefined` instead of `T`, since JavaScript doesn't guarantee the key exists.
+
+Both close real holes; both also touch a large fraction of existing index/optional-property call sites when retrofitted onto an established codebase. Turn them on for new projects by default; treat enabling them on an existing one as its own reviewed change, not a drive-by.
+
+## The Type System
+
+### Generics
+
+A generic function or class defers a type decision to its caller instead of committing to one type or widening to `any`:
+
+```typescript
+function firstOf<T>(items: T[]): T | undefined {
+  return items[0];
+}
+
+const n = firstOf([1, 2, 3]);        // T inferred as number
+const s = firstOf<string>(["a"]);    // T explicit
+```
+
+Constrain a type parameter with `extends` when the function body needs to rely on a property existing:
+
+```typescript
+interface HasLength {
+  length: number;
+}
+
+function longest<T extends HasLength>(a: T, b: T): T {
+  return a.length >= b.length ? a : b;
+}
+```
+
+`keyof` combined with a second type parameter constrained to it is the standard shape for a type-safe property getter:
+
+```typescript
+function get<T, K extends keyof T>(obj: T, key: K): T[K] {
+  return obj[key];
+}
+```
+
+Generic classes are generic only over their instance side — a static member cannot reference the class's own type parameter.
+
+### Conditional types and `infer`
+
+A conditional type picks between two branches based on an `extends` check evaluated at the type level:
+
+```typescript
+type IsString<T> = T extends string ? true : false;
+```
+
+`infer` introduces a type variable inside the `extends` clause and captures whatever the checked type matched there — this is how library-authored utility types extract a piece of a larger type:
+
+```typescript
+type Flatten<T> = T extends Array<infer Item> ? Item : T;
+type ElementOf<T extends readonly unknown[]> = T extends readonly (infer E)[] ? E : never;
+```
+
+Conditional types **distribute** over a union type parameter by default — `Cond<A | B>` evaluates as `Cond<A> | Cond<B>`. Wrap both sides in a tuple (`[T] extends [U] ? ... : ...`) to compare the union as one type instead of distributing across it. Distribution is usually what you want for a "filter this union" utility; non-distribution is what you want when the conditional is deciding between two shapes of the same aggregate type.
+
+### Mapped types and key remapping
+
+A mapped type transforms every property of an existing type using the same rule:
+
+```typescript
+type Readonly<T> = { readonly [K in keyof T]: T[K] };
+type Partial<T> = { [K in keyof T]?: T[K] };
+```
+
+The `as` clause in a mapped type (TypeScript 4.1+) remaps the resulting key, not just its value — the standard shape for deriving a getter/setter interface or an event-name map from a data shape:
+
+```typescript
+type Getters<T> = {
+  [K in keyof T as `get${Capitalize<string & K>}`]: () => T[K];
+};
+
+interface Person { name: string; age: number; }
+type PersonGetters = Getters<Person>;
+// { getName: () => string; getAge: () => number }
+```
+
+### Template literal types
+
+Template literal types build string-literal unions the same way template literal *values* build strings, but at the type level — combined with `as` remapping above, or standalone for validating a string shape like a route pattern or a CSS unit.
+
+```typescript
+type Vertical = "top" | "bottom";
+type Horizontal = "left" | "right";
+type Corner = `${Vertical}-${Horizontal}`;
+// "top-left" | "top-right" | "bottom-left" | "bottom-right"
+```
+
+## Utility Types
+
+Built-in generic types the compiler ships — reach for one of these before writing a custom mapped type; most "helper type" needs are already covered.
+
+| Utility | Does |
+|---|---|
+| `Partial<T>` | Every property optional |
+| `Required<T>` | Every property required (drops `?`) |
+| `Readonly<T>` | Every property `readonly` |
+| `Record<K, V>` | Object type with keys `K`, all values `V` |
+| `Pick<T, K>` | Subset of `T` limited to keys `K` |
+| `Omit<T, K>` | `T` minus keys `K` |
+| `Exclude<U, M>` | Union `U` minus members assignable to `M` |
+| `Extract<U, M>` | Union `U` narrowed to members assignable to `M` |
+| `NonNullable<T>` | `T` minus `null` and `undefined` |
+| `Parameters<F>` | Tuple of a function type's parameter types |
+| `ReturnType<F>` | A function type's return type |
+| `InstanceType<C>` | The instance type of a constructor type |
+| `Awaited<P>` | Recursively unwraps a `Promise` type, mirroring `await` |
+
+`Pick`/`Omit` are the two to reach for first when a type needs to be "the same shape as X, minus/plus a couple of fields" — writing that mapped type by hand is the YAGNI case the ladder in `/core:restraint` calls out directly.
+
+Full signatures, the string-manipulation utility types (`Uppercase`, `Capitalize`, ...), and `ThisType`/`ThisParameterType` are in `references/type-system-deep-dive.md`.
+
+## Declaration Files and Type-Only Imports
+
+A `.d.ts` file describes the shape of JavaScript without an implementation — the mechanism that lets an untyped JS library, or a project's own public API surface, carry types without shipping `.ts` source:
+
+```typescript
+// maths.d.ts
+export function absolute(num: number): number;
+export const pi: number;
+```
+
+`import type` and inline `type` imports mark an import as type-only, so the compiler strips it entirely at emit — no runtime module load for something only used in annotations. Prefer the inline form when a module mixes value and type exports:
+
+```typescript
+import type { Cat } from "./animal.js";                    // whole import is types-only
+import { createCatName, type Cat, type Dog } from "./animal.js"; // mixed
+```
+
+`export type { Cat }` does the same at the export boundary. Both forms exist specifically to avoid pulling in a module at runtime just because one of its exports is used as a type — relevant to bundler tree-shaking and to breaking import cycles that only exist because of type references.
+
+## Enums, Unions, and Exhaustiveness
+
+Prefer a union of string literals over `enum` for new code. A literal union has no runtime footprint, structurally matches plain strings from JSON/HTTP without a cast, and doesn't carry `enum`'s reverse-mapping surprises for numeric variants:
+
+```typescript
+type Status = "pending" | "active" | "archived"; // prefer this
+enum StatusEnum { Pending, Active, Archived }     // over this, for new code
+```
+
+A **discriminated union** is a union whose members share a literal-typed tag property — the tag lets the compiler narrow the whole object from one `if`/`switch` check:
+
+```typescript
+interface Circle { kind: "circle"; radius: number }
+interface Square { kind: "square"; side: number }
+type Shape = Circle | Square;
+
+function area(shape: Shape): number {
+  switch (shape.kind) {
+    case "circle": return Math.PI * shape.radius ** 2;
+    case "square": return shape.side ** 2;
+  }
+}
+```
+
+Add an exhaustiveness check so a new union member fails to compile instead of falling through silently at runtime:
+
+```typescript
+function area(shape: Shape): number {
+  switch (shape.kind) {
+    case "circle": return Math.PI * shape.radius ** 2;
+    case "square": return shape.side ** 2;
+    default: {
+      const _exhaustive: never = shape;
+      return _exhaustive;
+    }
+  }
+}
+```
+
+Adding a `Triangle` variant to `Shape` without a matching `case` now fails at compile time — `shape` in the `default` branch is no longer assignable to `never`.
+
+## tsconfig.json Practices
+
+- Start from `tsc --init` on a current TypeScript release rather than an old copied config — recent `tsc --init` output defaults to `"strict": true`, `"module": "nodenext"`, and `"moduleDetection": "force"`, which match modern Node/bundler resolution instead of the legacy `commonjs` default.
+- Set `"module"` and `"moduleResolution"` to match the runtime, not to whatever a tutorial used — `"nodenext"` for a Node ESM/CJS-dual package, `"bundler"` when a bundler (Vite, esbuild, webpack) does resolution and TypeScript only type-checks.
+- Keep `include`/`exclude` narrow — `dist`, `node_modules`, and generated output excluded explicitly rather than relying on defaults, since a stray `.ts` file under `dist` being re-type-checked is a common source of duplicate-identifier errors.
+- One `tsconfig.json` per emit target in a monorepo (`tsconfig.build.json` for the compiled output, a base `tsconfig.json` for editor/type-check-only use) via `"extends"`, rather than one config trying to serve both.
+
+## Anti-fabrication
+
+This skill follows `/core:anti-fabrication`. Every flag, utility type signature, and version number here was verified against the TypeScript Handbook (`typescriptlang.org/docs/handbook`) and the npm registry — see `sources.md` for the exact pages and access dates. Where a TypeScript release changes a flag's default or a utility type's signature, treat this skill as stale until re-verified against the current Handbook rather than assumed still accurate.
+
+## References
+
+- `references/type-system-deep-dive.md` — full utility type signatures, string-manipulation utility types, `ThisType`/`ThisParameterType`, and the `NoInfer` utility type

--- a/plugins/languages/typescript/skills/language/SKILL.md
+++ b/plugins/languages/typescript/skills/language/SKILL.md
@@ -44,12 +44,12 @@ Activate when:
 | `alwaysStrict` | Every emitted file is parsed as, and emits, ECMAScript strict mode |
 | `useUnknownInCatchVariables` | `catch (e)` types `e` as `unknown`, not `any` — forces a type check before use |
 
-Two flags `strict` does **not** enable — turn them on explicitly when the codebase can bear the churn:
+Two flags `strict` does **not** enable — they are separate opt-ins the `strict` family does not imply, though a current `tsc --init` now writes both into a fresh project's generated `tsconfig.json` alongside `strict: true` (listed under its own "Stricter Typechecking Options" heading, not inside the `strict` block itself):
 
 - `exactOptionalPropertyTypes` — an optional property (`foo?: string`) rejects an explicit `undefined` assignment unless the type says `foo?: string | undefined`. Catches call sites that "clear" a field by writing `undefined` when the schema meant "omit it."
 - `noUncheckedIndexedAccess` — indexing into a `Record<string, T>` or array by a computed key returns `T | undefined` instead of `T`, since JavaScript doesn't guarantee the key exists.
 
-Both close real holes; both also touch a large fraction of existing index/optional-property call sites when retrofitted onto an established codebase. Turn them on for new projects by default; treat enabling them on an existing one as its own reviewed change, not a drive-by.
+Both close real holes; both also touch a large fraction of existing index/optional-property call sites when retrofitted onto an established codebase. For a **new** project, accept them as part of the scaffolded default rather than deleting them — that's what `tsc --init` on a current release now hands you. For an **existing** codebase without them, treat enabling them as its own reviewed migration, not a drive-by addition alongside an unrelated change.
 
 ## The Type System
 

--- a/plugins/languages/typescript/skills/language/references/type-system-deep-dive.md
+++ b/plugins/languages/typescript/skills/language/references/type-system-deep-dive.md
@@ -1,0 +1,87 @@
+# TypeScript Type System Deep Dive
+
+Full utility type signatures and lesser-used utility types not covered in the main skill body. Source: TypeScript Handbook, Utility Types page.
+
+## Full Utility Type Reference
+
+| Utility | Signature shape | Example |
+|---|---|---|
+| `Awaited<Type>` | Recursively unwraps a `Promise` | `Awaited<Promise<string>>` → `string` |
+| `Partial<Type>` | `{ [P in keyof Type]?: Type[P] }` | `Partial<Todo>` |
+| `Required<Type>` | `{ [P in keyof Type]-?: Type[P] }` | `Required<Props>` |
+| `Readonly<Type>` | `{ readonly [P in keyof Type]: Type[P] }` | `Readonly<Todo>` |
+| `Record<Keys, Type>` | `{ [P in Keys]: Type }` | `Record<"a" \| "b", string>` → `{ a: string; b: string }` |
+| `Pick<Type, Keys>` | `{ [P in Keys]: Type[P] }` | `Pick<Todo, "title" \| "completed">` |
+| `Omit<Type, Keys>` | `Pick<Type, Exclude<keyof Type, Keys>>` | `Omit<Todo, "description">` |
+| `Exclude<UnionType, ExcludedMembers>` | Members of `UnionType` not assignable to `ExcludedMembers` | `Exclude<"a" \| "b" \| "c", "a">` → `"b" \| "c"` |
+| `Extract<Type, Union>` | Members of `Type` assignable to `Union` | `Extract<"a" \| "b", "a" \| "f">` → `"a"` |
+| `NonNullable<Type>` | `Type` minus `null` and `undefined` | `NonNullable<string \| null>` → `string` |
+| `Parameters<Type>` | Tuple of a function type's parameters | `Parameters<(s: string) => void>` → `[s: string]` |
+| `ConstructorParameters<Type>` | Tuple of a constructor's parameters | `ConstructorParameters<ErrorConstructor>` → `[message?: string]` |
+| `ReturnType<Type>` | A function type's return type | `ReturnType<() => string>` → `string` |
+| `InstanceType<Type>` | The instance type of a constructor type | `InstanceType<typeof C>` → `C` |
+| `NoInfer<Type>` | Blocks inference on the wrapped type (5.4+) | see below |
+| `ThisParameterType<Type>` | Extracts a function's `this` parameter type | `ThisParameterType<typeof toHex>` |
+| `OmitThisParameter<Type>` | Removes the `this` parameter from a function type | `OmitThisParameter<typeof toHex>` |
+| `ThisType<Type>` | Contextual `this` typing inside an object literal (requires `noImplicitThis`) | see below |
+
+### `NoInfer<Type>` (TypeScript 5.4+)
+
+Blocks a type parameter from being inferred from a particular argument, forcing inference to come from elsewhere in the call — useful when one parameter should constrain the type and a second should only be checked against it, not widen it:
+
+```typescript
+function createStreetLight<C extends string>(
+  colors: C[],
+  defaultColor?: NoInfer<C>,
+) {
+  // ...
+}
+
+createStreetLight(["red", "yellow", "green"], "red");   // ok
+createStreetLight(["red", "yellow", "green"], "blue");  // error — "blue" not in the colors array
+```
+
+Without `NoInfer`, TypeScript would widen `C` to include `"blue"` from the second argument, defeating the constraint.
+
+### `ThisType<Type>`
+
+A marker type with no members, consumed by the compiler to set the contextual type of `this` inside an object literal's methods — commonly used by fluent/builder-style option objects:
+
+```typescript
+interface ObjectDescriptor<D, M> {
+  data?: D;
+  methods?: M & ThisType<D & M>; // methods see `this` as D & M
+}
+
+function makeObject<D, M>(desc: ObjectDescriptor<D, M>): D & M {
+  // ...
+  return {} as D & M;
+}
+
+const obj = makeObject({
+  data: { x: 0, y: 0 },
+  methods: {
+    moveBy(dx: number, dy: number) {
+      this.x += dx; // `this` is typed as { x: number; y: number } & the methods object
+      this.y += dy;
+    },
+  },
+});
+```
+
+Requires `noImplicitThis` (implied by `strict`) — otherwise `this` inside the method falls back to an implicit `any` instead of using the `ThisType` hint.
+
+## String Manipulation Utility Types
+
+Operate on string literal types at the type level — the type-level counterparts of the JS string methods of the same name:
+
+```typescript
+type Greeting = "hello world";
+
+type A = Uppercase<Greeting>;     // "HELLO WORLD"
+type B = Lowercase<"HELLO">;      // "hello"
+type C = Capitalize<Greeting>;    // "Hello world"
+type D = Uncapitalize<"Hello">;   // "hello"
+```
+
+These compose with template literal types and the `as` mapped-type remapping clause — see the `Getters<T>` example in the main skill body, which uses `Capitalize` to build `getName`/`getAge` keys from a data shape.

--- a/plugins/languages/typescript/skills/linting/SKILL.md
+++ b/plugins/languages/typescript/skills/linting/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: linting
+description: Guide for linting and formatting TypeScript with ESLint, typescript-eslint, Biome, and Prettier. Use when configuring flat-config ESLint, choosing typescript-eslint's strict or recommended presets, evaluating Biome as an ESLint/Prettier replacement, wiring pre-commit lint hooks, or adding lint/format to CI.
+license: MIT
+---
+
+# TypeScript Linting and Formatting
+
+ESLint + typescript-eslint for type-aware linting, Biome as a fast all-in-one alternative, Prettier for formatting, and CI wiring.
+
+## When to Use This Skill
+
+Activate when:
+- Setting up `eslint.config.js` (flat config) for a TypeScript project
+- Choosing between typescript-eslint's `recommended`, `strict`, and `stylistic` presets
+- Deciding between the ESLint+Prettier stack and Biome
+- Configuring pre-commit hooks (`husky` + `lint-staged`) for lint/format
+- Adding lint and format checks to `mise run ci` or a CI workflow
+
+## ESLint with typescript-eslint
+
+### Setup
+
+```bash
+npm install -D eslint @eslint/js typescript typescript-eslint
+```
+
+ESLint 9+ uses **flat config** (`eslint.config.js` / `.mjs`) — a plain array of config objects, not the older `.eslintrc` cascading-file format. `npm init @eslint/config@latest` scaffolds one interactively; the shape by hand:
+
+```javascript
+// eslint.config.mjs
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  js.recommended,
+  ...tseslint.configs.strict,
+  ...tseslint.configs.stylistic,
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    },
+  },
+);
+```
+
+### Preset selection
+
+typescript-eslint ships three stacked preset tiers — pick a floor, don't cherry-pick individual rules out of a higher tier without understanding what the lower tier already covers:
+
+| Preset | What it adds |
+|---|---|
+| `recommended` | Rules that catch common bugs and mistakes with minimal false positives — the floor for any TypeScript project |
+| `strict` | A superset of `recommended` with more opinionated rules that catch bugs `recommended` deliberately leaves out to avoid false positives |
+| `stylistic` | Consistency rules with no bug-catching intent — naming conventions, member ordering; layered on top of either of the above, never a substitute |
+
+Default to `recommended` + `stylistic` for most projects; reach for `strict` when the codebase can absorb its stricter defaults (banning `// @ts-ignore` without a description, disallowing certain type assertions) without a large one-off migration. This mirrors the workspace's general strictness posture (`/core:security`, `/core:tdd` CI-strictness discipline) — start strict on new code, treat loosening as the exception that needs a reason.
+
+### Type-aware rules
+
+Some typescript-eslint rules (`no-floating-promises`, `no-unsafe-assignment`, `await-thenable`) require the TypeScript type checker, not just the parser — they need `parserOptions.project` (or `projectService: true` in newer configs) pointed at a `tsconfig.json`:
+
+```javascript
+export default tseslint.config(
+  ...tseslint.configs.strictTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+);
+```
+
+Type-aware linting is slower than syntax-only linting — it invokes the compiler. Scope it to source files (exclude generated output and config files) rather than running it over the whole repo, and expect it to dominate lint wall-clock time on a large codebase.
+
+## Biome
+
+Biome is a single Rust-implemented binary that combines a linter, a formatter, and import organization — the case for reaching for it instead of ESLint+Prettier is speed and zero-config startup, at the cost of a smaller (though fast-growing) rule set and plugin ecosystem compared to ESLint's.
+
+### Setup
+
+```bash
+npm install -D -E @biomejs/biome
+npx @biomejs/biome init
+```
+
+The `-E` flag pins the exact installed version — Biome's formatting output can shift between versions, so an unpinned range risks a CI failure from a formatter update alone, not a real style violation.
+
+### Commands
+
+```bash
+npx biome format --write .   # formatting only
+npx biome lint --write .     # linting, with safe autofixes
+npx biome check --write .    # format + lint + import organization together
+npx biome ci .               # non-mutating check, exit-code gate for CI
+```
+
+### Choosing Biome over ESLint+Prettier
+
+Reach for Biome when starting a new project and the team values one fast tool over ESLint's larger rule/plugin ecosystem. Don't migrate an existing ESLint config with custom plugins or shareable configs to Biome as a drive-by — Biome's rule set doesn't map 1:1 to typescript-eslint's, and a migration is its own reviewed change with a real rule-parity check, not a mechanical swap.
+
+## Prettier Integration
+
+If linting with ESLint (not Biome), keep Prettier as the formatter and ESLint focused on code-quality rules — don't run Prettier as an ESLint rule via `eslint-plugin-prettier`. Running formatting through the lint pipeline is slower than running Prettier directly and produces editor squiggles for pure formatting differences that autofix on save anyway.
+
+Use `eslint-config-prettier` instead, which disables the ESLint stylistic rules that would otherwise conflict with Prettier's own formatting decisions:
+
+```javascript
+import prettierConfig from "eslint-config-prettier";
+
+export default tseslint.config(
+  // ...other configs
+  prettierConfig, // last — turns off conflicting stylistic rules
+);
+```
+
+Run `prettier --check .` as its own CI step, separate from `eslint`.
+
+## Pre-Commit Hooks
+
+```bash
+npm install -D husky lint-staged
+npx husky init
+```
+
+```json
+// package.json
+{
+  "lint-staged": {
+    "*.{ts,tsx}": ["eslint --fix", "prettier --write"]
+  }
+}
+```
+
+```bash
+# .husky/pre-commit
+npx lint-staged
+```
+
+`lint-staged` runs the configured commands only against staged files, not the whole repo — keeps the pre-commit hook fast enough that it doesn't become the thing developers reach for `--no-verify` to skip. Per `/core:git`, skipping hooks is not something an agent does without explicit instruction; that applies to `lint-staged`-backed pre-commit hooks the same as any other.
+
+## CI Wiring
+
+```toml
+# mise.toml
+[tasks.lint]
+description = "Lint and type-check"
+run = [
+  "npx eslint .",
+  "npx tsc --noEmit",
+]
+
+[tasks.format]
+description = "Check formatting"
+run = "npx prettier --check ."
+
+[tasks.ci]
+description = "Full CI gate"
+depends = ["lint", "format", "test"]
+```
+
+`tsc --noEmit` belongs in the lint task, not the test task — a type error is a lint-time signal (it should fail fast, before tests even run) not a test-time one, and running it separately from `eslint` means a type error and a lint error are distinguishable in CI output.
+
+## Anti-fabrication
+
+This skill follows `/core:anti-fabrication`. Commands, config shapes, and preset names were verified against each tool's own documentation (eslint.org, typescript-eslint.io, biomejs.dev, prettier.io) — see `sources.md` for exact pages and access dates. Rule-level behavior for any specific typescript-eslint or Biome rule not named here should be checked against that tool's rule reference before being asserted, since individual rule defaults change across releases more often than the preset structure does.
+
+## References
+
+- `references/rule-catalog.md` — specific typescript-eslint rules worth enabling deliberately (`no-floating-promises`, `no-explicit-any`, `consistent-type-imports`) with the bug each one catches

--- a/plugins/languages/typescript/skills/linting/SKILL.md
+++ b/plugins/languages/typescript/skills/linting/SKILL.md
@@ -33,7 +33,7 @@ import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  js.recommended,
+  js.configs.recommended,
   ...tseslint.configs.strict,
   ...tseslint.configs.stylistic,
   {
@@ -43,6 +43,8 @@ export default tseslint.config(
   },
 );
 ```
+
+`@eslint/js` exports `{ meta, configs }` — `js.configs.recommended`, not `js.recommended` or `js.default`. Running `js.recommended` directly fails at config-load time (`Unexpected undefined config`) since it resolves to `undefined`.
 
 ### Preset selection
 

--- a/plugins/languages/typescript/skills/linting/references/rule-catalog.md
+++ b/plugins/languages/typescript/skills/linting/references/rule-catalog.md
@@ -76,4 +76,21 @@ Autofixable — safe to run with `eslint --fix` as part of a pre-commit hook or 
 
 ## Applying These Deliberately
 
-These four rules require the type-aware parser configuration (`parserOptions.project` / `projectService`) described in the main skill body — they inspect actual inferred types, not just syntax, so they only run correctly once ESLint has a `tsconfig.json` to type-check against. Enable them as part of `strictTypeChecked` rather than one at a time; the preset already bundles them with the parser wiring documented above.
+These four rules split into two groups, and conflating them means either configuring type-aware parsing a rule doesn't need, or assuming a preset enables a rule it doesn't:
+
+- **`no-floating-promises` and `no-misused-promises` are type-aware** (`requiresTypeChecking: true`) — they inspect actual inferred types (is this expression's type a `Promise`?), not just syntax, so they only run correctly once ESLint has the type-aware parser configuration (`parserOptions.project` / `projectService`) described in the main skill body. Both are included in `strictTypeChecked`.
+- **`no-explicit-any` is syntax-only** (`requiresTypeChecking: false`) — it flags the literal `any` token in an annotation, no type inference required. It runs under plain `recommended`/`strict`, with no `parserOptions.project` wiring needed.
+- **`consistent-type-imports` is also syntax-only, and is in no preset at all** — not `recommended`, not `strict`, not `stylistic`, and not any of the `*TypeChecked` variants. Adding `strictTypeChecked` does **not** turn it on; it must be enabled explicitly:
+
+```javascript
+export default tseslint.config(
+  ...tseslint.configs.strict,
+  {
+    rules: {
+      "@typescript-eslint/consistent-type-imports": "error",
+    },
+  },
+);
+```
+
+Verify a rule's `requiresTypeChecking` value and preset membership against the installed `typescript-eslint` package's own metadata before assuming either — preset composition changes across releases more often than rule behavior does.

--- a/plugins/languages/typescript/skills/linting/references/rule-catalog.md
+++ b/plugins/languages/typescript/skills/linting/references/rule-catalog.md
@@ -1,0 +1,79 @@
+# typescript-eslint Rule Catalog
+
+Rules worth enabling deliberately even outside the `strict` preset, with the specific bug each one catches. Verified against each rule's page at typescript-eslint.io — see `sources.md`.
+
+## `@typescript-eslint/no-floating-promises`
+
+Flags a Promise-valued expression statement with no error handling attached — no `await`, no `.then()`/`.catch()`, no `return`, no explicit `void`. A "floating" Promise silently swallows its rejection; nothing observes the failure.
+
+```typescript
+// Flagged — rejection is silently lost
+someAsyncOperation();
+
+// Fixed — pick one
+await someAsyncOperation();
+void someAsyncOperation();       // explicitly fire-and-forget
+someAsyncOperation().catch(handleError);
+```
+
+The `void` operator is the correct fix when fire-and-forget really is the intent (e.g. a non-critical analytics call) — it documents the decision instead of looking like an oversight.
+
+## `@typescript-eslint/no-misused-promises`
+
+Catches a Promise passed where the calling context expects a synchronous, non-Promise-returning callback — commonly an `async` arrow function handed to `Array.prototype.forEach`, which never awaits its callback's return value:
+
+```typescript
+// Flagged — forEach does not await; rejections are unhandled and
+// the loop does not wait for each iteration to finish
+[1, 2, 3].forEach(async (value) => {
+  await fetch(`/items/${value}`);
+});
+
+// Fixed — for...of lets the enclosing function await each iteration
+for (const value of [1, 2, 3]) {
+  await fetch(`/items/${value}`);
+}
+```
+
+Pairs with `no-floating-promises` — the two together cover the two most common ways async code silently drops an error: not handling a Promise at all, and handing one to a context that can't handle it.
+
+## `@typescript-eslint/no-explicit-any`
+
+Flags an explicit `: any` type annotation. `any` is not "unknown, be careful" — it disables type checking entirely for anything it touches, including values derived from it, which is why it is called out as a last resort rather than a normal type.
+
+```typescript
+// Flagged
+function parse(input: any): any { /* ... */ }
+
+// Preferred — forces a narrowing check before use
+function parse(input: unknown): ParsedResult {
+  if (typeof input !== "string") throw new TypeError("expected string");
+  // ...
+}
+```
+
+`unknown` is the type-safe alternative for "I don't know this type yet" — it requires a narrowing check (a `typeof`/`instanceof` guard, a schema-validation call) before any operation is permitted, where `any` permits everything unchecked.
+
+## `@typescript-eslint/consistent-type-imports`
+
+Enforces that an import used only for type positions (annotations, generic arguments) is marked `import type` — the same type-only-import distinction covered in the language skill, enforced automatically instead of relying on every author to remember it by hand.
+
+```typescript
+// Flagged (Foo and Bar are only ever used as types)
+import { Foo } from "./Foo.js";
+import Bar from "./Bar.js";
+type T = Foo;
+const x: Bar = 1;
+
+// Fixed
+import type { Foo } from "./Foo.js";
+import type Bar from "./Bar.js";
+type T = Foo;
+const x: Bar = 1;
+```
+
+Autofixable — safe to run with `eslint --fix` as part of a pre-commit hook or CI autofix step.
+
+## Applying These Deliberately
+
+These four rules require the type-aware parser configuration (`parserOptions.project` / `projectService`) described in the main skill body — they inspect actual inferred types, not just syntax, so they only run correctly once ESLint has a `tsconfig.json` to type-check against. Enable them as part of `strictTypeChecked` rather than one at a time; the preset already bundles them with the parser wiring documented above.

--- a/plugins/languages/typescript/skills/node/SKILL.md
+++ b/plugins/languages/typescript/skills/node/SKILL.md
@@ -142,7 +142,7 @@ Default new projects to `"type": "module"` — ESM is where the Node and browser
 }
 ```
 
-Conditions are evaluated most-specific-first (`node-addons` → `node` → `import`/`require` → `default`); always include a `"default"` fallback last. Keep a top-level `"main"` pointing at the CJS build alongside `"exports"` only for consumers on Node versions old enough not to read `exports` — new projects that don't need that floor can rely on `exports` alone.
+Node evaluates conditions in the **order they're written in the object** — first matching key wins, not some engine-enforced specificity ranking. Author them most-specific-first (`node-addons`, then `node`, then `import`/`require`, then `default` last) as a matter of convention, because listing a broader condition earlier would shadow every narrower one written after it and it would never be reached. `"default"` always goes last for the same reason: it matches everything, so anything after it is dead. Keep a top-level `"main"` pointing at the CJS build alongside `"exports"` only for consumers on Node versions old enough not to read `exports` — new projects that don't need that floor can rely on `exports` alone.
 
 ## Package Managers
 

--- a/plugins/languages/typescript/skills/node/SKILL.md
+++ b/plugins/languages/typescript/skills/node/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: node
+description: Guide for the Node.js runtime in TypeScript projects. Use when working with async/await and Promises, reading or writing streams, choosing between ESM and CommonJS, configuring package.json exports, picking npm/pnpm/bun, managing Node versions with mise, or wiring Node CI/CD.
+license: MIT
+---
+
+# Node.js Runtime
+
+Async patterns, streams, module systems, package managers, and mise/CI integration for Node.js TypeScript projects.
+
+## When to Use This Skill
+
+Activate when:
+- Writing async/await code, chaining Promises, or using `EventEmitter`
+- Reading, writing, or piping Node streams (`Readable`/`Writable`/`Duplex`/`Transform`)
+- Deciding between ESM (`"type": "module"`) and CommonJS for a package
+- Writing a `package.json` `exports` field, including dual ESM/CJS conditional exports
+- Choosing between npm, pnpm, and Bun for a project
+- Pinning a Node version with mise or wiring Node into CI
+
+## Async Patterns
+
+### async/await over raw Promise chains
+
+```typescript
+async function fetchUserAndPosts(userId: string) {
+  const user = await fetchUser(userId);
+  const posts = await fetchPosts(user.id);
+  return { user, posts };
+}
+```
+
+Prefer `await` in sequence over `.then()` chains for anything with more than one step — the stack trace on a rejected `await` points at the actual failing line, where a long `.then()` chain's error frequently doesn't.
+
+### Concurrency with `Promise.all` / `Promise.allSettled`
+
+Sequential `await` calls that don't depend on each other's results waste wall-clock time — run independent async work concurrently:
+
+```typescript
+// Sequential — unnecessarily slow if these don't depend on each other
+const user = await fetchUser(id);
+const settings = await fetchSettings(id);
+
+// Concurrent — same total work, shorter wall time
+const [user, settings] = await Promise.all([fetchUser(id), fetchSettings(id)]);
+```
+
+`Promise.all` rejects as soon as any one input rejects, discarding the other results. `Promise.allSettled` never rejects — it resolves with a `{ status: "fulfilled" | "rejected", ... }` record per input, appropriate when partial failure is an expected, handled case (e.g. "notify five webhooks, report which ones failed") rather than a hard error.
+
+### `EventEmitter`
+
+Node's `EventEmitter` is the base of most non-stream async Node APIs (`process`, `net.Server`, `child_process`) — extend it for a custom object that fires multiple named events over its lifetime, as opposed to a Promise's single resolve/reject:
+
+```typescript
+import { EventEmitter } from "node:events";
+
+class JobQueue extends EventEmitter {
+  enqueue(job: Job) {
+    // ...
+    this.emit("enqueued", job);
+  }
+}
+
+const queue = new JobQueue();
+queue.on("enqueued", (job: Job) => console.log(`queued ${job.id}`));
+```
+
+Reach for `EventEmitter` for "zero or more things will happen over time, listeners subscribe/unsubscribe" — reach for a Promise for "exactly one thing happens once." Mixing the two (a Promise that also emits progress events) is a common source of Node API confusion; if progress reporting is needed, an `EventEmitter` combined with a distinct completion Promise (or an async generator) is clearer than overloading one Promise for both jobs.
+
+## Streams
+
+Four stream types, all `EventEmitter` subclasses under the hood:
+
+| Type | Direction | Example |
+|---|---|---|
+| `Readable` | Data flows out | `fs.createReadStream()`, an HTTP response body |
+| `Writable` | Data flows in | `fs.createWriteStream()`, `process.stdout` |
+| `Duplex` | Both, independently | `net.Socket` |
+| `Transform` | Both, output derived from input | `zlib.createGzip()` |
+
+### Piping
+
+```typescript
+import { createReadStream, createWriteStream } from "node:fs";
+import { createGzip } from "node:zlib";
+
+createReadStream("input.txt")
+  .pipe(createGzip())
+  .pipe(createWriteStream("input.txt.gz"));
+```
+
+`.pipe()` is the default choice over manual `data`/`end` event listeners — it handles backpressure automatically, which manual event handling does not.
+
+### Backpressure
+
+A `Writable.write()` call returns `false` when its internal buffer is full — code writing directly (not through `.pipe()`) must pause until the stream's `'drain'` event fires, or memory grows unbounded on a fast producer / slow consumer:
+
+```typescript
+function writeAll(stream: NodeJS.WritableStream, data: string, done: () => void) {
+  if (!stream.write(data)) {
+    stream.once("drain", done);
+  } else {
+    process.nextTick(done);
+  }
+}
+```
+
+`stream.pipeline()` (from `node:stream/promises`) is the preferred modern API over chained `.pipe()` calls for anything that needs error propagation across the whole chain — a `.pipe()` chain does not automatically forward an error from an earlier stream to destroy later ones, `pipeline()` does.
+
+## ESM vs CommonJS
+
+### `"type"` field
+
+```json
+{ "type": "module" }
+```
+
+- `"module"` — `.js` files are ES modules (`import`/`export`)
+- `"commonjs"` or omitted — `.js` files are CommonJS (`require`/`module.exports`)
+- `.mjs` is always ESM and `.cjs` is always CommonJS, regardless of `"type"` — use the explicit extension when a package needs to ship both formats in adjacent files.
+
+Default new projects to `"type": "module"` — ESM is where the Node and browser ecosystems converge, and `tsc --init` on a current TypeScript release defaults `"module"` to `"nodenext"`, which follows this field.
+
+### `exports` field
+
+`exports` is both an encapsulation boundary (only listed paths are importable from outside the package — deep imports into unlisted internal files fail) and the mechanism for dual ESM/CJS publishing via **conditional exports**:
+
+```json
+{
+  "name": "my-package",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "./utils": {
+      "import": "./dist/utils.mjs",
+      "require": "./dist/utils.cjs"
+    }
+  }
+}
+```
+
+Conditions are evaluated most-specific-first (`node-addons` → `node` → `import`/`require` → `default`); always include a `"default"` fallback last. Keep a top-level `"main"` pointing at the CJS build alongside `"exports"` only for consumers on Node versions old enough not to read `exports` — new projects that don't need that floor can rely on `exports` alone.
+
+## Package Managers
+
+| Tool | Reach for it when |
+|---|---|
+| **npm** | The default — ships with Node, needs no extra install, fine for most single-package projects |
+| **pnpm** | A monorepo, or disk/install-speed matters — content-addressable store avoids per-project dependency duplication, and its non-flat `node_modules` (symlinks, not hoisting) catches undeclared-dependency bugs npm's flat hoisting hides |
+| **Bun** | The whole toolchain (runtime + package manager + test runner + bundler) is being adopted, not just the installer — Bun's `bun install` is fast, but picking Bun-the-package-manager while running Node-the-runtime forfeits most of its advantage |
+
+Bun ships as a single dependency-free binary combining a JavaScriptCore-based runtime (a drop-in Node replacement, still working toward full Node API parity), `bun install`, `bun test` (Jest-compatible), and `bun build`. It executes `.ts`/`.tsx` directly without a separate compile step. Node compatibility is an ongoing effort, not a guarantee — verify a specific Node API/package works under Bun before committing a production service to it, rather than assuming parity.
+
+Restraint applies to this choice directly: don't add pnpm to a single-package project that npm already handles, and don't adopt Bun for one fast test runner when the rest of the deployment target is Node.
+
+## mise Integration
+
+```toml
+# mise.toml
+[tools]
+node = "24"          # fuzzy — tracks the latest 24.x patch/minor
+# node = "24.1.2"     # --pin exact, for reproducible CI
+
+[tasks.dev]
+run = "node --watch src/index.ts"
+
+[tasks.build]
+run = "tsc -p tsconfig.build.json"
+```
+
+Pin the Node major to whichever release is Active LTS at the time (see `sources.md` for the version verified for this skill) — new projects should not start on a Current (non-LTS) release line, since Current releases have a shorter support window and are more likely to carry breaking changes between minors. `mise install` inside a freshly cloned repo installs the pinned version with no separate `nvm`/`fnm` step, consistent with `/core:mise`'s "mise, not brew" convention for this workspace's tool management.
+
+## CI/CD Patterns
+
+```yaml
+# .github/workflows/ci.yml
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: jdx/mise-action@v3
+      - run: mise run ci
+```
+
+Delegate to `mise run ci` from the CI workflow rather than duplicating individual `npm run lint` / `npm test` steps in YAML — the local and remote invocations then run the exact same command, so "passes locally, fails in CI" collapses to an environment difference (Node version, missing env var) instead of a command drift, per this workspace's `/core:git` Gate 2 discipline (local `mise run ci` green is a precondition for remote CI being meaningful, not a redundant check).
+
+## Anti-fabrication
+
+This skill follows `/core:anti-fabrication`. Stream types, backpressure behavior, and `exports`/`type` field semantics were verified against the Node.js API docs (`nodejs.org/api`) and the current Active LTS/Current release lines from `nodejs.org/en/about/previous-releases`; package manager claims were verified against each tool's own docs (pnpm.io, bun.sh/docs). See `sources.md` for exact pages and access dates. Bun's Node-compatibility status changes release to release — treat any specific "Bun supports X Node API" claim as needing a fresh check against `bun.sh/docs/runtime/nodejs-compat`, not this skill.
+
+## References
+
+- `references/module-resolution.md` — `moduleResolution` strategies (`node16`/`nodenext`/`bundler`), the dual-package hazard, and subpath import patterns (`#internal/*`)

--- a/plugins/languages/typescript/skills/node/references/module-resolution.md
+++ b/plugins/languages/typescript/skills/node/references/module-resolution.md
@@ -34,10 +34,10 @@ If a single application ends up loading the package through **both** paths — o
 Mitigations, roughly in order of preference:
 
 1. **Keep the package stateless at the module level.** No top-level singletons, no module-level mutable caches. If there's no shared state to duplicate, dual instantiation is harmless.
-2. **Make the CJS entry point a thin wrapper that re-exports the ESM implementation**, so there's only one real implementation and one place state can live — common in packages that publish CJS purely for backward compatibility with older Node consumers.
+2. **Make the ESM entry point a thin wrapper that re-exports the CJS implementation** — the direction Node's own dual CJS/ESM package guidance uses, and for a structural reason, not just convention: an ESM module can cleanly `import` a CommonJS module (Node's CJS-in-ESM interop is old and universally supported), but the reverse — a CommonJS module synchronously `require()`-ing an ESM module — only works at all on Node ≥22.12, and even then fails with `ERR_REQUIRE_ASYNC_MODULE` if the target ESM module uses top-level await. Keeping the real implementation as CJS and the ESM file as the wrapper avoids depending on that narrower, version-gated, TLA-sensitive path. Verified directly against Node v24.18.0: the ESM-wraps-CJS direction works with no top-level await required in the wrapper.
 3. **Publish ESM-only** where the audience can bear it (a library targeting only current Node/bundler consumers) — no dual entry, no hazard, at the cost of dropping older CJS-only consumers.
 
-This is the concrete, load-bearing reason the Node module skill in this plugin defaults new projects to `"type": "module"` rather than shipping dual CJS/ESM by default: dual publishing solves a real compatibility problem but introduces this hazard as its cost, so it should be a deliberate choice for a library maintaining broad compatibility, not the default for an application.
+This is the concrete, load-bearing reason the Node module skill in this plugin defaults new projects to `"type": "module"` rather than shipping dual CJS/ESM by default: dual publishing solves a real compatibility problem but introduces this hazard as its cost, so it should be a deliberate choice for a library maintaining broad compatibility, not the default for an application. When that choice is made, keep the CJS file as the canonical implementation and the ESM file as the wrapper, not the other way around.
 
 ## Subpath Imports (`#internal/*`)
 

--- a/plugins/languages/typescript/skills/node/references/module-resolution.md
+++ b/plugins/languages/typescript/skills/node/references/module-resolution.md
@@ -1,0 +1,66 @@
+# Module Resolution Deep Dive
+
+`moduleResolution` strategies, the dual-package hazard, and subpath imports. Verified against the TypeScript Handbook's Modules Reference and the Node.js `packages` API docs — see `sources.md`.
+
+## `moduleResolution` Strategies
+
+| Value | Intended for | Extensionless paths | `exports`/`imports` support |
+|---|---|---|---|
+| `node10` (formerly `node`) | Legacy pre-v12 Node — deprecated | Yes | No |
+| `node16` / `nodenext` | Any Node.js app or library, ESM or CJS | ESM: no. CJS: yes | Yes |
+| `bundler` | webpack/esbuild/Vite/Rollup, Bun, tsx — anything where a bundler (not `tsc`) does the actual module resolution and emit | Yes | Yes |
+
+`node16`/`nodenext` mirror Node's actual runtime resolution rules exactly, including the parts that are inconvenient in a TypeScript-first workflow — no extensionless ESM imports, no implicit `/index.js` directory resolution for ESM. That strictness is deliberate: it prevents `tsc` from accepting an import path Node itself would reject at runtime.
+
+`bundler` relaxes those rules to match what bundlers actually support (extensionless imports, directory index resolution) because the bundler — not `tsc` — performs the real resolution and emit; `tsc` under `bundler` mode is typically run with `noEmit: true` purely for type-checking.
+
+Match this setting to where the code actually runs, not to habit: a library published to npm and executed by Node needs `nodenext`; a frontend app built by Vite needs `bundler`.
+
+## The Dual Package Hazard
+
+Occurs when a package ships separate entry points for `require()` (CommonJS) and `import` (ESM) via conditional `exports`:
+
+```json
+{
+  "exports": {
+    "import": "./index.mjs",
+    "require": "./index.cjs"
+  }
+}
+```
+
+If a single application ends up loading the package through **both** paths — one dependency imports it via ESM, another (or the app itself) requires it via CJS — Node instantiates the module **twice**, once per entry point. Two separate module instances mean two separate copies of any module-level state: a singleton, a cache, a class whose `instanceof` checks now fail across the two copies, a registry pattern that silently splits in half.
+
+Mitigations, roughly in order of preference:
+
+1. **Keep the package stateless at the module level.** No top-level singletons, no module-level mutable caches. If there's no shared state to duplicate, dual instantiation is harmless.
+2. **Make the CJS entry point a thin wrapper that re-exports the ESM implementation**, so there's only one real implementation and one place state can live — common in packages that publish CJS purely for backward compatibility with older Node consumers.
+3. **Publish ESM-only** where the audience can bear it (a library targeting only current Node/bundler consumers) — no dual entry, no hazard, at the cost of dropping older CJS-only consumers.
+
+This is the concrete, load-bearing reason the Node module skill in this plugin defaults new projects to `"type": "module"` rather than shipping dual CJS/ESM by default: dual publishing solves a real compatibility problem but introduces this hazard as its cost, so it should be a deliberate choice for a library maintaining broad compatibility, not the default for an application.
+
+## Subpath Imports (`#internal/*`)
+
+The `imports` field (distinct from `exports`) maps internal-only import specifiers, always prefixed with `#` to disambiguate them from external package names:
+
+```json
+{
+  "imports": {
+    "#config": {
+      "node": "./src/config.node.js",
+      "default": "./src/config.browser.js"
+    }
+  }
+}
+```
+
+```typescript
+import { getConfig } from "#config"; // resolves per-condition, per the map above
+```
+
+Two things `imports` does that `exports` cannot:
+
+- It is private to the package — nothing outside the package can import through an `#`-prefixed specifier, where `exports` entries are the package's public surface.
+- It can map to an **external** package, not just an internal file — useful for swapping a Node-native dependency for a browser polyfill of the same internal import path, letting the rest of the codebase `import` one specifier regardless of which environment it runs in.
+
+Reach for `imports` when a module needs an environment-conditional internal dependency (Node-native vs. polyfill) and the goal is to keep that branching out of every call site — the call sites stay a single, unconditional `import "#config"`.

--- a/plugins/languages/typescript/skills/sources.md
+++ b/plugins/languages/typescript/skills/sources.md
@@ -1,0 +1,189 @@
+# TypeScript Plugin Sources
+
+This file documents the sources used to create the typescript plugin skills.
+
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `typescript`, `vitest`, `jest`, `playwright`, `expect-type`, `tsd`, `eslint`, `typescript-eslint`, `biome`, `prettier`, `husky`, `node`, `pnpm`, `bun`.
+
+## Language Skill
+
+### TypeScript Handbook
+- **URL**: https://www.typescriptlang.org/docs/handbook/
+- **Purpose**: Foundation for the language skill — the type system, strict mode, generics, conditional types, mapped types
+- **Date Accessed**: 2026-08-01
+- **Key Topics**: Strict flags, generics and constraints, conditional types and `infer`, mapped types with `as` remapping, template literal types
+
+### TSConfig Reference
+- **URL**: https://www.typescriptlang.org/tsconfig/
+- **Purpose**: Authoritative reference for `strict` and its component compiler options
+- **Date Accessed**: 2026-08-01
+- **Key Topics**: `noImplicitAny`, `strictNullChecks`, `strictFunctionTypes`, `strictBindCallApply`, `strictPropertyInitialization`, `noImplicitThis`, `alwaysStrict`, `useUnknownInCatchVariables`, `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`
+
+### TypeScript Utility Types
+- **URL**: https://www.typescriptlang.org/docs/handbook/utility-types.html
+- **Purpose**: Full utility type signature reference, extracted into `language/references/type-system-deep-dive.md`
+- **Date Accessed**: 2026-08-01
+- **Key Topics**: `Partial`, `Required`, `Readonly`, `Record`, `Pick`, `Omit`, `Exclude`, `Extract`, `NonNullable`, `Parameters`, `ReturnType`, `InstanceType`, `Awaited`, `NoInfer`, `ThisType`, string manipulation types
+
+### TypeScript Narrowing (Discriminated Unions)
+- **URL**: https://www.typescriptlang.org/docs/handbook/2/narrowing.html
+- **Purpose**: Discriminated unions and exhaustiveness checking with `never`
+- **Date Accessed**: 2026-08-01
+
+### TypeScript Generics
+- **URL**: https://www.typescriptlang.org/docs/handbook/2/generics.html
+- **Purpose**: Generic functions, constraints, and generic classes
+- **Date Accessed**: 2026-08-01
+
+### TypeScript Conditional Types
+- **URL**: https://www.typescriptlang.org/docs/handbook/2/conditional-types.html
+- **Purpose**: Conditional types, `infer`, mapped types with key remapping, distributive conditional types
+- **Date Accessed**: 2026-08-01
+
+### TypeScript Modules Handbook
+- **URL**: https://www.typescriptlang.org/docs/handbook/2/modules.html
+- **Purpose**: Type-only imports/exports (`import type`) and declaration files (`.d.ts`)
+- **Date Accessed**: 2026-08-01
+
+### TypeScript Modules Reference (moduleResolution)
+- **URL**: https://www.typescriptlang.org/docs/handbook/modules/reference.html
+- **Purpose**: `moduleResolution` strategy comparison, extracted into `node/references/module-resolution.md`
+- **Date Accessed**: 2026-08-01
+- **Key Topics**: `node10`, `node16`/`nodenext`, `bundler`
+
+### TypeScript 5.9 Release Notes
+- **URL**: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html
+- **Purpose**: `tsc --init` default shape cited in the tsconfig.json practices section
+- **Date Accessed**: 2026-08-01
+- **Key Topics**: Minimal `tsc --init` output (`strict: true`, `module: nodenext`, `moduleDetection: force`)
+
+### TypeScript npm Registry
+- **URL**: https://registry.npmjs.org/typescript/latest
+- **Purpose**: Version tracking — see the discrepancy note in `sources.toml`'s `typescript` entry
+- **Date Accessed**: 2026-08-01
+
+### GitHub Repository (microsoft/TypeScript)
+- **URL**: https://github.com/microsoft/TypeScript/releases
+- **Purpose**: Release tracking for `mise sources:check`
+- **Date Accessed**: 2026-08-01
+
+## Testing Skill
+
+### Vitest Guide
+- **URL**: https://vitest.dev/guide/
+- **Purpose**: Foundation for the Vitest section — setup, config, mocking, assertions
+- **Date Accessed**: 2026-08-01
+- **Key Topics**: `vi.fn()`, `vi.mock()`, Vite config reuse, Node/Vite version floors
+
+### Vitest / Jest npm Registry and GitHub Releases
+- **URLs**: https://registry.npmjs.org/vitest/latest, https://github.com/vitest-dev/vitest/releases, https://registry.npmjs.org/jest/latest, https://github.com/jestjs/jest/releases
+- **Purpose**: Version tracking
+- **Date Accessed**: 2026-08-01
+
+### Jest Getting Started
+- **URL**: https://jestjs.io/docs/getting-started
+- **Purpose**: Foundation for the Jest section — setup, `ts-jest` vs Babel, basic test shape
+- **Date Accessed**: 2026-08-01
+
+### Playwright Intro
+- **URL**: https://playwright.dev/docs/intro
+- **Purpose**: Foundation for the end-to-end testing section
+- **Date Accessed**: 2026-08-01
+- **Key Topics**: `npm init playwright@latest`, `npx playwright test`, `--ui` mode
+
+### Playwright npm Registry
+- **URL**: https://registry.npmjs.org/@playwright/test/latest
+- **Purpose**: Version tracking
+- **Date Accessed**: 2026-08-01
+
+### expect-type / tsd
+- **URLs**: https://github.com/mmkal/expect-type, https://github.com/tsdjs/tsd, https://registry.npmjs.org/expect-type/latest, https://registry.npmjs.org/tsd/latest
+- **Purpose**: Type-level testing section — `expectTypeOf`/`expectType` API entry points and version tracking
+- **Date Accessed**: 2026-08-01
+
+## Linting Skill
+
+### ESLint Getting Started
+- **URL**: https://eslint.org/docs/latest/use/getting-started
+- **Purpose**: Foundation for the ESLint section — flat config setup and shape
+- **Date Accessed**: 2026-08-01
+- **Key Topics**: `eslint.config.js`, `npm init @eslint/config@latest`
+
+### typescript-eslint Getting Started
+- **URL**: https://typescript-eslint.io/getting-started/
+- **Purpose**: Foundation for the typescript-eslint section — presets and config wiring
+- **Date Accessed**: 2026-08-01
+- **Key Topics**: `recommended`/`strict`/`stylistic` preset tiers
+
+### typescript-eslint Rule Pages
+- **URLs**: https://typescript-eslint.io/rules/no-floating-promises/, https://typescript-eslint.io/rules/no-misused-promises/, https://typescript-eslint.io/rules/no-explicit-any/, https://typescript-eslint.io/rules/consistent-type-imports/
+- **Purpose**: Individual rule behavior extracted into `linting/references/rule-catalog.md`
+- **Date Accessed**: 2026-08-01
+
+### Biome Getting Started
+- **URL**: https://biomejs.dev/guides/getting-started/
+- **Purpose**: Foundation for the Biome section — install, init, commands
+- **Date Accessed**: 2026-08-01
+- **Key Topics**: `biome init`, `biome format`/`lint`/`check`/`ci`
+
+### Prettier — Integrating with Linters
+- **URL**: https://prettier.io/docs/integrating-with-linters
+- **Purpose**: `eslint-config-prettier` vs `eslint-plugin-prettier` recommendation, cited directly
+- **Date Accessed**: 2026-08-01
+
+### ESLint / typescript-eslint / Biome / Prettier / Husky npm Registry and GitHub Releases
+- **URLs**: https://registry.npmjs.org/eslint/latest, https://github.com/eslint/eslint/releases, https://registry.npmjs.org/typescript-eslint/latest, https://github.com/typescript-eslint/typescript-eslint/releases, https://registry.npmjs.org/@biomejs/biome/latest, https://github.com/biomejs/biome/releases, https://registry.npmjs.org/prettier/latest, https://registry.npmjs.org/husky/latest
+- **Purpose**: Version tracking
+- **Date Accessed**: 2026-08-01
+
+## Node Skill
+
+### Node.js Streams API
+- **URL**: https://nodejs.org/api/stream.html
+- **Purpose**: Foundation for the Streams section — the four stream types, piping, backpressure
+- **Date Accessed**: 2026-08-01
+
+### Node.js Packages API (exports/imports/type)
+- **URL**: https://nodejs.org/api/packages.html
+- **Purpose**: Foundation for the ESM vs CommonJS section — `exports`, `imports`, `type` fields, conditional exports
+- **Date Accessed**: 2026-08-01
+
+### Node.js Packages API — Subpath Imports
+- **URL**: https://nodejs.org/api/packages.html#subpath-imports
+- **Purpose**: `imports` field and `#`-prefixed subpath imports, extracted into `node/references/module-resolution.md`
+- **Date Accessed**: 2026-08-01
+
+### Node.js Packages API — Dual Package Hazard
+- **URL**: https://nodejs.org/api/packages.html#dual-package-hazard
+- **Purpose**: Dual CJS/ESM entry-point hazard, extracted into `node/references/module-resolution.md`
+- **Date Accessed**: 2026-08-01
+- **Note**: The page's own prose is thin here (points to an external examples repo); the module-instance-duplication explanation in the reference is this skill's own synthesis of the documented cause, not a verbatim quote — flagged for re-verification if a more authoritative Node source is found.
+
+### Node.js Release Schedule
+- **URL**: https://nodejs.org/en/about/previous-releases
+- **Purpose**: Active LTS vs Current release line determination for the mise pinning guidance
+- **Date Accessed**: 2026-08-01
+- **Key Topics**: v24 "Krypton" (Active LTS), v26 (Current)
+
+### pnpm Motivation
+- **URL**: https://pnpm.io/motivation
+- **Purpose**: Foundation for the pnpm entry in the package-manager comparison table
+- **Date Accessed**: 2026-08-01
+
+### Bun Documentation
+- **URL**: https://bun.sh/docs
+- **Purpose**: Foundation for the Bun entry in the package-manager comparison table
+- **Date Accessed**: 2026-08-01
+- **Key Topics**: Runtime + package manager + test runner + bundler, JavaScriptCore engine, Node-compatibility status as an ongoing effort
+
+### pnpm / bun-types npm Registry
+- **URLs**: https://registry.npmjs.org/pnpm/latest, https://registry.npmjs.org/bun-types/latest
+- **Purpose**: Version tracking
+- **Date Accessed**: 2026-08-01
+
+## Plugin Information
+
+- **Name**: typescript
+- **Description**: TypeScript development skills: language and type system, Vitest/Jest/Playwright testing, ESLint/typescript-eslint/Biome linting, and the Node.js runtime
+- **Skills**: 4 skills covering the TypeScript language, testing, linting, and the Node.js runtime
+- **Created**: 2026-08-01
+- **Updated**: 2026-08-01

--- a/plugins/languages/typescript/skills/sources.toml
+++ b/plugins/languages/typescript/skills/sources.toml
@@ -1,0 +1,247 @@
+# sources.toml - Machine-readable version tracking for skill dependencies
+# Run `mise sources:check` to compare against the latest upstream release.
+
+[meta]
+plugin = "typescript"
+reviewed_at_plugin_version = "0.1.0"
+last_full_check = "2026-08-01"
+
+# ----------------------------------------------------------------------------
+# TypeScript itself — the Handbook (type system, strict flags, utility types,
+# modules, declaration files) cited from the language skill, and moduleResolution
+# semantics cited from the language and node skills' modules-reference material.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["language"]
+name = "typescript"
+url = "https://www.typescriptlang.org/docs/handbook/"
+releases_url = "https://github.com/microsoft/TypeScript/releases"
+check_method = "github-releases"
+github_repo = "microsoft/TypeScript"
+current_version = "7.0.2"
+version_constraint = "semver"
+last_checked = "2026-08-01"
+update_priority = "high"
+breaking_changes_likely = true
+notes = "current_version 7.0.2 is the npm registry 'latest' dist-tag (registry.npmjs.org/typescript/latest, checked live 2026-08-01). Two other live checks the same day disagreed: the typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html page describes a 5.9 release dated 2026-07-27, and github.com/microsoft/TypeScript/releases showed 6.0.3 as its top entry — GitHub's releases page returned partial-render errors on fetch, so that number may be stale/incomplete rather than authoritative. Skill content (generics, conditional types, mapped types, utility types, strict flags, modules) is grounded in the stable Handbook feature set that has not changed across these point releases, not in any single version's changelog — re-verify before adding a claim specific to TypeScript 6 or 7 (e.g. the native/Go compiler port) that this skill does not currently make."
+
+# ----------------------------------------------------------------------------
+# Vitest — testing skill's primary unit-test runner section.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["testing"]
+name = "vitest"
+url = "https://vitest.dev/guide/"
+releases_url = "https://github.com/vitest-dev/vitest/releases"
+check_method = "github-releases"
+github_repo = "vitest-dev/vitest"
+current_version = "4.1.10"
+version_constraint = "semver"
+last_checked = "2026-08-01"
+update_priority = "high"
+breaking_changes_likely = false
+notes = "current_version 4.1.10 verified via both vitest.dev/guide/ (documented version) and registry.npmjs.org/vitest/latest (npm dist-tag), checked live 2026-08-01 — the two agreed. github.com/vitest-dev/vitest/releases shows a v5.0.0-beta.7 prerelease ahead of this on the same date; not used as current_version since it is pre-release, not the npm 'latest' dist-tag."
+
+# ----------------------------------------------------------------------------
+# Jest — testing skill's alternative unit-test runner section.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["testing"]
+name = "jest"
+url = "https://jestjs.io/docs/getting-started"
+releases_url = "https://github.com/jestjs/jest/releases"
+check_method = "github-releases"
+github_repo = "jestjs/jest"
+current_version = "30.4.2"
+version_constraint = "semver"
+last_checked = "2026-08-01"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "current_version 30.4.2 verified via registry.npmjs.org/jest/latest and cross-checked against github.com/jestjs/jest/releases (both agreed), live 2026-08-01. jestjs.io/docs/getting-started itself only states the shorter '30.4'."
+
+# ----------------------------------------------------------------------------
+# Playwright — testing skill's end-to-end section.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["testing"]
+name = "playwright"
+url = "https://playwright.dev/docs/intro"
+releases_url = "https://github.com/microsoft/playwright/releases"
+check_method = "github-releases"
+github_repo = "microsoft/playwright"
+current_version = "1.62.1"
+version_constraint = "semver"
+last_checked = "2026-08-01"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "current_version 1.62.1 is the @playwright/test npm registry 'latest' dist-tag (registry.npmjs.org/@playwright/test/latest), checked live 2026-08-01. playwright.dev/docs/intro does not state a version number directly."
+
+# ----------------------------------------------------------------------------
+# Type-level testing tools — expect-type and tsd, cited from the testing
+# skill's 'Type-Level Testing' section only, not separately documented in depth.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["testing"]
+name = "expect-type"
+url = "https://github.com/mmkal/expect-type"
+releases_url = "https://github.com/mmkal/expect-type/releases"
+check_method = "manual"
+current_version = "1.4.0"
+version_constraint = "semver"
+last_checked = "2026-08-01"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "current_version 1.4.0 from registry.npmjs.org/expect-type/latest, checked live 2026-08-01. check_method=manual because this is a supporting reference, not a primary section — full API surface not independently verified beyond the documented expectTypeOf entry point."
+
+[[sources]]
+skills = ["testing"]
+name = "tsd"
+url = "https://github.com/tsdjs/tsd"
+releases_url = "https://github.com/tsdjs/tsd/releases"
+check_method = "manual"
+current_version = "0.33.0"
+version_constraint = "semver"
+last_checked = "2026-08-01"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "current_version 0.33.0 from registry.npmjs.org/tsd/latest, checked live 2026-08-01. check_method=manual because this is a supporting reference, not a primary section."
+
+# ----------------------------------------------------------------------------
+# ESLint (flat config) — linting skill's primary linter section.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["linting"]
+name = "eslint"
+url = "https://eslint.org/docs/latest/use/getting-started"
+releases_url = "https://github.com/eslint/eslint/releases"
+check_method = "github-releases"
+github_repo = "eslint/eslint"
+current_version = "10.8.0"
+version_constraint = "semver"
+last_checked = "2026-08-01"
+update_priority = "high"
+breaking_changes_likely = false
+notes = "current_version 10.8.0 verified via both eslint.org/docs/latest/use/getting-started (documented version) and registry.npmjs.org/eslint/latest, checked live 2026-08-01 — agreed. Flat config (eslint.config.js) is the only config format documented in this skill; the legacy .eslintrc cascading format is intentionally not covered."
+
+# ----------------------------------------------------------------------------
+# typescript-eslint — linting skill's TypeScript-aware rule presets and the
+# rule-catalog reference's individual rule pages.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["linting"]
+name = "typescript-eslint"
+url = "https://typescript-eslint.io/getting-started/"
+releases_url = "https://github.com/typescript-eslint/typescript-eslint/releases"
+check_method = "github-releases"
+github_repo = "typescript-eslint/typescript-eslint"
+current_version = "8.65.0"
+version_constraint = "semver"
+last_checked = "2026-08-01"
+update_priority = "high"
+breaking_changes_likely = false
+notes = "current_version 8.65.0 verified via registry.npmjs.org/typescript-eslint/latest and cross-checked against github.com/typescript-eslint/typescript-eslint/releases (both agreed), live 2026-08-01. Covers the getting-started page plus the four individual rule pages extracted into references/rule-catalog.md: no-floating-promises, no-misused-promises, no-explicit-any, consistent-type-imports."
+
+# ----------------------------------------------------------------------------
+# Biome — linting skill's all-in-one linter/formatter alternative.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["linting"]
+name = "biome"
+url = "https://biomejs.dev/guides/getting-started/"
+releases_url = "https://github.com/biomejs/biome/releases"
+check_method = "github-releases"
+github_repo = "biomejs/biome"
+current_version = "2.5.6"
+version_constraint = "semver"
+last_checked = "2026-08-01"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "current_version 2.5.6 (published as 'Biome CLI v2.5.6') verified via both registry.npmjs.org/@biomejs/biome/latest and github.com/biomejs/biome/releases, live 2026-08-01 — agreed."
+
+# ----------------------------------------------------------------------------
+# Prettier — linting skill's formatter section, and the eslint-config-prettier
+# integration guidance.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["linting"]
+name = "prettier"
+url = "https://prettier.io/docs/integrating-with-linters"
+releases_url = "https://github.com/prettier/prettier/releases"
+check_method = "github-releases"
+github_repo = "prettier/prettier"
+current_version = "3.9.6"
+version_constraint = "semver"
+last_checked = "2026-08-01"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "current_version 3.9.6 from registry.npmjs.org/prettier/latest, checked live 2026-08-01. The eslint-plugin-prettier vs eslint-config-prettier guidance in the skill is drawn directly from prettier.io/docs/integrating-with-linters, the 'Integrating with linters' page's own stated recommendation."
+
+# ----------------------------------------------------------------------------
+# Pre-commit hook tooling — husky and lint-staged, cited from the linting
+# skill's 'Pre-Commit Hooks' section only.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["linting"]
+name = "husky"
+url = "https://typicode.github.io/husky/"
+releases_url = "https://github.com/typicode/husky/releases"
+check_method = "manual"
+current_version = "9.1.7"
+version_constraint = "semver"
+last_checked = "2026-08-01"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "current_version 9.1.7 from registry.npmjs.org/husky/latest, checked live 2026-08-01. lint-staged's exact version was not independently checked; the skill does not cite a version number for it."
+
+# ----------------------------------------------------------------------------
+# Node.js runtime itself — node skill's async/streams/modules sections.
+# check_method=manual because LTS status (not raw release recency) is what
+# matters for the version this skill recommends pinning, and nodejs.org's own
+# release table is the authoritative source for that, not the GitHub tag list.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["node"]
+name = "node"
+url = "https://nodejs.org/api/packages.html"
+releases_url = "https://nodejs.org/en/about/previous-releases"
+check_method = "manual"
+current_version = "24"
+version_constraint = "semver"
+last_checked = "2026-08-01"
+update_priority = "high"
+breaking_changes_likely = false
+notes = "current_version '24' (major only) is the Active LTS line ('Krypton') per nodejs.org/en/about/previous-releases, checked live 2026-08-01; exact patch not recorded since the skill recommends pinning the LTS major via mise, not a specific patch. Node 26 is the concurrent Current (non-LTS) release line as of the same check — not recommended in the skill for new projects. Stream types, backpressure, and package.json exports/imports semantics verified against nodejs.org/api/stream.html and nodejs.org/api/packages.html directly."
+
+# ----------------------------------------------------------------------------
+# pnpm — node skill's package-manager comparison section.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["node"]
+name = "pnpm"
+url = "https://pnpm.io/motivation"
+releases_url = "https://github.com/pnpm/pnpm/releases"
+check_method = "manual"
+current_version = "11.18.0"
+version_constraint = "semver"
+last_checked = "2026-08-01"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "current_version 11.18.0 from registry.npmjs.org/pnpm/latest, checked live 2026-08-01. pnpm.io/motivation itself only states 'versions 11 & 12' ambiguously as the current docs version, not a precise release — the npm registry figure is the one recorded here as it is unambiguous."
+
+# ----------------------------------------------------------------------------
+# Bun — node skill's package-manager/runtime comparison section. bun-types is
+# the npm package tracked since Bun itself does not publish to the npm
+# registry as an installable package (it ships via its own installer).
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["node"]
+name = "bun"
+url = "https://bun.sh/docs"
+releases_url = "https://github.com/oven-sh/bun/releases"
+check_method = "manual"
+current_version = "1.3.14"
+version_constraint = "semver"
+last_checked = "2026-08-01"
+update_priority = "low"
+breaking_changes_likely = true
+notes = "current_version 1.3.14 from registry.npmjs.org/bun-types/latest (the bun-types package version tracks the Bun runtime release it was generated from), checked live 2026-08-01, since Bun's own binary is not npm-distributed. Node-compatibility status is explicitly called out in the skill as needing a fresh check against bun.sh/docs/runtime/nodejs-compat rather than being asserted as complete."

--- a/plugins/languages/typescript/skills/sources.toml
+++ b/plugins/languages/typescript/skills/sources.toml
@@ -16,14 +16,14 @@ skills = ["language"]
 name = "typescript"
 url = "https://www.typescriptlang.org/docs/handbook/"
 releases_url = "https://github.com/microsoft/TypeScript/releases"
-check_method = "github-releases"
+check_method = "manual"
 github_repo = "microsoft/TypeScript"
 current_version = "7.0.2"
 version_constraint = "semver"
 last_checked = "2026-08-01"
 update_priority = "high"
 breaking_changes_likely = true
-notes = "current_version 7.0.2 is the npm registry 'latest' dist-tag (registry.npmjs.org/typescript/latest, checked live 2026-08-01). Two other live checks the same day disagreed: the typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html page describes a 5.9 release dated 2026-07-27, and github.com/microsoft/TypeScript/releases showed 6.0.3 as its top entry — GitHub's releases page returned partial-render errors on fetch, so that number may be stale/incomplete rather than authoritative. Skill content (generics, conditional types, mapped types, utility types, strict flags, modules) is grounded in the stable Handbook feature set that has not changed across these point releases, not in any single version's changelog — re-verify before adding a claim specific to TypeScript 6 or 7 (e.g. the native/Go compiler port) that this skill does not currently make."
+notes = "current_version 7.0.2 is the npm registry 'latest' dist-tag (registry.npmjs.org/typescript/latest, published 2026-07-08, checked live 2026-08-01). check_method is deliberately 'manual' rather than 'github-releases' despite github_repo being known: github.com/microsoft/TypeScript/releases tops out at 6.0.3, four months stale relative to the npm dist-tag, so an automated github-releases check against this repo would permanently report 'latest older than current' and be wrong every time — the npm registry is the correct authority for this package, GitHub's release feed is not kept current for it. A third live source, typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html, describes an even older 5.9 release dated 2026-07-27; also superseded by 7.0.2. Skill content (generics, conditional types, mapped types, utility types, strict flags, modules) is grounded in the stable Handbook feature set that has not changed across these point releases, not in any single version's changelog — re-verify before adding a claim specific to TypeScript 6 or 7 (e.g. the native/Go compiler port) that this skill does not currently make."
 
 # ----------------------------------------------------------------------------
 # Vitest — testing skill's primary unit-test runner section.

--- a/plugins/languages/typescript/skills/testing/SKILL.md
+++ b/plugins/languages/typescript/skills/testing/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: testing
+description: Guide for testing TypeScript projects with Vitest, Jest, and Playwright. Use when writing unit tests, mocking modules or timers, asserting types at compile time, running end-to-end browser tests, configuring coverage thresholds, or wiring test tasks into CI.
+license: MIT
+---
+
+# TypeScript Testing
+
+Vitest and Jest for unit/integration tests, Playwright for end-to-end, type-level testing, coverage, and CI wiring.
+
+## When to Use This Skill
+
+Activate when:
+- Choosing or configuring a unit test runner (Vitest or Jest) for a TypeScript project
+- Mocking modules, timers, or globals in a test
+- Asserting that a type is exactly what's expected, at compile time rather than runtime
+- Writing or running Playwright end-to-end browser tests
+- Setting coverage thresholds or wiring `test`/`coverage` into `mise run ci`
+- Debugging a flaky or slow TypeScript test suite
+
+## Choosing Vitest vs Jest
+
+Both are viable; the deciding factor is the rest of the toolchain, not raw feature count.
+
+- **Vitest** reads the project's existing Vite config and reuses its transform pipeline, so a Vite-based app (React/Vue/Svelte via Vite, or a Vite-built library) gets test config for near-free. Vitest requires Vite ≥6 and Node ≥20. Its API is Jest-compatible (`describe`/`test`/`expect`/`vi.fn()`), so migrating an existing Jest suite is mostly a find-and-replace of the mock namespace.
+- **Jest** is the default for a project with no Vite in its pipeline — plain Node libraries, Next.js (which documents first-class Jest support), or a codebase already standardized on Jest tooling (snapshot serializers, custom matchers written against Jest's APIs). TypeScript support comes via `ts-jest` (type-checks as part of the test run) or Babel (transpile-only, faster, no type errors caught).
+
+Restraint applies here directly: don't add Vitest to a project that already has a working Jest suite just because Vitest is newer, and don't bolt Jest onto a Vite app that would get Vitest for free.
+
+## Vitest
+
+### Setup
+
+```bash
+npm install -D vitest
+```
+
+No separate config file is required — Vitest reads `vite.config.ts` by default. Add a dedicated `vitest.config.ts` only when test-specific settings (environment, coverage thresholds, setup files) would otherwise clutter the Vite config:
+
+```typescript
+// vitest.config.ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",       // or "jsdom" / "happy-dom" for DOM tests
+    globals: false,            // false = import describe/test/expect explicitly (recommended)
+    coverage: {
+      provider: "v8",
+      thresholds: { lines: 80, functions: 80, branches: 75, statements: 80 },
+    },
+  },
+});
+```
+
+Leaving `globals: false` and importing `describe`/`test`/`expect`/`vi` explicitly from `"vitest"` keeps test files free of ambient globals — the same reasoning as avoiding `any`: an explicit import is a grep target and a type-checked one.
+
+### Assertions and structure
+
+```typescript
+import { describe, test, expect } from "vitest";
+import { add } from "./math.js";
+
+describe("add", () => {
+  test("adds two positive numbers", () => {
+    expect(add(2, 3)).toBe(5);
+  });
+
+  test("adds negative numbers", () => {
+    expect(add(-1, -1)).toBe(-2);
+  });
+});
+```
+
+### Mocking
+
+```typescript
+import { vi, expect, test } from "vitest";
+import { fetchUser } from "./api.js";
+
+vi.mock("./api.js", () => ({
+  fetchUser: vi.fn().mockResolvedValue({ id: 1, name: "Ada" }),
+}));
+
+test("uses the mocked fetch", async () => {
+  const user = await fetchUser(1);
+  expect(user.name).toBe("Ada");
+});
+```
+
+`vi.fn()` creates a spy/mock function; `vi.mock(path, factory)` replaces a module's exports for the whole file. `vi.useFakeTimers()` / `vi.advanceTimersByTime(ms)` control time for code under test that uses `setTimeout`/`setInterval` — mock the boundary (the module doing I/O or the clock), never the function under test itself, matching the `/core:agent-loop` mock-external-boundaries convention this workspace uses across languages.
+
+## Jest
+
+### Setup
+
+```bash
+npm install -D jest ts-jest @types/jest
+npx ts-jest config:init
+```
+
+`ts-jest` type-checks test files as part of the run — a type error in a test fails the test run, not just `tsc`. The Babel path (`babel-jest` + `@babel/preset-typescript`) is faster because it strips types without checking them; pick it only when a separate `tsc --noEmit` step in CI already covers type-checking, so Babel isn't silently letting a type error through untested.
+
+### Basic test
+
+```typescript
+// math.test.ts
+import { add } from "./math";
+
+test("adds 1 + 2 to equal 3", () => {
+  expect(add(1, 2)).toBe(3);
+});
+```
+
+### Mocking modules
+
+```typescript
+import { fetchUser } from "./api";
+
+jest.mock("./api");
+const mockFetchUser = fetchUser as jest.MockedFunction<typeof fetchUser>;
+
+test("uses the mocked fetch", async () => {
+  mockFetchUser.mockResolvedValue({ id: 1, name: "Ada" });
+  const user = await fetchUser(1);
+  expect(user.name).toBe("Ada");
+});
+```
+
+The `as jest.MockedFunction<typeof fetchUser>` cast is the standard Jest+TypeScript pattern for getting mock-specific methods (`mockResolvedValue`, `mockReturnValueOnce`) on a function whose static type is the real implementation's signature.
+
+## Type-Level Testing
+
+A test suite that only exercises runtime behavior can still ship a type regression — a generic that silently widens to `any`, an overload that resolves to the wrong branch. Two focused tools assert on the *type*, not the value:
+
+- **`expect-type`** — runtime-free type assertions inside a normal test file, checked by `tsc`, not executed:
+
+  ```typescript
+  import { expectTypeOf } from "expect-type";
+
+  expectTypeOf(add(1, 2)).toEqualTypeOf<number>();
+  expectTypeOf<Partial<{ a: number }>>().toEqualTypeOf<{ a?: number }>();
+  ```
+
+  These assertions run as part of a normal `vitest`/`tsc` pass — no separate command. Vitest also ships an `expectTypeOf` re-export built on the same library.
+
+- **`tsd`** — a standalone CLI that type-checks `.test-d.ts` files against `.d.ts` output, aimed at library authors verifying their *published* declaration file, not internal application types:
+
+  ```typescript
+  // index.test-d.ts
+  import { expectType } from "tsd";
+  import { add } from "./index.js";
+
+  expectType<number>(add(1, 2));
+  ```
+
+  Run via `npx tsd`. Reach for `tsd` specifically when the thing under test is a package's public `.d.ts`, not its implementation — `expect-type` inside the normal suite covers everything else.
+
+## Playwright (End-to-End)
+
+### Setup
+
+```bash
+npm init playwright@latest
+```
+
+Interactive: choose TypeScript, the test directory (default `tests/` or `e2e/`), whether to add a GitHub Actions workflow, and which browsers to install. Produces `playwright.config.ts`.
+
+### Running tests
+
+```bash
+npx playwright test                # headless, parallel across configured browsers
+npx playwright test --headed       # watch the browser
+npx playwright test --project=chromium
+npx playwright test --ui           # interactive UI mode with time-travel debugging
+npx playwright show-report         # HTML report from the last run
+```
+
+### Example test
+
+```typescript
+import { test, expect } from "@playwright/test";
+
+test("home page has expected heading", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Welcome" })).toBeVisible();
+});
+```
+
+Playwright tests run against a real browser engine (Chromium/Firefox/WebKit) — treat them as the outermost layer of the test pyramid (`/core:tdd` "Ice Cream Cone" anti-pattern applies directly): cover behavior with fast Vitest/Jest unit tests first, and reserve Playwright for flows that only a real browser can verify (navigation, layout, cross-tab behavior).
+
+## Coverage and CI Integration
+
+```json
+// package.json
+{
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test"
+  }
+}
+```
+
+```toml
+# mise.toml
+[tasks.test]
+description = "Run unit tests"
+run = "npm run test"
+
+[tasks."test:coverage"]
+description = "Run unit tests with coverage"
+run = "npm run test:coverage"
+
+[tasks.ci]
+description = "Full CI gate"
+depends = ["lint", "test", "test:coverage"]
+```
+
+Fail CI on a coverage threshold drop, not just on a red test — set `coverage.thresholds` in `vitest.config.ts` (see the Vitest section above) so a PR that adds code without tests fails the same gate a red test would, consistent with `/core:tdd` "code without tests is not complete."
+
+## Anti-fabrication
+
+This skill follows `/core:anti-fabrication`. Package names, CLI commands, and config shapes were verified against each tool's own documentation (vitest.dev, jestjs.io, playwright.dev) and the npm registry for version numbers — see `sources.md` for exact pages and access dates. `expect-type` and `tsd` API surfaces shown here are the documented public entry points (`expectTypeOf`, `expectType`); verify against the installed package version before relying on a less common assertion method not shown here.
+
+## References
+
+- `references/mocking-patterns.md` — timer mocking, partial module mocks, and spying on object methods in both Vitest and Jest

--- a/plugins/languages/typescript/skills/testing/references/mocking-patterns.md
+++ b/plugins/languages/typescript/skills/testing/references/mocking-patterns.md
@@ -1,0 +1,119 @@
+# Mocking Patterns: Vitest and Jest
+
+Patterns beyond the basics in the main skill body: timer mocking, partial module mocks, and spying on existing object methods. Both runners expose a Jest-compatible mock API, so the shapes below differ mainly in namespace (`vi.*` vs `jest.*`).
+
+## Timer Mocking
+
+Code that calls `setTimeout`/`setInterval`/`Date.now()` needs fake timers so the test doesn't actually wait — mock the clock, never restructure the code under test just to make it testable.
+
+### Vitest
+
+```typescript
+import { vi, test, expect, beforeEach, afterEach } from "vitest";
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+test("debounced function fires once after the delay", () => {
+  const fn = vi.fn();
+  const debounced = debounce(fn, 200);
+
+  debounced();
+  debounced();
+  vi.advanceTimersByTime(200);
+
+  expect(fn).toHaveBeenCalledTimes(1);
+});
+```
+
+### Jest
+
+```typescript
+beforeEach(() => jest.useFakeTimers());
+afterEach(() => jest.useRealTimers());
+
+test("debounced function fires once after the delay", () => {
+  const fn = jest.fn();
+  const debounced = debounce(fn, 200);
+
+  debounced();
+  debounced();
+  jest.advanceTimersByTime(200);
+
+  expect(fn).toHaveBeenCalledTimes(1);
+});
+```
+
+Always pair `useFakeTimers()` with `useRealTimers()` in `afterEach` — an un-restored fake timer leaks into the next test file's real-timer expectations, the same class of test-isolation bug `/core:tdd`'s isolation guidance and this workspace's binding test-isolation rules call out for other kinds of global state.
+
+## Partial Module Mocks
+
+Mocking an entire module is sometimes too broad — a module might export five functions and only one needs a fake implementation, with the rest expected to run for real.
+
+### Vitest
+
+```typescript
+import { vi, test, expect } from "vitest";
+
+vi.mock("./api.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./api.js")>();
+  return {
+    ...actual,
+    fetchUser: vi.fn().mockResolvedValue({ id: 1, name: "Ada" }),
+  };
+});
+```
+
+`importOriginal()` returns the real module so everything not explicitly overridden keeps its real implementation — the standard shape for "mock this one boundary call, leave the rest of the module alone."
+
+### Jest
+
+```typescript
+jest.mock("./api", () => ({
+  ...jest.requireActual("./api"),
+  fetchUser: jest.fn().mockResolvedValue({ id: 1, name: "Ada" }),
+}));
+```
+
+`jest.requireActual` is the Jest equivalent of Vitest's `importOriginal`.
+
+## Spying on Existing Methods
+
+Spying replaces one method on a real object while leaving the object's other behavior untouched — useful for asserting a method was called without replacing the whole collaborator.
+
+### Vitest
+
+```typescript
+import { vi, test, expect } from "vitest";
+import * as logger from "./logger.js";
+
+test("logs an error on failure", () => {
+  const spy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+  runRiskyOperation();
+
+  expect(spy).toHaveBeenCalledWith(expect.stringContaining("failed"));
+  spy.mockRestore();
+});
+```
+
+### Jest
+
+```typescript
+import * as logger from "./logger";
+
+test("logs an error on failure", () => {
+  const spy = jest.spyOn(logger, "error").mockImplementation(() => {});
+
+  runRiskyOperation();
+
+  expect(spy).toHaveBeenCalledWith(expect.stringContaining("failed"));
+  spy.mockRestore();
+});
+```
+
+Call `.mockRestore()` (or configure `restoreMocks: true` in the runner config so it happens automatically between tests) — an un-restored spy is the same isolation hazard as an un-restored fake timer: it silently changes behavior for every test that runs after it in the same file.
+
+## Mock Boundary Discipline
+
+Both runners make it just as easy to mock an internal module as an external one — the API doesn't distinguish. The discipline that keeps tests meaningful is the same one this workspace applies across languages (`/core:agent-loop` mock-external-boundaries convention): mock HTTP calls, the filesystem, the system clock, and third-party SDKs; let internal modules run for real against their actual implementation. A test that mocks a module in the same package it's testing is usually testing the mock, not the code.


### PR DESCRIPTION
- Add `typescript` language plugin with four skills: `language` (strict mode, type system, utility types, declaration files, discriminated unions), `testing` (Vitest, Jest, Playwright, type-level testing), `linting` (ESLint + typescript-eslint, Biome, Prettier integration), `node` (async patterns, streams, ESM/CJS, package managers)
- Add `sources.toml`/`sources.md` with 14 tracked upstream sources, versions verified live against each tool's own docs and the npm registry on 2026-08-01
- Register the plugin in `.claude-plugin/marketplace.json` (category: language) and sync `all-skills` meta-plugin via `mise update-all-skills`
