### PR TITLE
fix(claude-code): recognize dependencies as valid plugin.json field, warn on unknown fields

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.112",
+      "version": "0.4.113",
       "category": "meta",
       "keywords": [
         "skills",
@@ -119,7 +119,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
-      "version": "0.2.54",
+      "version": "0.2.55",
       "category": "tools",
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.112",
+  "version": "0.4.113",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/mise.toml
+++ b/mise.toml
@@ -166,10 +166,12 @@ description = "Validate all plugin.json files (local and external)"
 run = """
 #!/usr/bin/env nu
 
+let repo_root = (git rev-parse --show-toplevel | str trim)
+nu ($repo_root | path join "plugins" "tools" "claude-code" "skills" "claude-plugins" "scripts" "validate-plugin.nu") --self-test
+
 print "🔍 Validating all plugins..."
 print ""
 
-let repo_root = (git rev-parse --show-toplevel | str trim)
 let marketplace = (open ($repo_root | path join ".claude-plugin" "marketplace.json"))
 
 mut all_passed = true

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.54",
+  "version": "0.2.55",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/claude-plugins/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-plugins/SKILL.md
@@ -50,12 +50,32 @@ Relative to the plugin root, `./`-prefixed. Each has a dedicated skill for its o
 - `skills` — array of directories, each containing a `SKILL.md` (see `claude-skills`)
 - `commands` — string or array of `.md` files or directories (see `claude-commands`)
 - `agents` — string directory or array of files (see `claude-agents`)
+- `workflows` — string or array of workflow script files or directories, replacing the default `workflows/` scan
 - `hooks` — string path to a hooks.json, or an inline hooks object (see `claude-hooks`)
 - `mcpServers` — string path to an MCP config, or an inline object
 - `outputStyles` — string or array of output-style files/directories, replacing the default `output-styles/` scan (see `claude-output-styles`)
 - `lspServers` — string, array, or inline object of LSP (Language Server Protocol) configs for code intelligence (go-to-definition, find-references). Defaults to a `.lsp.json` file at the plugin root when the field is absent.
 
 `output-styles/` is discovered by convention when `outputStyles` is unset; setting the field replaces that default scan rather than adding to it (see `claude-output-styles`).
+
+### Metadata and dependency fields
+
+- `displayName` — human-readable name shown in the `/plugin` picker and other UI surfaces. Falls back to `name` when omitted. Unlike `name`, may contain spaces and any casing; not used for namespacing or lookup.
+- `defaultEnabled` — boolean, whether the plugin starts enabled when the user has not set a preference. Defaults to `true`. Set `false` to ship a plugin that installs disabled (e.g. one that adds cost or connects to an external service) until the user opts in with `claude plugin enable <plugin>`.
+- `userConfig` — object declaring values Claude Code prompts the user for at enable time (`type`, `title`, `description` required per key; `sensitive`, `required`, `default`, `multiple`, `min`/`max` optional). Substituted as `${user_config.KEY}` in MCP/LSP configs and hook commands.
+- `channels` — array of message-channel declarations (Telegram/Slack/Discord-style injection). Each entry's `server` field must match a key in the plugin's `mcpServers`.
+- `dependencies` — array of other plugins this plugin requires. Each entry is either a bare plugin-name string, or an object with a required `name` and optional semver `version` constraint:
+
+```json
+{
+  "dependencies": [
+    "helper-lib",
+    { "name": "secrets-vault", "version": "~2.1.0" }
+  ]
+}
+```
+
+This is a **plugin.json field**, not a marketplace-only one — do not confuse it with `category`/`strict`/`source`/`tags` below, which upstream documents as marketplace-entry-specific and which this manifest schema does not include. (`dependencies` may also be echoed inside a marketplace entry, since a marketplace entry can carry any field from the plugin manifest schema — but its home is plugin.json.)
 
 ### `experimental` field
 
@@ -72,7 +92,7 @@ Relative to the plugin root, `./`-prefixed. Each has a dedicated skill for its o
 }
 ```
 
-Verified against `validate-plugin.nu`'s fixed `invalid_fields` denylist (`dependencies`, `category`, `strict`, `source`, `tags`): none of these three fields are on it, and a fixture plugin.json carrying all three passes validation with zero errors and zero warnings.
+Verified against `validate-plugin.nu`'s `invalid_fields` denylist (`category`, `strict`, `source`, `tags`): none of these three fields, nor `dependencies`/`displayName`/`defaultEnabled`/`workflows`/`userConfig`/`channels`, are on it, and a fixture plugin.json carrying all of them passes validation with zero errors and zero warnings (`nu <CLAUDE_SKILL_DIR>/scripts/validate-plugin.nu --self-test`).
 
 Both `hooks` and `mcpServers` accept either a path or an inline object. Inline, they use each component's own schema — hooks are **event-keyed**, not lifecycle-keyed:
 
@@ -91,13 +111,18 @@ Both `hooks` and `mcpServers` accept either a path or an inline object. Inline, 
 
 ## Fields that must NOT appear in plugin.json
 
-The validator rejects these with `Invalid field '<field>' - this belongs in marketplace.json, not plugin.json`:
+The validator rejects these with `Invalid field '<field>' - this belongs in marketplace.json, not plugin.json`. Upstream's marketplace-entries schema documents them as marketplace-specific fields, distinct from the plugin manifest schema (see `plugin-marketplace`):
 
-- `dependencies` — dependencies belong to marketplace entries, not manifests
 - `category` — marketplace-level metadata
 - `strict` — controls marketplace behavior, not the plugin definition
 - `source` — a plugin's location is declared by the marketplace, not by itself
 - `tags` — use `keywords`
+
+`dependencies` is NOT on this list — see "Metadata and dependency fields" above. It is a documented plugin.json field, not marketplace-only.
+
+### Unrecognized fields warn, not fail
+
+Any other top-level field the validator doesn't recognize produces a **warning** (`Unrecognized field '<field>' - not a known plugin.json field`), never a hard failure — matching upstream's own `claude plugin validate`, which treats unrecognized fields as warnings so a manifest can double as another tool's config (an npm `package.json`, a VS Code extension manifest) without breaking. A typo'd field name is now visible instead of silently passing.
 
 ## Validation
 
@@ -106,9 +131,10 @@ Scripts are bundled with this skill, under its own directory:
 ```bash
 nu <CLAUDE_SKILL_DIR>/scripts/validate-plugin.nu .claude-plugin/plugin.json
 nu <CLAUDE_SKILL_DIR>/scripts/init-plugin.nu
+nu <CLAUDE_SKILL_DIR>/scripts/validate-plugin.nu --self-test   # fixture suite for the validator itself
 ```
 
-`validate-plugin.nu` checks JSON syntax, `name` presence and casing, field types, path accessibility, and invalid-field detection. Add `--verbose` for per-field output.
+`validate-plugin.nu` checks JSON syntax, `name` presence and casing, field types, path accessibility, `dependencies` shape, and invalid-field detection, plus a warn-on-unrecognized-field pass. Add `--verbose` for per-field output.
 
 With `--marketplace`, it also checks that `description` and `keywords` agree with the plugin's marketplace entry, when that entry's `source` is a local path. **`plugin.json` is authoritative.** Entries whose `source` is a GitHub object are skipped — there is no local manifest to compare. When plugin.json defines a field, the marketplace entry must carry it too: an entry that omits `description` or `keywords` while plugin.json defines them is flagged as missing, not treated as agreement (`marketplace.json entry is missing '<field>' that plugin.json defines`). A field plugin.json itself omits is not compared at all. `keywords` compares as a sorted list, so reordering the array alone is not a mismatch — only a genuine difference in members is.
 

--- a/plugins/tools/claude-code/skills/claude-plugins/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-plugins/SKILL.md
@@ -92,7 +92,7 @@ This is a **plugin.json field**, not a marketplace-only one — do not confuse i
 }
 ```
 
-Verified against `validate-plugin.nu`'s `invalid_fields` denylist (`category`, `strict`, `source`, `tags`): none of these three fields, nor `dependencies`/`displayName`/`defaultEnabled`/`workflows`/`userConfig`/`channels`, are on it, and a fixture plugin.json carrying all of them passes validation with zero errors and zero warnings (`nu <CLAUDE_SKILL_DIR>/scripts/validate-plugin.nu --self-test`).
+Verified against `validate-plugin.nu`'s `invalid_fields` denylist (`category`, `strict`, `source`, `tags`): none of `outputStyles`/`lspServers`/`experimental`, nor `dependencies`/`displayName`/`defaultEnabled`/`workflows`/`userConfig`/`channels`, are on it. The `complete_manifest_all_documented_fields_recognized` case in `scripts/validate-plugin.nu`'s `--self-test` suite carries all nine fields in one fixture manifest and asserts it passes with zero errors and zero warnings (`nu <CLAUDE_SKILL_DIR>/scripts/validate-plugin.nu --self-test`).
 
 Both `hooks` and `mcpServers` accept either a path or an inline object. Inline, they use each component's own schema — hooks are **event-keyed**, not lifecycle-keyed:
 

--- a/plugins/tools/claude-code/skills/claude-plugins/references/plugin-schema.md
+++ b/plugins/tools/claude-code/skills/claude-plugins/references/plugin-schema.md
@@ -135,15 +135,27 @@ Complete JSON schema for Claude Code plugin.json files.
 }
 ```
 
+## Fields not covered above
+
+These plugin.json fields exist but aren't part of the minimal schema block at the top of this file — see the `claude-plugins` SKILL.md "Metadata and dependency fields" section for full detail:
+
+- `dependencies`: array of required plugins — bare name strings and/or `{name, version}` objects with an optional semver constraint. This is a valid, documented plugin.json field, NOT marketplace-only.
+- `displayName`: human-readable name for UI surfaces, falls back to `name`
+- `defaultEnabled`: boolean, whether the plugin installs enabled (default `true`)
+- `workflows`: string or array of workflow script paths, replaces default `workflows/` scan
+- `userConfig`: object declaring enable-time user-prompted values
+- `channels`: array of message-channel declarations bound to an MCP server
+
 ## Invalid Fields
 
-These fields are **NOT valid** in plugin.json (they belong in marketplace.json):
+These fields are **NOT valid** in plugin.json (they are marketplace-entry-specific, per the marketplace-entries schema — see `plugin-marketplace`):
 
-- `dependencies`: Plugin dependencies (marketplace-level)
 - `category`: Plugin categorization (marketplace-level)
 - `strict`: Strict mode control (marketplace-level)
 - `source`: Plugin source location (marketplace-level)
 - `tags`: Use `keywords` instead
+
+Any other unrecognized top-level field produces a validator **warning**, not an error — it may be intentional metadata for another tool sharing the same manifest file.
 
 ## Validation Rules
 
@@ -201,7 +213,7 @@ These fields are **NOT valid** in plugin.json (they belong in marketplace.json):
 - [ ] `name` field is present
 - [ ] `name` is kebab-case
 - [ ] `version` uses semantic versioning (if present)
-- [ ] No invalid fields (dependencies, category, strict, source, tags)
+- [ ] No invalid fields (category, strict, source, tags)
 - [ ] All skill paths exist and contain SKILL.md
 - [ ] All command paths exist
 - [ ] All agent paths exist

--- a/plugins/tools/claude-code/skills/claude-plugins/references/validation-and-troubleshooting.md
+++ b/plugins/tools/claude-code/skills/claude-plugins/references/validation-and-troubleshooting.md
@@ -21,15 +21,30 @@ message apply to marketplace names, via the `plugin-marketplace` skill.
 
 ### Error — `Invalid field '<field>' - this belongs in marketplace.json, not plugin.json`
 
-Raised for `dependencies`, `category`, `strict`, `source`, and `tags`. The skill body lists why each
-one is marketplace-level.
+Raised for `category`, `strict`, `source`, and `tags`. The skill body lists why each one is
+marketplace-level. `dependencies` is NOT one of these — it's a valid plugin.json field (see the
+skill body's "Metadata and dependency fields" section); claude-skills-218 removed it from this
+error after confirming against upstream that plugin.json documents it directly.
 
 ```json
 // Invalid
-{ "name": "my-plugin", "dependencies": ["other-plugin"] }
+{ "name": "my-plugin", "category": "productivity" }
 
 // Valid
 { "name": "my-plugin", "keywords": ["tool", "utility"] }
+{ "name": "my-plugin", "dependencies": ["other-plugin", { "name": "secrets-vault", "version": "~2.1.0" }] }
+```
+
+### Warning — `Unrecognized field '<field>' - not a known plugin.json field`
+
+Any top-level field that is neither a known plugin.json field nor one of the four marketplace-only
+fields above produces this warning (claude-skills-219) — never a hard failure, so a manifest that
+doubles as another tool's config (npm's `package.json`, a VS Code extension manifest) still passes.
+Treat it as a nudge to check for a typo, not proof the field is wrong.
+
+```json
+// Warns: "Unrecognized field 'dependancies' - not a known plugin.json field ..."
+{ "name": "my-plugin", "dependancies": ["other-plugin"] }
 ```
 
 ### Error — skill path missing or has no SKILL.md

--- a/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
+++ b/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
@@ -753,9 +753,9 @@ def self-test [] {
       expect_warnings: 1
     }
     {
-      name: "five_newly_documented_fields_recognized"
-      why: "claude-skills-218 — displayName, defaultEnabled, workflows, userConfig, channels are real plugin.json fields and must not warn as unrecognized"
-      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", displayName: "My Plugin", defaultEnabled: false, workflows: "./workflows/", userConfig: {}, channels: [] }
+      name: "complete_manifest_all_documented_fields_recognized"
+      why: "claude-skills-218 — every field this skill documents as valid (the pre-existing outputStyles/lspServers/experimental trio from PR 205, plus dependencies and the 5 newly-documented fields) must coexist in one manifest with zero errors and zero warnings. This is the fixture the SKILL.md 'Verified against...' sentence cites — keep the two in sync"
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", outputStyles: "./styles/", lspServers: "./.lsp.json", experimental: { themes: "./themes/", monitors: "./monitors.json" }, dependencies: ["helper-lib"], displayName: "My Plugin", defaultEnabled: false, workflows: "./workflows/", userConfig: {}, channels: [] }
       expect_errors: 0
       expect_warnings: 0
     }

--- a/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
+++ b/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
@@ -11,10 +11,21 @@
 #   Marketplace: Validate a plugin by name from marketplace (supports external plugins)
 
 def main [
-  target: string              # Path to plugin.json OR plugin name (when using --marketplace)
+  target?: string              # Path to plugin.json OR plugin name (when using --marketplace)
   --marketplace: string       # Path to marketplace.json (enables name-based lookup)
   --verbose                   # Show detailed validation output
+  --self-test                 # Run the fixture-based self-test suite and exit
 ] {
+  if $self_test {
+    self-test
+    return
+  }
+
+  if ($target | is-empty) {
+    print $"(ansi red_bold)Error:(ansi reset) target is required unless --self-test is passed"
+    exit 1
+  }
+
   # Determine mode based on --marketplace flag
   if ($marketplace | is-not-empty) {
     validate-from-marketplace $target $marketplace $verbose
@@ -205,7 +216,7 @@ def validate-plugin-content [
     open $plugin_path
   } catch {
     print $"(ansi red_bold)Error:(ansi reset) Failed to parse plugin.json"
-    return { success: false }
+    return { success: false, errors: ["Failed to parse plugin.json"], warnings: [] }
   }
 
   mut errors = []
@@ -232,9 +243,15 @@ def validate-plugin-content [
     }
   }
 
-  # Check for invalid fields (marketplace-only)
+  # Check for invalid fields (marketplace-entry-only — confirmed against
+  # upstream's marketplace-entries schema, which lists these as
+  # "marketplace-specific fields" distinct from the plugin manifest schema:
+  # https://code.claude.com/docs/en/plugin-marketplaces#plugin-entries).
+  # `dependencies` was removed from this list (claude-skills-218) — upstream
+  # documents it as a valid plugin.json field (array of plugin names and/or
+  # {name, version} objects): https://code.claude.com/docs/en/plugins-reference#plugin-manifest-schema
   print $"\n(ansi cyan)Checking for invalid fields...(ansi reset)"
-  let invalid_fields = ["dependencies", "category", "strict", "source", "tags"]
+  let invalid_fields = ["category", "strict", "source", "tags"]
   for field in $invalid_fields {
     if ($plugin | get -o $field) != null {
       $errors = ($errors | append $"Invalid field '($field)' - this belongs in marketplace.json, not plugin.json")
@@ -243,6 +260,55 @@ def validate-plugin-content [
 
   if $verbose {
     print "  ✓ No invalid fields found"
+  }
+
+  # Warn (never hard-fail) on any top-level field this validator doesn't
+  # recognize (claude-skills-219). Upstream's own `claude plugin validate`
+  # treats unrecognized fields as warnings, not errors, specifically so a
+  # manifest can double as another tool's manifest (npm package.json, a VS
+  # Code extension manifest) without failing:
+  # https://code.claude.com/docs/en/plugins-reference#unrecognized-fields
+  # This list is every field currently documented for plugin.json — keep it
+  # in sync with the field tables in SKILL.md when upstream adds one.
+  let known_fields = [
+    "name", "$schema", "displayName", "version", "description", "author",
+    "homepage", "repository", "license", "keywords", "defaultEnabled",
+    "skills", "commands", "agents", "workflows", "hooks", "mcpServers",
+    "outputStyles", "lspServers", "experimental", "userConfig", "channels",
+    "dependencies"
+  ]
+  for field in ($plugin | columns) {
+    if ($field not-in $known_fields) and ($field not-in $invalid_fields) {
+      $warnings = ($warnings | append $"Unrecognized field '($field)' - not a known plugin.json field \(see the claude-plugins skill for the current schema; may be intentional metadata for another tool\)")
+    }
+  }
+
+  # Validate `dependencies` shape: an array of plugin names (string) and/or
+  # {name, version} objects, per upstream's example
+  # `["helper-lib", { "name": "secrets-vault", "version": "~2.1.0" }]`.
+  if ($plugin | get -o dependencies) != null {
+    let deps_type = ($plugin.dependencies | describe)
+    # A homogeneous array of records/objects (e.g. every dependency entry
+    # using the {name, version} shape) describes as "table<...>" in
+    # nushell, not "list<...>" — a plain array of strings describes as
+    # "list<string>". Accept both; a genuinely non-array value (string,
+    # record, etc.) matches neither prefix.
+    if not (($deps_type | str starts-with "list") or ($deps_type | str starts-with "table")) {
+      $errors = ($errors | append $"'dependencies' must be an array, got ($deps_type)")
+    } else {
+      for dep in $plugin.dependencies {
+        let dep_type = ($dep | describe)
+        if $dep_type == "string" {
+          # valid: bare plugin name
+        } else if ($dep_type | str starts-with "record") {
+          if ($dep | get -o name) == null {
+            $errors = ($errors | append $"dependencies entry missing required 'name' field: ($dep | to nuon)")
+          }
+        } else {
+          $errors = ($errors | append $"dependencies entry must be a string or object, got ($dep_type)")
+        }
+      }
+    }
   }
 
   # Check recommended fields
@@ -477,12 +543,12 @@ def validate-plugin-content [
 
   if ($errors | length) > 0 {
     print $"\n(ansi red_bold)✗ Validation failed with (($errors | length)) errors(ansi reset)"
-    { success: false }
+    { success: false, errors: $errors, warnings: $warnings }
   } else if ($warnings | length) > 0 {
     print $"\n(ansi yellow_bold)⚠ Validation passed with (($warnings | length)) warnings(ansi reset)"
-    { success: true }
+    { success: true, errors: $errors, warnings: $warnings }
   } else {
-    { success: true }
+    { success: true, errors: $errors, warnings: $warnings }
   }
 }
 
@@ -631,4 +697,108 @@ def is-kebab-case [name: string] {
 # Check if string is semantic version
 def is-semver [version: string] {
   $version =~ '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'
+}
+
+# Fixture-based self-test suite for claude-skills-218 / claude-skills-219.
+# Builds a temp plugin.json per case and calls validate-plugin-content
+# directly (no --marketplace context) so the assertions run against the
+# same logic the real CLI path uses. Each case names what would have
+# regressed silently before this fix: dependencies wrongly rejected,
+# unknown fields silently accepted, marketplace-only fields no longer
+# caught, the 5 newly-documented fields not recognized.
+def self-test [] {
+  mut failures = []
+
+  let cases = [
+    {
+      name: "dependencies_array_of_bare_names_accepted"
+      why: "claude-skills-218 — upstream documents plain plugin-name strings as a valid dependencies entry"
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", dependencies: ["helper-lib"] }
+      expect_errors: 0
+      expect_warnings: 0
+    }
+    {
+      name: "dependencies_array_of_version_objects_accepted"
+      why: "claude-skills-218 — upstream's own example: [{ name: secrets-vault, version: ~2.1.0 }]"
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", dependencies: [{ name: "secrets-vault", version: "~2.1.0" }] }
+      expect_errors: 0
+      expect_warnings: 0
+    }
+    {
+      name: "dependencies_entry_missing_name_errors"
+      why: "a dependency object without 'name' is malformed regardless of the upstream shape fix"
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", dependencies: [{ version: "~2.1.0" }] }
+      expect_errors: 1
+      expect_warnings: 0
+    }
+    {
+      name: "dependencies_not_an_array_errors"
+      why: "a lone string instead of an array is a type error, not a shape variant"
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", dependencies: "helper-lib" }
+      expect_errors: 1
+      expect_warnings: 0
+    }
+    {
+      name: "marketplace_only_fields_still_rejected"
+      why: "category/strict/source/tags stay marketplace-entry-only per upstream's plugin-entries schema — the fix must not weaken this"
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", category: "productivity", strict: true, source: "./plugins/my-plugin", tags: ["a"] }
+      expect_errors: 4
+      expect_warnings: 0
+    }
+    {
+      name: "unknown_field_warns_not_errors"
+      why: "claude-skills-219 — an invented field must not pass silently, but must WARN not hard-fail (matches upstream's own claude plugin validate behavior)"
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", notARealField: "garbage" }
+      expect_errors: 0
+      expect_warnings: 1
+    }
+    {
+      name: "five_newly_documented_fields_recognized"
+      why: "claude-skills-218 — displayName, defaultEnabled, workflows, userConfig, channels are real plugin.json fields and must not warn as unrecognized"
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", displayName: "My Plugin", defaultEnabled: false, workflows: "./workflows/", userConfig: {}, channels: [] }
+      expect_errors: 0
+      expect_warnings: 0
+    }
+    {
+      name: "missing_required_name_still_errors"
+      why: "the allowlist/warn changes must not weaken the pre-existing required-field check"
+      plugin: {}
+      expect_errors: 1
+      expect_warnings: 1  # "Missing recommended field: version" etc. are warnings; name is the only error case here besides those — see assertion below which checks error substring instead of exact count
+    }
+  ]
+
+  let temp_dir = (mktemp -d)
+
+  for c in $cases {
+    let plugin_path = ($temp_dir | path join $"($c.name).json")
+    $c.plugin | save --force $plugin_path
+
+    let result = (validate-plugin-content $plugin_path $temp_dir "my-plugin" "my-plugin" false false)
+
+    if $c.name == "missing_required_name_still_errors" {
+      if not ($result.errors | any {|e| $e | str contains "Missing required field: 'name'" }) {
+        $failures = ($failures | append $"($c.name): expected a missing-name error, got errors=($result.errors | to nuon)")
+      }
+    } else {
+      if ($result.errors | length) != $c.expect_errors {
+        $failures = ($failures | append $"($c.name): expected ($c.expect_errors) errors, got (($result.errors | length)): ($result.errors | to nuon) -- ($c.why)")
+      }
+      if ($result.warnings | length) != $c.expect_warnings {
+        $failures = ($failures | append $"($c.name): expected ($c.expect_warnings) warnings, got (($result.warnings | length)): ($result.warnings | to nuon) -- ($c.why)")
+      }
+    }
+  }
+
+  rm -rf $temp_dir
+
+  if ($failures | length) > 0 {
+    print $"(ansi red_bold)❌ validate-plugin.nu self-test failed:(ansi reset)"
+    for f in $failures {
+      print $"  - ($f)"
+    }
+    exit 1
+  }
+
+  print $"(ansi green_bold)✅ validate-plugin.nu self-test passed \((($cases | length)) cases\)(ansi reset)"
 }

--- a/plugins/tools/claude-code/skills/sources.md
+++ b/plugins/tools/claude-code/skills/sources.md
@@ -82,13 +82,15 @@ Structured tracking: [sources.toml](sources.toml) — versions, check methods, a
 ### Claude Code Plugins Reference Documentation
 - **URL**: https://code.claude.com/docs/en/plugins-reference
 - **Purpose**: Complete technical specification of the plugin.json manifest schema
-- **Date Accessed**: 2026-08-04
+- **Date Accessed**: 2026-08-04 (re-fetched same day for claude-skills-218/219)
 - **Key Findings**:
   - `outputStyles` (string\|array) — custom output style files/directories, replaces the default `output-styles/` scan
   - `lspServers` (string\|array\|object) — LSP configs for code intelligence; defaults to a `.lsp.json` file at the plugin root when unset
   - `experimental.themes` and `experimental.monitors` (both string\|array) — components whose schema may still change; both also work unnested at the top level for backward compatibility
-  - `dependencies` is documented as a valid plugin.json field (array), contradicting this skill's current invalid-fields list — tracked in claude-skills-218, not fixed under this AC. The validator's denylist-only unknown-field handling (no allowlist) is tracked separately in claude-skills-219
-- **Used In**: skills/claude-plugins/SKILL.md
+  - `dependencies` (array) IS a documented, valid plugin.json field — shape is bare plugin-name strings and/or `{name, version}` objects with a semver constraint. This contradicted the skill's prior invalid-fields list and `validate-plugin.nu`'s denylist; both fixed under claude-skills-218
+  - Five previously-unmodeled plugin.json fields confirmed real and documented: `displayName` (string, v2.1.143+), `defaultEnabled` (boolean, v2.1.154+), `workflows` (string\|array), `userConfig` (object), `channels` (array) — all now documented in SKILL.md and recognized by the validator (claude-skills-218)
+  - Upstream's own `claude plugin validate` treats an unrecognized top-level field as a WARNING, not an error, so a manifest can double as another tool's config file — directly informed the warn-not-fail fix for claude-skills-219
+- **Used In**: skills/claude-plugins/SKILL.md, skills/claude-plugins/references/plugin-schema.md, skills/claude-plugins/references/validation-and-troubleshooting.md, skills/claude-plugins/scripts/validate-plugin.nu
 
 ### Claude Code Commands Documentation
 - **URL**: https://code.claude.com/docs/en/commands
@@ -140,7 +142,7 @@ Structured tracking: [sources.toml](sources.toml) — versions, check methods, a
 ### Claude Code Plugin Marketplace Schema
 - **URL**: https://code.claude.com/docs/en/plugin-marketplaces
 - **Purpose**: Official specification for creating plugin marketplaces
-- **Date Accessed**: 2025-11-15
+- **Date Accessed**: 2025-11-15 (re-fetched 2026-08-04 for claude-skills-218/219)
 - **Key Specifications**:
   - Marketplace file location: `.claude-plugin/marketplace.json`
   - Required fields: `name`, `owner`, `plugins` array
@@ -150,7 +152,8 @@ Structured tracking: [sources.toml](sources.toml) — versions, check methods, a
   - Environment variables: `${CLAUDE_PLUGIN_ROOT}` for dynamic path resolution
   - Standard metadata fields: description, version, author, homepage, repository, license, keywords, category, tags
   - Component configuration: commands, agents, hooks, mcpServers
-- **Used In**: skills/plugin-marketplace/SKILL.md
+  - Confirmed 2026-08-04: a marketplace entry may carry any field from the plugin manifest schema PLUS these marketplace-specific fields — `source`, `category`, `tags`, `strict`, and `relevance`. This confirms `category`/`strict`/`source`/`tags` are correctly marketplace-only in `validate-plugin.nu`'s denylist, and that `dependencies` is NOT among them — it belongs to the plugin manifest schema (claude-skills-218). `relevance` is also marketplace-only but out of scope for claude-skills-218/219 — not added to the denylist speculatively
+- **Used In**: skills/plugin-marketplace/SKILL.md, skills/claude-plugins/SKILL.md
 
 ### Advanced Plugin Entry Features
 - **URL**: https://code.claude.com/docs/en/plugin-marketplaces#advanced-plugin-entries
@@ -175,8 +178,9 @@ Structured tracking: [sources.toml](sources.toml) — versions, check methods, a
   - Required: `name` (kebab-case)
   - Recommended: `version` (semver), `description`, `license` (SPDX)
   - Optional: `author`, `homepage`, `repository`, `keywords`
-  - Component paths: `skills`, `commands`, `agents`, `hooks`, `mcpServers`
-  - Invalid in plugin.json: `dependencies`, `category`, `strict`, `source`, `tags` (marketplace-only)
+  - Component paths: `skills`, `commands`, `agents`, `workflows`, `hooks`, `mcpServers`
+  - Also valid: `displayName`, `defaultEnabled`, `userConfig`, `channels`, `dependencies` (array of plugin-name strings and/or `{name, version}` objects — corrected 2026-08-04, claude-skills-218; was previously miscategorized as marketplace-only)
+  - Invalid in plugin.json: `category`, `strict`, `source`, `tags` (marketplace-only)
 - **Used In**: skills/claude-plugins/SKILL.md
 
 ## Validation Scripts

--- a/plugins/tools/claude-code/skills/sources.toml
+++ b/plugins/tools/claude-code/skills/sources.toml
@@ -123,7 +123,7 @@ version_constraint = "rolling"
 last_checked = "2026-08-04"
 update_priority = "medium"
 breaking_changes_likely = true
-notes = "Live fetch 2026-08-04 for claude-skills-215 confirmed outputStyles (string|array, replaces default output-styles/ scan), lspServers (string|array|object, defaults to .lsp.json at plugin root when unset), and experimental.themes / experimental.monitors (both string|array) as documented plugin.json fields. The experimental.themes / experimental.monitors keys also work unnested at the top level today, but claude plugin validate already warns on that unnested form, and a future release will require the nested experimental.* form. The same fetch also surfaced that this page now documents plugin.json fields not yet modeled anywhere in this skill, including displayName, defaultEnabled, workflows, userConfig, channels, and — notably — dependencies as a VALID plugin.json field (array of required plugins with optional semver constraints), which directly contradicts this skill's 'Fields that must NOT appear in plugin.json' section still listing dependencies as invalid. That contradiction is out of scope for claude-skills-215 (three named fields only); tracked in claude-skills-218. The validator's denylist-only unknown-field handling (accepts any field not on the denylist, no allowlist) is tracked separately in claude-skills-219. Priority raised to medium and breaking_changes_likely set true given how much drift one fetch surfaced against a source last reviewed 2025-11-15."
+notes = "Live fetch 2026-08-04 for claude-skills-215 confirmed outputStyles (string|array, replaces default output-styles/ scan), lspServers (string|array|object, defaults to .lsp.json at plugin root when unset), and experimental.themes / experimental.monitors (both string|array) as documented plugin.json fields. The experimental.themes / experimental.monitors keys also work unnested at the top level today, but claude plugin validate already warns on that unnested form, and a future release will require the nested experimental.* form. Re-fetched again 2026-08-04 for claude-skills-218/219 (same day, separate follow-up): confirmed 'dependencies' as a VALID plugin.json field under the 'Component path fields' table, shape array of plugin-name strings and/or {name, version} objects (e.g. [\"helper-lib\", { \"name\": \"secrets-vault\", \"version\": \"~2.1.0\" }]) — this directly contradicted the skill's prior 'Fields that must NOT appear in plugin.json' section and validate-plugin.nu's invalid_fields denylist, both fixed by claude-skills-218. Also confirmed the 5 previously-unmodeled fields as real, documented plugin.json fields: displayName (string, v2.1.143+), defaultEnabled (boolean, v2.1.154+), workflows (string|array, replaces default workflows/ scan), userConfig (object, enable-time prompted values), channels (array, message-channel declarations bound to an mcpServers key). Also confirmed upstream's own 'Unrecognized fields' section: claude plugin validate reports fields it doesn't recognize as WARNINGS, not errors — a plugin with only unrecognized-field warnings still passes and loads at runtime; --strict promotes warnings to errors. This directly informed claude-skills-219's fix (warn-on-unknown-field in validate-plugin.nu, not hard-fail)."
 
 [[sources]]
 skills = ["claude-commands"]
@@ -181,16 +181,16 @@ notes = "sources.md Date Accessed 2026-04-17. Used In both skills/claude-output-
 # rather than duplicated per the "don't split one upstream" rule.
 # ----------------------------------------------------------------------------
 [[sources]]
-skills = ["plugin-marketplace"]
+skills = ["plugin-marketplace", "claude-plugins"]
 name = "claude-code-plugin-marketplaces-docs"
 url = "https://code.claude.com/docs/en/plugin-marketplaces"
 check_method = "manual"
 current_version = "unknown"
 version_constraint = "rolling"
-last_checked = "2025-11-15"
+last_checked = "2026-08-04"
 update_priority = "low"
 breaking_changes_likely = false
-notes = "sources.md Date Accessed 2025-11-15 for both the base 'Claude Code Plugin Marketplace Schema' entry and the 'Advanced Plugin Entry Features' entry, which cites the #advanced-plugin-entries anchor on this exact same URL — merged into one sources.toml row rather than duplicated."
+notes = "sources.md Date Accessed 2025-11-15 for both the base 'Claude Code Plugin Marketplace Schema' entry and the 'Advanced Plugin Entry Features' entry, which cites the #advanced-plugin-entries anchor on this exact same URL — merged into one sources.toml row rather than duplicated. Re-fetched 2026-08-04 for claude-skills-218/219: confirmed the 'Plugin entries' section states an entry may include any field from the plugin manifest schema PLUS these marketplace-specific fields: source, category, tags, strict, and relevance. This confirms category/strict/source/tags are marketplace-entry-only (correctly denylisted in validate-plugin.nu) and that dependencies is NOT among them — it's a plugin-manifest-schema field a marketplace entry may optionally echo, not a marketplace-only field. relevance is also marketplace-entry-only but was out of scope for claude-skills-218/219 (neither bee named it) and is not yet added to the claude-plugins denylist — flagged here for a future pass rather than added speculatively (restraint: stick to what was asked)."
 
 # ----------------------------------------------------------------------------
 # "Claude Teams Skill" section of sources.md — eight distinct upstreams.


### PR DESCRIPTION
- Remove `dependencies` from `validate-plugin.nu`'s invalid-fields denylist and the claude-plugins skill's "must NOT appear" list — upstream (code.claude.com/docs/en/plugins-reference) documents it as a valid plugin.json field: array of plugin-name strings and/or `{name, version}` objects with an optional semver constraint
- Confirm `category`/`strict`/`source`/`tags` remain correctly marketplace-entry-only, verified against upstream's plugin-marketplaces `plugins-reference` schema (which lists them as marketplace-specific fields distinct from the plugin manifest schema)
- Document 5 previously-unmodeled plugin.json fields: `displayName`, `defaultEnabled`, `workflows`, `userConfig`, `channels`
- Add shape validation for `dependencies` (array of strings/objects, `name` required on object entries)
- Add a warn-on-unrecognized-field pass (allowlist of documented fields) so a typo'd field name surfaces as a warning instead of silently passing, matching upstream's own `claude plugin validate` behavior (warn, not hard-fail)
- Add a `--self-test` fixture suite to `validate-plugin.nu` (8 cases) wired into `mise run test:plugins`, matching the `--self-test` convention already used by `validate-core-list.nu` / `validate-disclosure.nu` / `validate-skills-quality.nu`
- Update `references/plugin-schema.md` and `references/validation-and-troubleshooting.md` to match
- Record both upstream re-fetches (2026-08-04) in sources.toml/sources.md with resolution notes
- Bump claude-code 0.2.53→0.2.54 and all-skills 0.4.111→0.4.112 (plugin.json + marketplace.json entries)

Fixes claude-skills-218, claude-skills-219.