### PR TITLE
docs(claude-code): settle CLAUDE_PLUGIN_ROOT body notation to angle brackets

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.108",
+      "version": "0.4.109",
       "category": "meta",
       "keywords": [
         "skills",
@@ -119,7 +119,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
-      "version": "0.2.51",
+      "version": "0.2.52",
       "category": "tools",
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.108",
+  "version": "0.4.109",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.51",
+  "version": "0.2.52",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/claude-plugins/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-plugins/SKILL.md
@@ -80,14 +80,14 @@ Both `hooks` and `mcpServers` accept either a path or an inline object. Inline, 
 {
   "hooks": {
     "PostToolUse": [
-      { "matcher": "Write|Edit", "hooks": [{ "type": "command", "command": "CLAUDE_PLUGIN_ROOT/scripts/format.sh" }] }
+      { "matcher": "Write|Edit", "hooks": [{ "type": "command", "command": "<CLAUDE_PLUGIN_ROOT>/scripts/format.sh" }] }
     ]
   },
   "mcpServers": { "filesystem": { "command": "mcp-server-filesystem", "args": ["./workspace"] } }
 }
 ```
 
-`CLAUDE_PLUGIN_ROOT` is written bare above, but a real hooks value wraps it as a **quoted brace expansion** — the harness expands it at hook runtime, which is correct in a JSON config. It is shown bare here because the braced form expands when *this skill* loads, replacing it with one machine's absolute path before any reader sees it. That is the same reason script commands on this page use `CLAUDE_SKILL_DIR` bare. For the copyable braced form, see `/claude-code:claude-hooks`, whose reference files are read as raw bytes and can carry it safely.
+`CLAUDE_PLUGIN_ROOT` is written in angle brackets above, but a real hooks value wraps it as a **quoted brace expansion** — the harness expands it at hook runtime, which is correct in a JSON config. It is shown angle-bracketed here, not braced, because the braced form expands when *this skill* loads, replacing it with one machine's absolute path before any reader sees it — the same reason script commands on this page use `<CLAUDE_SKILL_DIR>` angle-bracketed rather than braced (see `/claude-code:claude-skills` "Dynamic context and substitutions" for the full notation convention). For the copyable braced form, see `/claude-code:claude-hooks`, whose reference files are read as raw bytes and can carry it safely.
 
 ## Fields that must NOT appear in plugin.json
 

--- a/plugins/tools/claude-code/skills/claude-skills/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-skills/SKILL.md
@@ -118,8 +118,15 @@ Fencing does not protect this example — nesting it inside a five-backtick oute
 - `CLAUDE_SESSION_ID` — current session ID
 - `CLAUDE_EFFORT` — current effort level
 - `CLAUDE_SKILL_DIR` — absolute path to this skill's directory (use for bundled scripts: `bash <CLAUDE_SKILL_DIR>/scripts/foo.sh`)
+- `CLAUDE_PLUGIN_ROOT` — absolute path to the enclosing plugin's root directory (use for scripts shared across a plugin's skills: `bash <CLAUDE_PLUGIN_ROOT>/scripts/foo.sh`)
 
-The three `CLAUDE_*` names are written bare because they are used as brace expansions in real files and **the leading-backslash escape does not work on the braced form** — verified by loading: the backslash survives and the token still expands, printing the live session ID and paths. See `/claude-code:claude-commands` "Argument Substitution" for the full rule.
+The four `CLAUDE_*` names are written bare because they are used as brace expansions in real files and **the leading-backslash escape does not work on the braced form** — verified by loading: the backslash survives and the token still expands, printing the live session ID and paths. See `/claude-code:claude-commands` "Argument Substitution" for the full rule.
+
+**Settled notation for `CLAUDE_SKILL_DIR` and `CLAUDE_PLUGIN_ROOT` in bodies (claude-skills-206):** three distinct forms, three distinct roles — never interchange them within a SKILL.md or commands/*.md body.
+
+- **Bare name** (`CLAUDE_SKILL_DIR`, `CLAUDE_PLUGIN_ROOT`) — naming or defining the variable itself in prose, e.g. a definition-list entry ("`CLAUDE_SKILL_DIR` — absolute path to..."). Never expands; safe anywhere.
+- **Angle brackets** (`<CLAUDE_SKILL_DIR>`, `<CLAUDE_PLUGIN_ROOT>`) — showing the variable embedded in a literal, copyable command or path, e.g. `` nu <CLAUDE_SKILL_DIR>/scripts/foo.nu ``. This is the form to use whenever the variable appears as part of runnable syntax rather than as its own subject.
+- **Braced** — a dollar sign, opening curly brace, the variable name, and a closing curly brace: the real, functioning expansion syntax. Safe in YAML frontmatter, `references/`, `templates/`, and standalone `hooks.json`/`.mcp.json` files — anywhere that is not the live-loading body itself. Deliberately not shown literally in this paragraph, for the same reason: writing it here would expand it before any reader sees it. That is also why the braced form is never written directly in a SKILL.md or commands/*.md body — it would substitute one machine's absolute path at load time.
 
 Disable shell injection across user/project/plugin skills via `"disableSkillShellExecution": true` in settings — useful for managed environments.
 


### PR DESCRIPTION
- Document a three-tier `CLAUDE_SKILL_DIR`/`CLAUDE_PLUGIN_ROOT` body notation in the claude-skills skill: bare name for naming the variable, angle brackets for embedded usage syntax, braced for real functioning expansion (frontmatter/references/templates/hooks.json only)
- Fix the one genuine notation conflict found: `claude-plugins/SKILL.md`'s JSON usage-example converted from fully-bare to angle-bracketed, matching the already-established `CLAUDE_SKILL_DIR` convention on the same page
- Correct an adjacent factual error: the same paragraph claimed `CLAUDE_SKILL_DIR` is used "bare" on that page, when its own script-invocation lines already use the angle-bracket form
- No changes to agent-sandboxing — investigation confirmed its 14 `<CLAUDE_PLUGIN_ROOT>` occurrences already match the settled convention
- Verified by loading (not by reading source): built two throwaway isolated plugins via `claude --plugin-dir`, loaded each edited skill, and confirmed the body arrives byte-identical with no unexpected expansion
