### PR TITLE
fix(test): guard broken references and cover version-bump wiring

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -638,6 +638,7 @@ cd "$(git rev-parse --show-toplevel)"
 BASE="${1:-origin/main}"
 
 nu test/check-version-bumps.nu --self-test
+nu test/check-version-bumps.nu --integration-self-test
 nu test/check-version-bumps.nu --base "$BASE"
 """
 

--- a/test/check-version-bumps.nu
+++ b/test/check-version-bumps.nu
@@ -4,7 +4,8 @@
 #
 # Usage:
 #   nu check-version-bumps.nu [--base main]
-#   nu check-version-bumps.nu --self-test
+#   nu check-version-bumps.nu --self-test              # pure-function fixtures (no git, no filesystem)
+#   nu check-version-bumps.nu --integration-self-test   # real git-fixture wiring test (claude-skills-221)
 #
 # Compares current branch to base branch and ensures any plugin
 # with file changes also has a version bump in both:
@@ -109,10 +110,19 @@ def all-skills-in-scope [changed_files: list<string>, modified_plugin_count: int
 def main [
   --base: string = "origin/main"  # Base branch to compare against
   --self-test                      # Run the pure-function fixture suite and exit
+  --integration-self-test          # Run the git-fixture wiring test and exit
 ] {
   if $self_test {
     self-test
     return
+  }
+
+  if $integration_self_test {
+    # $env.CURRENT_FILE must be captured before any `cd` — it is this
+    # script's own absolute path, needed to invoke a fresh subprocess of
+    # itself against the fixture repo built below.
+    if (integration-self-test ($env.CURRENT_FILE | path expand)) { exit 1 }
+    exit 0
   }
 
   # A bare "main" is the LOCAL branch ref, which can be a merge or more
@@ -517,4 +527,105 @@ def self-test [] {
 
   let total = (($semver_cases | length) + ($bump_cases | length) + ($scope_cases | length))
   print $"(ansi green_bold)✅ check-version-bumps self-test passed \(($total) cases\)(ansi reset)"
+}
+
+# Git-fixture integration test (claude-skills-221). `self-test` above proves
+# semver-compare / classify-bump / all-skills-in-scope are individually
+# correct, but nothing exercises the WIRING in `main` that calls them — the
+# per-plugin loop (get-modified-plugins, check-plugin-version-bump) and the
+# all-skills special case (lines ~188-200). A future refactor that drops or
+# breaks that wiring leaves every self-test green, because the fixtures never
+# call `main` at all. That is the exact shape of the original claude-skills-207
+# bug: the logic was simply absent and nothing noticed.
+#
+# Builds a REAL throwaway git repo (own `.git`, own commits), then invokes
+# THIS SAME SCRIPT as a subprocess against it via `--base <sha>` — the actual
+# entry point CI uses — and asserts on its exit code. A green run on a
+# corpus with no violation proves nothing, so the fixture drives both
+# directions from one repo:
+#   commit 1 (base):      core@0.1.0, all-skills@0.1.0
+#   commit 2:             core content changed + bumped to 0.1.1,
+#                         all-skills left at 0.1.0 (unbumped) — must FAIL
+#   commit 3:             all-skills bumped to 0.1.1 — must PASS
+# Returns true when either assertion failed.
+def integration-self-test [self_path: string] {
+  mut failed = false
+  let root = (mktemp -d)
+
+  let outcome = (do {
+    cd $root
+    ^git init --quiet -b main
+    ^git config user.email "test@example.com"
+    ^git config user.name "Test"
+
+    mkdir ".claude-plugin"
+    mkdir (["plugins" "core" ".claude-plugin"] | path join)
+    mkdir (["plugins" "core" "skills" "foo"] | path join)
+
+    # commit 1: base — everything at 0.1.0
+    { name: "all-skills", version: "0.1.0", skills: [] } | to json | save ".claude-plugin/plugin.json"
+    {
+      plugins: [
+        { name: "core", source: "./plugins/core", version: "0.1.0" }
+        { name: "all-skills", source: "./", version: "0.1.0" }
+      ]
+      metadata: { version: "0.1.0" }
+    } | to json | save ".claude-plugin/marketplace.json"
+    { name: "core", version: "0.1.0", skills: ["./skills/foo"] } | to json | save (["plugins" "core" ".claude-plugin" "plugin.json"] | path join)
+    "old content" | save (["plugins" "core" "skills" "foo" "SKILL.md"] | path join)
+    ^git add -A
+    ^git commit --quiet -m "base"
+    let base_sha = (^git rev-parse HEAD | str trim)
+
+    # commit 2: core's content changes and its version bumps correctly, but
+    # all-skills (which aggregates core) is left unbumped — the regression
+    # shape this integration test exists to guard.
+    "new content" | save --force (["plugins" "core" "skills" "foo" "SKILL.md"] | path join)
+    { name: "core", version: "0.1.1", skills: ["./skills/foo"] } | to json | save --force (["plugins" "core" ".claude-plugin" "plugin.json"] | path join)
+    {
+      plugins: [
+        { name: "core", source: "./plugins/core", version: "0.1.1" }
+        { name: "all-skills", source: "./", version: "0.1.0" }
+      ]
+      metadata: { version: "0.1.0" }
+    } | to json | save --force ".claude-plugin/marketplace.json"
+    ^git add -A
+    ^git commit --quiet -m "bump core only"
+
+    let unbumped = (^nu $self_path --base $base_sha | complete)
+
+    # commit 3: all-skills catches up to 0.1.1 — now everything in scope has
+    # strictly increased from base, so the same wiring must pass.
+    { name: "all-skills", version: "0.1.1", skills: [] } | to json | save --force ".claude-plugin/plugin.json"
+    {
+      plugins: [
+        { name: "core", source: "./plugins/core", version: "0.1.1" }
+        { name: "all-skills", source: "./", version: "0.1.1" }
+      ]
+      metadata: { version: "0.1.0" }
+    } | to json | save --force ".claude-plugin/marketplace.json"
+    ^git add -A
+    ^git commit --quiet -m "bump all-skills too"
+
+    let bumped = (^nu $self_path --base $base_sha | complete)
+
+    { unbumped_exit: $unbumped.exit_code, bumped_exit: $bumped.exit_code, unbumped_out: $unbumped.stdout }
+  })
+
+  if $outcome.unbumped_exit == 0 {
+    print $"(ansi red_bold)❌ integration self-test: unbumped all-skills wiring did not fail \(exit ($outcome.unbumped_exit)\)(ansi reset)"
+    print $"  stdout: ($outcome.unbumped_out)"
+    $failed = true
+  }
+
+  if $outcome.bumped_exit != 0 {
+    print $"(ansi red_bold)❌ integration self-test: correctly bumped fixture wrongly failed \(exit ($outcome.bumped_exit)\)(ansi reset)"
+    $failed = true
+  }
+
+  rm -rf $root
+  if not $failed {
+    print $"(ansi green_bold)✅ check-version-bumps integration self-test passed \(2 cases\)(ansi reset)"
+  }
+  $failed
 }

--- a/test/validate-skills-quality.nu
+++ b/test/validate-skills-quality.nu
@@ -394,24 +394,29 @@ def is-reserved-name [name: string]: nothing -> bool {
 
 # Guards a single reference-file read against three failure modes that used
 # to abort the whole run via an unhandled `open --raw` error (claude-skills-222):
-# a dangling symlink, an unreadable-permissions file, and a symlink that
-# resolves outside the repo. The first two are read attempts that fail; the
-# third succeeds but must never happen — reading it would scan arbitrary
-# filesystem content into the corpus, so it is quarantined (content never
-# read) rather than opened. Returns {name, content, unsafe, reason} where
+# a dangling path, an unreadable-permissions file, and a path that resolves
+# outside the repo. The first two are read attempts that fail; the third
+# succeeds but must never happen — reading it would scan arbitrary filesystem
+# content into the corpus, so it is quarantined (content never read) rather
+# than opened. The outside-the-repo guard covers a symlinked ANCESTOR as well
+# as a symlinked leaf, because the whole path is canonicalized before either
+# check runs. Returns {name, content, unsafe, reason} where
 # reason is "broken" | "unreadable" | "external" | null. Content is "" for
 # every unsafe case.
 def safe-read-ref [f: string, repo_root: string]: nothing -> record {
     let name = ($f | path basename)
-    if ($f | path type) == "symlink" {
-        let resolved = ($f | path expand)
-        if not ($resolved | path exists) {
-            return {name: $name, content: "", unsafe: true, reason: "broken"}
-        }
-        let root = ($repo_root | path expand)
-        if not ($resolved | str starts-with $"($root)/") {
-            return {name: $name, content: "", unsafe: true, reason: "external"}
-        }
+    # Canonicalize unconditionally, not just when the leaf itself is a symlink:
+    # a symlinked ANCESTOR (e.g. the whole references/ directory pointing outside
+    # the repo) leaves every leaf a plain file, so a leaf-only check would read
+    # arbitrary filesystem content into the corpus. `path expand` resolves the
+    # entire path, so both shapes land on the same guard.
+    let resolved = ($f | path expand)
+    if not ($resolved | path exists) {
+        return {name: $name, content: "", unsafe: true, reason: "broken"}
+    }
+    let root = ($repo_root | path expand)
+    if not ($resolved | str starts-with $"($root)/") {
+        return {name: $name, content: "", unsafe: true, reason: "external"}
     }
     let read = (try {
         {ok: true, data: (open --raw $f)}
@@ -3028,10 +3033,11 @@ def main [--update-baseline, --self-test] {
                 []
             }
             # 19. Reference files are safe to read (claude-skills-222). See
-            # safe-read-ref: a broken symlink or unreadable-permissions file
-            # is reported as a finding instead of aborting the run, and a
-            # symlink resolving outside the repo is quarantined (never read)
-            # and reported rather than silently scanned into the corpus.
+            # safe-read-ref: a broken path or unreadable-permissions file is
+            # reported as a finding instead of aborting the run, and a path
+            # resolving outside the repo — whether via a symlinked leaf or a
+            # symlinked ancestor directory — is quarantined (never read) and
+            # reported rather than silently scanned into the corpus.
             let ref_reads = ($ref_files | each {|f| safe-read-ref $f $repo_root})
             let refs = ($ref_reads | each {|r| {name: $r.name, content: $r.content}})
             let unsafe_refs = ($ref_reads | where {|r| $r.unsafe})

--- a/test/validate-skills-quality.nu
+++ b/test/validate-skills-quality.nu
@@ -25,7 +25,7 @@
 # Checks whose findings are countable at runtime; their baseline entries must
 # carry an integer detail_count so a waiver covers the recorded count, not
 # unbounded growth of the same check.
-const DETAIL_CHECKS = ["lines" "links" "orphans" "invocations" "version_pin" "ref_depth" "duplicate_block" "vocab_disjoint" "fm_schema"]
+const DETAIL_CHECKS = ["lines" "links" "orphans" "invocations" "version_pin" "ref_depth" "duplicate_block" "vocab_disjoint" "fm_schema" "ref_unsafe"]
 
 # Sliding-window size for the corpus-wide duplicate-block check: 8 normalised
 # lines. Measured in the claude-skills-124 plan (revision 2): at N=8 with no
@@ -390,6 +390,38 @@ def strip-fences [content: string] {
 # too: names like claude-api or anthropic-sdk are legitimate domains.
 def is-reserved-name [name: string]: nothing -> bool {
     $name in ["claude" "anthropic"]
+}
+
+# Guards a single reference-file read against three failure modes that used
+# to abort the whole run via an unhandled `open --raw` error (claude-skills-222):
+# a dangling symlink, an unreadable-permissions file, and a symlink that
+# resolves outside the repo. The first two are read attempts that fail; the
+# third succeeds but must never happen — reading it would scan arbitrary
+# filesystem content into the corpus, so it is quarantined (content never
+# read) rather than opened. Returns {name, content, unsafe, reason} where
+# reason is "broken" | "unreadable" | "external" | null. Content is "" for
+# every unsafe case.
+def safe-read-ref [f: string, repo_root: string]: nothing -> record {
+    let name = ($f | path basename)
+    if ($f | path type) == "symlink" {
+        let resolved = ($f | path expand)
+        if not ($resolved | path exists) {
+            return {name: $name, content: "", unsafe: true, reason: "broken"}
+        }
+        let root = ($repo_root | path expand)
+        if not ($resolved | str starts-with $"($root)/") {
+            return {name: $name, content: "", unsafe: true, reason: "external"}
+        }
+    }
+    let read = (try {
+        {ok: true, data: (open --raw $f)}
+    } catch {
+        {ok: false, data: ""}
+    })
+    if not $read.ok {
+        return {name: $name, content: "", unsafe: true, reason: "unreadable"}
+    }
+    {name: $name, content: $read.data, unsafe: false, reason: null}
 }
 
 # Examples check: the skill presents at least one example — a code fence or
@@ -1204,6 +1236,73 @@ def run-orphans-self-test [] {
 
     if not $failed {
         print $"(ansi green_bold)✅ Orphans self-test passed \(($cases | length) cases\)(ansi reset)"
+    }
+    $failed
+}
+
+# Embedded self-test for safe-read-ref (claude-skills-222): a broken symlink
+# under references/ used to abort the ENTIRE run via an unhandled `open --raw`
+# error before this function existed — zero tables printed, every other
+# finding masked (reproduced against the pre-fix script: exit 1, only a raw
+# nu error trace, no scorecard). Exercises all three unsafe modes against a
+# REAL filesystem fixture (dangling symlink, chmod-000 file, symlink
+# resolving outside the fixture's own tree) plus the normal-read path, so a
+# regression that lets any one of them raise again is caught here instead of
+# by a crash with no diagnostic. A green run on a corpus with no broken
+# symlinks proves nothing — this fixture manufactures the failure modes
+# directly. Fixture tree removed at the end. Returns true when any case
+# failed.
+def run-safe-read-ref-self-test [] {
+    mut failed = false
+
+    let root = (mktemp -d)
+    let repo = ($root | path join "repo")
+    let refs = ($repo | path join "references")
+    mkdir $refs
+    "normal content" | save ($refs | path join "good.md")
+    ^ln -s /nonexistent-target-claude-skills-222 ($refs | path join "broken.md")
+    "" | save ($refs | path join "unreadable.md")
+    ^chmod 000 ($refs | path join "unreadable.md")
+    # The outside target must exist and be readable, so this case proves
+    # "resolves outside the repo", not "happens to also be broken".
+    let outside = ($root | path join "outside.md")
+    "outside content" | save $outside
+    ^ln -s $outside ($refs | path join "external.md")
+
+    # Case: normal file reads through unchanged.
+    let good = (safe-read-ref ($refs | path join "good.md") $repo)
+    if $good.unsafe or $good.content != "normal content" {
+        print $"(ansi red_bold)❌ safe-read-ref self-test: normal file wrongly flagged unsafe \(got: ($good)\)(ansi reset)"
+        $failed = true
+    }
+
+    # Case: broken (dangling) symlink is reported, not raised.
+    let broken = (safe-read-ref ($refs | path join "broken.md") $repo)
+    if not $broken.unsafe or $broken.reason != "broken" {
+        print $"(ansi red_bold)❌ safe-read-ref self-test: broken symlink not reported \(got: ($broken)\)(ansi reset)"
+        $failed = true
+    }
+
+    # Case: unreadable permissions is reported, not raised.
+    let unreadable = (safe-read-ref ($refs | path join "unreadable.md") $repo)
+    if not $unreadable.unsafe or $unreadable.reason != "unreadable" {
+        print $"(ansi red_bold)❌ safe-read-ref self-test: unreadable file not reported \(got: ($unreadable)\)(ansi reset)"
+        $failed = true
+    }
+
+    # Case: symlink resolving outside the repo is quarantined — reported, and
+    # its content is never read (empty), even though the target itself is
+    # perfectly readable.
+    let external = (safe-read-ref ($refs | path join "external.md") $repo)
+    if not $external.unsafe or $external.reason != "external" or $external.content != "" {
+        print $"(ansi red_bold)❌ safe-read-ref self-test: external symlink not quarantined \(got: ($external)\)(ansi reset)"
+        $failed = true
+    }
+
+    ^chmod 644 ($refs | path join "unreadable.md")
+    rm -rf $root
+    if not $failed {
+        print $"(ansi green_bold)✅ safe-read-ref self-test passed \(4 cases\)(ansi reset)"
     }
     $failed
 }
@@ -2726,12 +2825,13 @@ def main [--update-baseline, --self-test] {
         let vocab_failed = (run-vocab-self-test)
         let pass2_links_failed = (run-pass2-links-self-test)
         let orphans_failed = (run-orphans-self-test)
+        let safe_read_ref_failed = (run-safe-read-ref-self-test)
         let fm_schema_failed = (run-frontmatter-schema-self-test)
         let accumulator_failed = (run-accumulator-self-test)
         let pass2_eval_failed = (run-pass2-eval-self-test)
         let anti_fab_failed = (run-anti-fab-self-test)
         let braced_claude_failed = (run-braced-claude-self-test)
-        if $skills_failed or $baseline_failed or $checks_failed or $duplicate_failed or $vocab_failed or $pass2_links_failed or $orphans_failed or $fm_schema_failed or $accumulator_failed or $pass2_eval_failed or $anti_fab_failed or $braced_claude_failed { exit 1 }
+        if $skills_failed or $baseline_failed or $checks_failed or $duplicate_failed or $vocab_failed or $pass2_links_failed or $orphans_failed or $safe_read_ref_failed or $fm_schema_failed or $accumulator_failed or $pass2_eval_failed or $anti_fab_failed or $braced_claude_failed { exit 1 }
         exit 0
     }
 
@@ -2927,7 +3027,15 @@ def main [--update-baseline, --self-test] {
             } else {
                 []
             }
-            let refs = ($ref_files | each {|f| {name: ($f | path basename), content: (open --raw $f)}})
+            # 19. Reference files are safe to read (claude-skills-222). See
+            # safe-read-ref: a broken symlink or unreadable-permissions file
+            # is reported as a finding instead of aborting the run, and a
+            # symlink resolving outside the repo is quarantined (never read)
+            # and reported rather than silently scanned into the corpus.
+            let ref_reads = ($ref_files | each {|f| safe-read-ref $f $repo_root})
+            let refs = ($ref_reads | each {|r| {name: $r.name, content: $r.content}})
+            let unsafe_refs = ($ref_reads | where {|r| $r.unsafe})
+            if ($unsafe_refs | length) > 0 { $failed = ($failed | append "ref_unsafe") }
 
             # 8. Has examples: code fence / example header in SKILL.md, or a
             # code fence in a reference file SKILL.md mentions (see has-examples)
@@ -3060,9 +3168,10 @@ def main [--update-baseline, --self-test] {
                 {check: "version_pin", count: ($stale_pins | length)}
                 {check: "ref_depth", count: ($nested | length)}
                 {check: "fm_schema", count: ($fm_unknown | length)}
+                {check: "ref_unsafe", count: ($unsafe_refs | length)}
             ])
 
-            let check_count = 18
+            let check_count = 19
             let score = $check_count - ($failed | length)
 
             $results = ($results | append {
@@ -3072,7 +3181,7 @@ def main [--update-baseline, --self-test] {
                 score: $"($score)/($check_count)"
                 failed: ($failed | str join " ")
                 new: ($new_failures | each {|k| $k | split row ":" | last} | str join " ")
-                details: ($broken_links | append $bad_invocations | append $stale_pins | append ($orphans | each {|f| $f | path basename}) | append ($fm_unknown | each {|k| $"frontmatter:($k)"}) | append ($nested | each {|r| $"nested:($r.name)"}) | str join " ")
+                details: ($broken_links | append $bad_invocations | append $stale_pins | append ($orphans | each {|f| $f | path basename}) | append ($fm_unknown | each {|k| $"frontmatter:($k)"}) | append ($nested | each {|r| $"nested:($r.name)"}) | append ($unsafe_refs | each {|r| $"($r.reason):($r.name)"}) | str join " ")
             })
 
             if ($failed | is-empty) {


### PR DESCRIPTION
- validate-skills-quality.nu: guard reference-file reads (safe-read-ref) so a broken symlink, unreadable file, or out-of-repo symlink under a skill's references/ is reported as a ref_unsafe finding instead of aborting the whole run and masking every other result
- add a real filesystem self-test fixture for safe-read-ref (normal read, dangling symlink, chmod-000 file, symlink resolving outside the repo)
- check-version-bumps.nu: add --integration-self-test, a real git-fixture test that builds a throwaway repo and invokes the script as a subprocess to prove the all-skills wiring in main (not just the pure semver-compare/classify-bump helpers) fails on an unbumped aggregator and passes once bumped
- wire --integration-self-test into the existing test:version-bumps mise task alongside --self-test