### PR TITLE
fix(claude-code): sources tooling follow-ups from PR #208/#211 Gate 3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.113",
+      "version": "0.4.114",
       "category": "meta",
       "keywords": [
         "skills",
@@ -119,7 +119,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
-      "version": "0.2.55",
+      "version": "0.2.56",
       "category": "tools",
       "keywords": [
         "claude-code",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -256,7 +256,7 @@
       "source": "./plugins/tools/agent-sandboxing",
       "strict": true,
       "description": "Agent sandboxing for AI coding agents: microVM and kernel-isolated execution environments. Index skill (sandbox) routes to substrate-specific paths. Currently covers the kubernetes-sigs/agent-sandbox path on kind, GKE, and kina (Kubernetes-in-Apple-Containers), with Kata, gVisor, and Apple Container microVM substrates. Ships 7 skills + 6 slash commands + nushell scripts. Designed to expand to non-k8s sandboxing paths.",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "category": "tools",
       "keywords": [
         "agent-sandbox",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.113",
+  "version": "0.4.114",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/agent-sandboxing/.claude-plugin/plugin.json
+++ b/plugins/tools/agent-sandboxing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sandboxing",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Agent sandboxing for AI coding agents: microVM and kernel-isolated execution environments. Index skill (sandbox) routes to substrate-specific paths. Currently covers the kubernetes-sigs/agent-sandbox path on kind, GKE, and kina (Kubernetes-in-Apple-Containers), with Kata, gVisor, and Apple Container microVM substrates. Ships 7 skills + 6 slash commands + nushell scripts. Designed to expand to non-k8s sandboxing paths.",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/agent-sandboxing/skills/sources.md
+++ b/plugins/tools/agent-sandboxing/skills/sources.md
@@ -2,7 +2,7 @@
 
 Citations for the `agent-sandboxing` plugin skills. Each entry lists the upstream source, what was extracted from it, and the date of last verification.
 
-Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `kubernetes-sigs/agent-sandbox` (this section), `gke-agent-sandbox-docs` (the Google Cloud — GKE Agent Sandbox docs section), `kata-containers` (the Kata Containers section), `agent-substrate` (the agent-substrate/substrate section), `claude-code-devcontainer-docs` (the Claude Code section), `kina` (the kina section), `claude-code-devcontainer-reference` (the Anthropic devcontainer reference image section), `gcp-agent-sandbox-substrate-blog` (the Google Cloud blog section), `sandbox-index-skill` (the `sandbox` routing/index skill, which has no external upstream).
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `kubernetes-sigs/agent-sandbox` (this section), `gke-agent-sandbox-docs` (the Google Cloud — GKE Agent Sandbox docs section), `kata-containers` (the Kata Containers section), `agent-substrate` (the agent-substrate/substrate section), `claude-code-devcontainer-docs` (the Claude Code section), `kina` (the kina section), `claude-code-devcontainer-reference` (the Anthropic devcontainer reference image section), `debian-13-slim-base-image` (the Docker Hub debian:13-slim base image section), `gcp-agent-sandbox-substrate-blog` (the Google Cloud blog section), `sandbox-index-skill` (the `sandbox` routing/index skill, which has no external upstream).
 
 ## kubernetes-sigs/agent-sandbox
 
@@ -66,6 +66,13 @@ Structured tracking: [sources.toml](sources.toml) — versions, check methods, a
 - **Used in**: `claude-code-on-sandbox`, `templates/Dockerfile.claude-code`
 - **Extracted**: Dockerfile structure, non-root user pattern (UID 1000), `~/.claude` named volume, `init-firewall.sh` NET_ADMIN/NET_RAW egress allowlist. The Dockerfile in this plugin's `templates/` is mise-driven rather than copying Anthropic's npm-driven setup, per [[feedback-mise-first]] + [[feedback-mise-registry-short-names]].
 - **Date accessed**: 2026-05-23
+
+## Docker Hub debian:13-slim base image
+
+- **URL**: https://hub.docker.com/_/debian
+- **Used in**: `claude-code-on-sandbox`, `templates/Dockerfile.claude-code`
+- **Extracted**: `templates/Dockerfile.claude-code:7` pins `FROM debian:13-slim AS base`. Tracked via `check_method = "docker-hub"` with `docker_tag = "13-slim"` (claude-skills-225 F1) — `current_version` stores the tag's content digest rather than a version string, so `mise sources:check` reports drift when the base image is re-pushed (security patch, layer rebuild), not merely when a new tag name appears.
+- **Date accessed**: 2026-08-04
 
 ## Google Cloud blog — Agent Sandbox + Agent Substrate
 

--- a/plugins/tools/agent-sandboxing/skills/sources.toml
+++ b/plugins/tools/agent-sandboxing/skills/sources.toml
@@ -3,8 +3,8 @@
 
 [meta]
 plugin = "agent-sandboxing"
-reviewed_at_plugin_version = "0.2.3"
-last_full_check = "2026-07-30"
+reviewed_at_plugin_version = "0.2.12"
+last_full_check = "2026-08-04"
 
 # ----------------------------------------------------------------------------
 # kubernetes-sigs/agent-sandbox — the upstream CRD project (Sandbox,
@@ -132,6 +132,29 @@ last_checked = "2026-07-30"
 update_priority = "low"
 breaking_changes_likely = false
 notes = "sources.md Date accessed 2026-05-23 for the extracted content (Dockerfile structure, non-root user pattern UID 1000, ~/.claude named volume, init-firewall.sh NET_ADMIN/NET_RAW egress allowlist); this plugin's own templates/Dockerfile.claude-code is mise-driven rather than copying Anthropic's npm-driven setup, per feedback-mise-first + feedback-mise-registry-short-names. check_method is 'manual' rather than github-releases because the cited content is a specific example directory, not something versioned by CLI release tags. Live GitHub API check 2026-07-30 confirms anthropics/claude-code still resolves (full_name unchanged) — repo-reachability verified only, directory contents not re-diffed."
+
+# ----------------------------------------------------------------------------
+# Docker Hub debian:13-slim — the real `FROM` base image pinned in this
+# plugin's own templates/Dockerfile.claude-code (claude-skills-225 F1: the
+# first real docker_tag adopter, exercising check-docker-hub-tag's per-tag
+# digest comparator end-to-end instead of only the template's illustrative
+# example). current_version is the tag's content digest, not a version
+# string — drift means the base image was re-pushed since last_checked and
+# the pin should be re-verified.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["claude-code-on-sandbox"]
+name = "debian-13-slim-base-image"
+url = "https://hub.docker.com/_/debian"
+check_method = "docker-hub"
+docker_image = "library/debian"
+docker_tag = "13-slim"
+current_version = "sha256:020c0d20b9880058cbe785a9db107156c3c75c2ac944a6aa7ab59f2add76a7bd"
+version_constraint = "rolling"
+last_checked = "2026-08-04"
+update_priority = "low"
+breaking_changes_likely = false
+notes = "templates/Dockerfile.claude-code:7 pins FROM debian:13-slim AS base. Live digest captured 2026-08-04 via https://hub.docker.com/v2/repositories/library/debian/tags/13-slim/ — matches this file's current_version byte-for-byte. Re-run mise sources:check to detect when Debian re-pushes the 13-slim tag (security patch, base-layer rebuild)."
 
 # ----------------------------------------------------------------------------
 # Google Cloud blog — GKE Agent Sandbox GA announcement and Sandbox-vs-

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.55",
+  "version": "0.2.56",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/skill-update/SKILL.md
+++ b/plugins/tools/claude-code/skills/skill-update/SKILL.md
@@ -39,6 +39,7 @@ Each plugin's `skills/sources.toml` tracks upstream dependencies. See `templates
 | `crate_name` | string | conditional | Required for `crates-io` |
 | `npm_package` | string | conditional | Required for `npm` (registry package name, `@scope/name` included) |
 | `docker_image` | `namespace/repository` | conditional | Required for `docker-hub` (e.g. `library/node`) |
+| `docker_tag` | string | conditional | Optional for `docker-hub` (e.g. `13-slim`) — when set, switches the check to the per-tag content digest of that exact pin instead of the newest tag's name (claude-skills-225); `current_version` then holds a `sha256:<64 hex>` digest, accepted by `b3_version_shape` only for entries that set this field |
 | `eol_product` | string | conditional | Required for `endoflife-date` (the endoflife.date product slug, e.g. `nodejs`) |
 | `current_version` | QUOTED shape-checked version string \| `unknown` | yes unless `none` | The upstream version this skill content was last verified/documented against |
 | `version_constraint` | `pre-1.0` \| `semver` \| `rolling` \| `stable` | yes unless `none` | Version stability model — NOT valid values for `current_version` itself; a rolling/stable source with no discrete version records `current_version = "unknown"` (the convention 117 of 119 `rolling` entries and 8 of 12 `stable` entries already follow) |
@@ -82,6 +83,10 @@ Structured tracking: [sources.toml](sources.toml) — versions, check methods, a
 | `none` | N/A | N/A | N/A — no external upstream exists |
 
 Docker Hub tags are not semver in general — `check-docker-hub` reports "is a newer tag available" (string equality against the most-recently-updated tag name), not "is there a newer semver release." A specific pinned tag that isn't itself version-shaped (e.g. `16-buster-slim`) belongs in `notes`, not `current_version` — `current_version = "unknown"` with `version_constraint = "rolling"` is the schema-compliant way to track it (see `templates/sources.toml`).
+
+Setting `docker_tag` switches the check to `check-docker-hub-tag`, which queries the per-tag endpoint (`https://hub.docker.com/v2/repositories/{namespace}/{repository}/tags/{tag}/` — reads that tag's own `digest` field) instead of the newest-tag-name endpoint above. This answers a narrower, genuinely answerable question for a realistically pinned image: has THIS exact tag been re-pushed since I last checked, not merely does a differently-named tag exist. `current_version` stores the last-observed digest; drift means the base image was rebuilt (security patch, layer update) under the same tag name. See `plugins/tools/agent-sandboxing/skills/sources.toml`'s `debian-13-slim-base-image` entry for a worked, live example (claude-skills-225).
+
+`check-endoflife-status` (in `scripts/sources-lib.nu`) is the EOL-aware counterpart to the `endoflife-date` check_method above: one call to the same `https://endoflife.date/api/{product}.json` endpoint returns the newest cycle's `latest` patch, that cycle's own `eol` state, and its `cycle` identifier, rather than only the string `fetch-latest`/`classify-staleness` consume. `check-endoflife-date` (the schema-facing function) calls it and returns just `.latest`, preserving `current_version`/`stale` semantics unchanged — call `check-endoflife-status` directly when the EOL sentinel itself is needed (claude-skills-226).
 
 See `references/version-check-methods.md` for Nushell parsing examples.
 

--- a/plugins/tools/claude-code/skills/skill-update/references/version-check-methods.md
+++ b/plugins/tools/claude-code/skills/skill-update/references/version-check-methods.md
@@ -20,7 +20,7 @@ Queries the GitHub Releases API for the latest published release.
 
 ```nushell
 # Query latest release for a GitHub repo
-def get-github-latest [repo: string] -> string {
+def get-github-latest [repo: string]: nothing -> string {
     let url = $"https://api.github.com/repos/($repo)/releases/latest"
     let headers = if ("GITHUB_TOKEN" in $env) {
         {Authorization: $"Bearer ($env.GITHUB_TOKEN)", "X-GitHub-Api-Version": "2022-11-28"}
@@ -58,7 +58,7 @@ Queries the Hex.pm package registry for Elixir/Erlang packages.
 
 ```nushell
 # Query latest stable version for a Hex.pm package
-def get-hex-latest [package: string] -> string {
+def get-hex-latest [package: string]: nothing -> string {
     let url = $"https://hex.pm/api/packages/($package)"
     let response = http get $url
     $response.latest_stable_version
@@ -92,7 +92,7 @@ Queries the crates.io registry for Rust packages.
 
 ```nushell
 # Query latest stable version for a crates.io package
-def get-crates-latest [crate_name: string] -> string {
+def get-crates-latest [crate_name: string]: nothing -> string {
     let url = $"https://crates.io/api/v1/crates/($crate_name)"
     # User-Agent is REQUIRED by crates.io policy
     let headers = {"User-Agent": "claude-skills/mise-sources-check (github.com/vinnie357/claude-skills)"}
@@ -128,7 +128,7 @@ Queries the npm registry for a package's `dist-tags.latest` version.
 
 ```nushell
 # Query latest dist-tag for an npm package
-def get-npm-latest [package: string] -> string {
+def get-npm-latest [package: string]: nothing -> string {
     let url = $"https://registry.npmjs.org/($package)"
     let response = http get $url
     $response | get -o dist-tags.latest | default "unknown"
@@ -147,7 +147,7 @@ let latest = get-npm-latest "express"
 
 ## docker-hub
 
-Queries the Docker Hub Hub API v2 tags list for an image, sorted by most-recently-updated.
+Queries the Docker Hub Hub API v2 tags list for an image, sorted by most-recently-updated. An optional `docker_tag` field switches to a per-tag digest comparison instead — see "Tracking a specific pinned tag" below.
 
 | Property | Value |
 |---|---|
@@ -155,12 +155,13 @@ Queries the Docker Hub Hub API v2 tags list for an image, sorted by most-recentl
 | Auth | None required (public repos) |
 | Rate limit | Not documented for Hub API reads (distinct from the image-pull rate limit) |
 | Required field | `docker_image = "namespace/repository"` (e.g. `library/node`) |
+| Optional field | `docker_tag = "tag"` — see below |
 
 **Response parsing**: Extract `.results[0].name`. **`ordering=last_updated` (no leading `-`) is NEWEST-first** — verified live; do not "correct" this to `-last_updated`, which is oldest-first and the opposite of what this check needs.
 
 ```nushell
 # Query the most-recently-updated tag for a Docker Hub image
-def get-docker-hub-latest [image: string] -> string {
+def get-docker-hub-latest [image: string]: nothing -> string {
     let url = $"https://hub.docker.com/v2/repositories/($image)/tags?page_size=1&ordering=last_updated"
     let response = http get $url
     let results = ($response.results? | default [])
@@ -175,6 +176,34 @@ let latest = get-docker-hub-latest "library/node"
 **Notes**:
 - Docker Hub tags are not semver in general — this answers "is a newer tag available" (string equality against the most-recently-updated tag name), not "is there a newer semver release"
 - A specific pinned tag that isn't itself version-shaped (e.g. `16-buster-slim`) belongs in `notes`, not `current_version` — `current_version = "unknown"` with `version_constraint = "rolling"` is the schema-compliant way to track it (see `templates/sources.toml`)
+- **claude-skills-225**: the two schema-compliant usages above never produce a transitioning staleness signal for a realistically pinned image. `current_version = "unknown"`/rolling is never compared, so it reports no-pin forever. A version-shaped `current_version` set to the pinned tag (e.g. `"16-buster-slim"`) is compared against the newest tag OVERALL (e.g. `"lts-trixie-slim"`), which never equals a stable pin, so it reports stale forever. Neither state ever changes. Set `docker_tag` (below) when a real drift signal is needed for a specific pin.
+
+### Tracking a specific pinned tag (`docker_tag`)
+
+When `docker_tag` is set, `check-docker-hub-tag` queries the per-tag endpoint for that exact tag and returns its content **digest** instead of the newest tag's name. `current_version` then stores the last-observed digest; a re-push of that tag (a patched base image, a rebuilt binary) changes the digest and correctly reports drift on the next check. An exact-match, unchanged tag correctly reports current. A deleted tag 404s and classifies as `no-releases`, same as every other check_method's dead-feed handling.
+
+| Property | Value |
+|---|---|
+| Endpoint | `https://hub.docker.com/v2/repositories/{namespace}/{repository}/tags/{tag}/` |
+| Auth | None required (public repos) |
+| Required field | `docker_image` (as above) plus `docker_tag = "tag"` (e.g. `16-buster-slim`) |
+
+```nushell
+# Query a specific pinned tag's content digest
+def get-docker-hub-tag-digest [image: string, tag: string]: nothing -> string {
+    let url = $"https://hub.docker.com/v2/repositories/($image)/tags/($tag)/"
+    let response = http get $url
+    $response | get -o digest | default "unknown"
+}
+
+# Example
+let latest = get-docker-hub-tag-digest "library/node" "24-alpine"
+# Returns: "sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43" (verified live 2026-08-04)
+```
+
+**Notes**:
+- `current_version` for a `docker_tag`-tracked source stores a digest string (e.g. `"sha256:..."`), not a semver-shaped version — `version_constraint = "rolling"` still applies, since the tag itself has no discrete version progression, only content churn
+- This answers "has this exact tag's content changed since I last checked", a narrower and different question from "is a newer version available" — appropriate for a deliberately pinned, non-version-shaped tag where that is the only meaningful drift signal available
 
 ---
 
@@ -193,7 +222,7 @@ Queries endoflife.date's per-product release-cycle feed for the newest cycle's l
 
 ```nushell
 # Query the newest release cycle's latest patch version
-def get-endoflife-latest [product: string] -> string {
+def get-endoflife-latest [product: string]: nothing -> string {
     let url = $"https://endoflife.date/api/($product).json"
     let cycles = (http get $url | default [])
     if ($cycles | is-empty) { "unknown" } else { $cycles | first | get -o latest | default "unknown" }
@@ -205,8 +234,44 @@ let latest = get-endoflife-latest "nodejs"
 ```
 
 **Notes**:
-- Reports the newest cycle's latest patch UNCONDITIONALLY, even when that cycle is itself past its own `eol` date (a fully-EOL product like `centos` still returns its last cycle's last patch). This matches every other check_method here — none of them filter by "is this still supported", only "is a newer version available to pin". A future caller wanting "is this product line still supported" would build that as a separate check against each cycle's `eol` field, not fold it into this one
+- Reports the newest cycle's latest patch UNCONDITIONALLY, even when that cycle is itself past its own `eol` date (a fully-EOL product like `centos` still returns its last cycle's last patch). This matches every other check_method here — none of them filter by "is this still supported", only "is a newer version available to pin"
 - The product slug must match endoflife.date's URL scheme exactly (check the product's page URL, e.g. `endoflife.date/nodejs` → `nodejs`)
+
+### EOL sentinel (`check-endoflife-status`)
+
+**claude-skills-226**: the plain `get-endoflife-latest` above confidently reports an EOL version as "latest" — verified live: `centos` returns `"8 (2111)"` with no signal that cycle 8 has been end-of-life since 2021-12-31. `check-endoflife-status` (in `sources-lib.nu`) is the separate, explicit check named as future work above: it makes the SAME network call and additionally surfaces the newest cycle's own `eol` field as a tri-state (`true` / `false` / `"unknown"` when the date string fails to parse), plus the cycle identifier.
+
+```nushell
+# Query the newest cycle's latest patch AND whether that cycle is EOL
+def get-endoflife-status [product: string]: nothing -> record<latest: string, eol: any, cycle: string> {
+    let url = $"https://endoflife.date/api/($product).json"
+    let cycles = (http get $url | default [])
+    if ($cycles | is-empty) {
+        {latest: "unknown", eol: "unknown", cycle: "unknown"}
+    } else {
+        let newest = ($cycles | first)
+        let eol_val = ($newest.eol? | default false)
+        let is_eol = if ($eol_val | describe) == "bool" {
+            $eol_val
+        } else if ($eol_val | describe) == "string" and ($eol_val | is-not-empty) {
+            try { ($eol_val | into datetime) < (date now) } catch { "unknown" }
+        } else {
+            false
+        }
+        {latest: ($newest | get -o latest | default "unknown"), eol: $is_eol, cycle: ($newest | get -o cycle | default "unknown" | into string)}
+    }
+}
+
+# Example
+get-endoflife-status "centos"
+# Returns: {latest: "8 (2111)", eol: true, cycle: "8"} (verified live 2026-08-04)
+get-endoflife-status "nodejs"
+# Returns: {latest: "26.6.0", eol: false, cycle: "26"} (verified live 2026-08-04)
+```
+
+**Notes**:
+- `check-endoflife-date` (the plain string-returning check used by `fetch-latest`/`classify-staleness`) is unchanged and delegates to `check-endoflife-status` internally — one network call serves both
+- Use `check-endoflife-status` directly when the EOL sentinel is needed; it is not wired into `mise sources:check`/`sources-report`/`sources-stale`'s output columns — those scripts still report only the plain staleness signal. Surfacing EOL status in the report output is a separate change to those three scripts, out of scope here
 
 ---
 

--- a/plugins/tools/claude-code/skills/skill-update/scripts/fence-freshness.nu
+++ b/plugins/tools/claude-code/skills/skill-update/scripts/fence-freshness.nu
@@ -32,8 +32,18 @@
 # target has been deleted upstream still produces code that cannot run,
 # which is exactly the failure mode this tool exists to catch regardless of
 # intent.
+#
+# claude-skills-229: the report above answers "does this exist" and "is it
+# EOL" but never "how far behind is it" — a reader had no way to see
+# currency at all, even as context. Each row now also prints an
+# INFORMATIONAL `latest=` line (github-releases and docker-hub only; other
+# check_methods have nothing automated to fetch) sourced from
+# sources-lib.nu's already-self-tested check-github-releases/check-docker-hub.
+# This is deliberately NOT a policy reversal — "in-support-but-not-latest"
+# still never joins needs_fix — only a presentational gap being closed. The
+# `ok` badge is also renamed to `exists`, which is what it actually asserts.
 
-use sources-lib.nu [catch-http-error]
+use sources-lib.nu [catch-http-error, check-github-releases, check-docker-hub]
 
 const USER_AGENT = "claude-skills-fence-freshness/1.0 (github.com/vinnie357/claude-skills)"
 
@@ -152,6 +162,28 @@ export def check-eol-status [product: string, cycle: string]: nothing -> record 
     }
 }
 
+# ---- latest-vs-pinned (informational only; claude-skills-229) --------------
+
+# What's newest available upstream for this literal's check_method, reusing
+# sources-lib.nu's own already-self-tested check-* functions rather than
+# re-implementing the lookup. "manual" for check_method=manual (nothing
+# automated to fetch), matching the existing convention for `exists`/`eol`
+# on manual entries.
+#
+# claude-skills-229: this is INFORMATIONAL, not a finding — it answers "how
+# far behind is this pin", the question classify-fence-status deliberately
+# does NOT answer (an in-support-but-not-latest pin is not flagged; see the
+# module docstring above). Never fed into classify-fence-status or the
+# needs_fix list.
+def get-latest-for-literal [entry: record]: nothing -> string {
+    let check_method = ($entry.check_method? | default "manual")
+    match $check_method {
+        "github-releases" => (check-github-releases ($entry.github_repo? | default ""))
+        "docker-hub" => (check-docker-hub ($entry.docker_image? | default ""))
+        _ => "manual"
+    }
+}
+
 # ---- report row assembly ----------------------------------------------------
 
 def check-one-literal [entry: record] {
@@ -171,6 +203,7 @@ def check-one-literal [entry: record] {
 
     let policy = ($entry.policy? | default "track")
     let status = classify-fence-status $policy $existence.exists $eol.is_eol
+    let latest = get-latest-for-literal $entry
 
     {
         file: $entry.file
@@ -182,6 +215,7 @@ def check-one-literal [entry: record] {
         eol_detail: $eol.detail
         policy: $policy
         status: $status
+        latest: $latest
         notes: ($entry.notes? | default "")
     }
 }
@@ -275,8 +309,13 @@ def main [--self-test] {
     # terminal. One line per literal keeps every field visible.
     print ""
     for r in $rows {
+        # claude-skills-229: "ok" renamed to "exists" — that is what this
+        # badge actually asserts (the pin resolves and isn't EOL), not that
+        # it is the newest available. The `latest=` line below is the
+        # informational answer to "how far behind", printed separately so
+        # it can never be mistaken for a finding.
         let badge = match $r.status {
-            "ok" => "🟢 ok"
+            "ok" => "🟢 exists"
             "eol" => "🔴 EOL"
             "broken" => "⚫ broken"
             "intentional-pin" => "🔵 intentional-pin"
@@ -285,6 +324,9 @@ def main [--self-test] {
         }
         print $"($badge)  ($r.file) :: ($r.literal)"
         print $"       exists=($r.exists) \(($r.exists_detail)\)  eol=($r.eol) \(($r.eol_detail)\)"
+        if $r.latest != "manual" {
+            print $"       latest=($r.latest)  \(informational — not a finding\)"
+        }
     }
 
     let needs_fix = ($rows | where {|r| $r.status in ["broken" "eol"]})

--- a/plugins/tools/claude-code/skills/skill-update/scripts/sources-lib.nu
+++ b/plugins/tools/claude-code/skills/skill-update/scripts/sources-lib.nu
@@ -269,14 +269,113 @@ export def check-docker-hub [image: string] {
     }
 }
 
+# Parse a Docker Hub per-tag response (the /tags/{tag}/ endpoint, not the
+# tags-list endpoint) into that tag's content digest. Pure, self-tested
+# below against a captured response fixture.
+export def parse-docker-hub-tag-digest [response: record]: nothing -> string {
+    $response | get -o digest | default "unknown"
+}
+
+# Check whether a SPECIFIC pinned Docker Hub tag's content has changed,
+# via the per-tag endpoint (claude-skills-225). `image` is
+# "namespace/repository" (e.g. "library/node"), `tag` is the exact pinned
+# tag (e.g. "16-buster-slim").
+#
+# claude-skills-225: check-docker-hub above compares the NEWEST tag's NAME
+# against current_version, which is degenerate for a realistically pinned
+# image — current_version="unknown"/rolling (the schema's own prescribed
+# usage) never transitions because "unknown" is never compared, and a
+# version-shaped pin never transitions either because the newest tag on a
+# high-churn alias (e.g. "lts-trixie-slim") never equals a stable pin like
+# "16-buster-slim". Neither state can report drift.
+#
+# This function answers a different, narrower, but genuinely answerable
+# question instead: has THIS exact tag been re-pushed since I last checked?
+# Docker Hub's per-tag `digest` is a content hash of the tag's current
+# manifest — verified live (2026-08-04) that /tags/{tag}/ returns a `digest`
+# field distinct from `name`. Comparing the last-observed digest
+# (current_version) against a freshly-fetched digest (latest) via the
+# existing classify-staleness equality check transitions correctly in both
+# directions: unchanged tag -> same digest -> "no"; re-pushed tag (patched
+# base image, rebuilt binary, etc.) -> different digest -> "yes". A deleted
+# tag 404s and is classified "no-releases" by the existing
+# catch-http-error path, same as every other check_method.
+#
+# Used by fetch-latest when a source sets the optional `docker_tag` field
+# (see templates/sources.toml); check-docker-hub above remains the
+# behavior when `docker_tag` is absent, unchanged for backward
+# compatibility.
+export def check-docker-hub-tag [image: string, tag: string]: nothing -> string {
+    let url = $"https://hub.docker.com/v2/repositories/($image)/tags/($tag)/"
+    try {
+        let response = http get $url
+        parse-docker-hub-tag-digest $response
+    } catch {|err|
+        catch-http-error $err
+    }
+}
+
+# Parse one endoflife.date release-cycle record's own `eol` field into a
+# tri-state: true (past EOL), false (not EOL / no EOL date set), or
+# "unknown" (an eol date string that fails to parse). Pure, self-tested
+# below against captured cycle fixtures (centos "8" — a past ISO date — and
+# nodejs "26" — a future ISO date).
+#
+# endoflife.date renders `eol` as either a boolean `false` (no EOL date
+# scheduled) or an ISO date string (past or future) — verified against both
+# the centos and nodejs feeds (2026-08-04). A boolean `true` would be
+# unusual but is handled the same way fence-freshness.nu's check-eol-status
+# already handles it, for consistency between the two EOL-parsing call
+# sites.
+export def parse-endoflife-cycle-eol [cycle: record]: nothing -> any {
+    let eol_val = ($cycle.eol? | default false)
+    if ($eol_val | describe) == "bool" {
+        $eol_val
+    } else if ($eol_val | describe) == "string" and ($eol_val | is-not-empty) {
+        try { ($eol_val | into datetime) < (date now) } catch { "unknown" }
+    } else {
+        false
+    }
+}
+
+# Parse an endoflife.date product-cycles response into the newest cycle's
+# latest-version string, its own eol state, and its cycle identifier. Pure,
+# self-tested below against captured response fixtures.
+export def parse-endoflife-status [cycles: list]: nothing -> record<latest: string, eol: any, cycle: string> {
+    let c = ($cycles | default [])
+    if ($c | is-empty) {
+        {latest: "unknown", eol: "unknown", cycle: "unknown"}
+    } else {
+        let newest = ($c | first)
+        {
+            latest: ($newest | get -o latest | default "unknown"),
+            eol: (parse-endoflife-cycle-eol $newest),
+            cycle: ($newest | get -o cycle | default "unknown" | into string)
+        }
+    }
+}
+
 # Parse an endoflife.date product-cycles response into a latest-version
 # string. Pure, self-tested below against a captured response fixture.
 export def parse-endoflife-latest [cycles: list]: nothing -> string {
-    let c = ($cycles | default [])
-    if ($c | is-empty) {
-        "unknown"
-    } else {
-        $c | first | get -o latest | default "unknown"
+    (parse-endoflife-status $cycles).latest
+}
+
+# Check the newest release cycle's latest patch version AND whether that
+# cycle is itself past its own end-of-life date (claude-skills-226).
+# `product` is the endoflife.date product slug (e.g. "nodejs"). One network
+# call serves both check-endoflife-date (below, unchanged string contract)
+# and any caller that wants the EOL sentinel — verified empirically against
+# the real nodejs.json (not EOL) and centos.json (EOL, confirming the exact
+# behavior claude-skills-226 reported: "8 (2111)" with eol=true) feeds
+# (2026-08-04).
+export def check-endoflife-status [product: string]: nothing -> record<latest: string, eol: any, cycle: string> {
+    let url = $"https://endoflife.date/api/($product).json"
+    try {
+        let response = http get $url
+        parse-endoflife-status $response
+    } catch {|err|
+        {latest: (catch-http-error $err), eol: "unknown", cycle: "unknown"}
     }
 }
 
@@ -286,25 +385,22 @@ export def parse-endoflife-latest [cycles: list]: nothing -> string {
 # that cycle's newest patch version — verified empirically against the real
 # nodejs.json feed (2026-08-04).
 #
-# Deliberate scope decision (Gate 3): this reports the newest cycle's latest
-# patch UNCONDITIONALLY, even when that cycle is itself past its own `eol`
-# date (e.g. a fully-EOL product like centos still returns its last cycle's
-# last patch as "latest"). Every other check_method in this file has the
-# same shape — github-releases reports the newest tag whether or not the
-# repo is archived, hex-pm/crates-io report the newest publish whether or
-# not the maintainer still supports it. This check_method answers "is a
-# newer version available to pin", the same question the others answer, not
-# "is this product line still supported" — endoflife.date's `eol` field
-# would let a future caller build the latter as a separate, explicit check,
-# but that is a different question from staleness and out of scope here.
+# Deliberate scope decision (Gate 3, carried forward by claude-skills-226):
+# this reports the newest cycle's latest patch UNCONDITIONALLY, even when
+# that cycle is itself past its own `eol` date (e.g. a fully-EOL product
+# like centos still returns its last cycle's last patch as "latest"). Every
+# other check_method in this file has the same shape — github-releases
+# reports the newest tag whether or not the repo is archived, hex-pm/
+# crates-io report the newest publish whether or not the maintainer still
+# supports it. This check_method answers "is a newer version available to
+# pin", the same question the others answer, not "is this product line
+# still supported". claude-skills-226 added check-endoflife-status above as
+# the separate, explicit EOL check this comment used to say was future
+# work — call that function instead when the EOL sentinel is needed; this
+# function's string-only contract stays unchanged for fetch-latest/
+# classify-staleness callers.
 export def check-endoflife-date [product: string] {
-    let url = $"https://endoflife.date/api/($product).json"
-    try {
-        let response = http get $url
-        parse-endoflife-latest $response
-    } catch {|err|
-        catch-http-error $err
-    }
+    (check-endoflife-status $product).latest
 }
 
 # Dispatch version check by method
@@ -329,7 +425,14 @@ export def fetch-latest [source: record] {
         }
         "docker-hub" => {
             let image = $source.docker_image? | default ""
-            if ($image | is-empty) { "error" } else { check-docker-hub $image }
+            let tag = $source.docker_tag? | default ""
+            if ($image | is-empty) {
+                "error"
+            } else if ($tag | is-not-empty) {
+                check-docker-hub-tag $image $tag
+            } else {
+                check-docker-hub $image
+            }
         }
         "endoflife-date" => {
             let product = $source.eol_product? | default ""
@@ -448,6 +551,11 @@ export def run-self-test []: nothing -> record<failed: bool, count: int> {
         {label: "docker-hub: empty results falls through to unknown" fn: "docker-hub" input: {count: 0 results: []} want: "unknown"}
         {label: "endoflife-date: newest cycle's latest extracted from a real-shaped response" fn: "endoflife-date" input: [{cycle: "26" latest: "26.6.0" eol: "2029-04-30"} {cycle: "25" latest: "25.9.0" eol: "2026-06-01"}] want: "26.6.0"}
         {label: "endoflife-date: empty cycles list falls through to unknown" fn: "endoflife-date" input: [] want: "unknown"}
+        # claude-skills-225: fixture shaped from the real per-tag response
+        # captured live against hub.docker.com/v2/repositories/library/node/
+        # tags/24-alpine/ (2026-08-04).
+        {label: "docker-hub-tag-digest: digest extracted from a real per-tag response" fn: "docker-hub-tag-digest" input: {name: "24-alpine" last_updated: "2026-08-03T23:38:54.128466Z" digest: "sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43"} want: "sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43"}
+        {label: "docker-hub-tag-digest: missing digest field falls through to unknown" fn: "docker-hub-tag-digest" input: {name: "24-alpine"} want: "unknown"}
     ]
     for c in $parse_cases {
         $count += 1
@@ -455,9 +563,46 @@ export def run-self-test []: nothing -> record<failed: bool, count: int> {
             "npm" => (parse-npm-latest $c.input)
             "docker-hub" => (parse-docker-hub-latest $c.input)
             "endoflife-date" => (parse-endoflife-latest $c.input)
+            "docker-hub-tag-digest" => (parse-docker-hub-tag-digest $c.input)
         }
         if $got != $c.want {
             print $"(ansi red_bold)❌ ($c.fn) parse: ($c.label): want ($c.want), got ($got)(ansi reset)"
+            $failed = true
+        }
+    }
+
+    # claude-skills-226: parse-endoflife-cycle-eol / parse-endoflife-status
+    # fixtures shaped from CAPTURED real responses (endoflife.date/api/
+    # centos.json's cycle "8" — a fully-EOL product, matching the exact bug
+    # report: "8 (2111)" reported with no EOL sentinel — and
+    # endoflife.date/api/nodejs.json's cycle "26" — not EOL — both captured
+    # 2026-08-04), not invented shapes.
+    let eol_cycle_cases = [
+        {label: "centos cycle 8: past ISO eol date classifies as EOL" cycle: {cycle: "8" eol: "2021-12-31" latest: "8 (2111)"} want: true}
+        {label: "nodejs cycle 26: future ISO eol date classifies as not EOL" cycle: {cycle: "26" eol: "2029-04-30" latest: "26.6.0"} want: false}
+        {label: "boolean eol=false classifies as not EOL" cycle: {cycle: "x" eol: false latest: "1.0.0"} want: false}
+        {label: "boolean eol=true classifies as EOL" cycle: {cycle: "x" eol: true latest: "1.0.0"} want: true}
+        {label: "unparseable eol string classifies as unknown, not a crash" cycle: {cycle: "x" eol: "not-a-date" latest: "1.0.0"} want: "unknown"}
+    ]
+    for c in $eol_cycle_cases {
+        $count += 1
+        let got = parse-endoflife-cycle-eol $c.cycle
+        if $got != $c.want {
+            print $"(ansi red_bold)❌ parse-endoflife-cycle-eol: ($c.label): want ($c.want), got ($got)(ansi reset)"
+            $failed = true
+        }
+    }
+
+    let eol_status_cases = [
+        {label: "centos: fully-EOL product surfaces eol=true alongside latest (the exact claude-skills-226 report)" cycles: [{cycle: "8" eol: "2021-12-31" latest: "8 (2111)"} {cycle: "7" eol: "2024-06-30" latest: "7 (2009)"}] want: {latest: "8 (2111)" eol: true cycle: "8"}}
+        {label: "nodejs: supported product surfaces eol=false" cycles: [{cycle: "26" eol: "2029-04-30" latest: "26.6.0"}] want: {latest: "26.6.0" eol: false cycle: "26"}}
+        {label: "empty cycles list is unknown across all three fields" cycles: [] want: {latest: "unknown" eol: "unknown" cycle: "unknown"}}
+    ]
+    for c in $eol_status_cases {
+        $count += 1
+        let got = parse-endoflife-status $c.cycles
+        if $got != $c.want {
+            print $"(ansi red_bold)❌ parse-endoflife-status: ($c.label): want ($c.want), got ($got)(ansi reset)"
             $failed = true
         }
     }
@@ -472,6 +617,7 @@ export def run-self-test []: nothing -> record<failed: bool, count: int> {
         {label: "crates-io with empty crate_name returns error" source: {check_method: "crates-io"} want: "error"}
         {label: "npm with empty npm_package returns error" source: {check_method: "npm"} want: "error"}
         {label: "docker-hub with empty docker_image returns error" source: {check_method: "docker-hub"} want: "error"}
+        {label: "docker-hub with docker_tag set but docker_image empty still returns error before touching the network" source: {check_method: "docker-hub" docker_image: "" docker_tag: "16-buster-slim"} want: "error"}
         {label: "endoflife-date with empty eol_product returns error" source: {check_method: "endoflife-date"} want: "error"}
         {label: "manual never calls the network" source: {check_method: "manual"} want: "manual"}
         {label: "none is always internal" source: {check_method: "none"} want: "internal"}

--- a/plugins/tools/claude-code/skills/skill-update/templates/sources.toml
+++ b/plugins/tools/claude-code/skills/skill-update/templates/sources.toml
@@ -47,6 +47,10 @@ check_method = "manual"
 # crate_name = "crate"          # REQUIRED iff check_method = "crates-io"
 # npm_package = "package"       # REQUIRED iff check_method = "npm" ("@scope/name" ok)
 # docker_image = "ns/repo"      # REQUIRED iff check_method = "docker-hub" (e.g. "library/node")
+# docker_tag = "tag"            # OPTIONAL, check_method = "docker-hub" only. When set, compares
+#                                # a specific pinned tag's content digest instead of the newest
+#                                # tag's name (claude-skills-225) — see the docker-hub examples
+#                                # below for when to use each.
 # eol_product = "product"       # REQUIRED iff check_method = "endoflife-date" (e.g. "nodejs")
 
 # The upstream version this skill's content was last verified or documented
@@ -148,6 +152,9 @@ notes = ""
 # "rolling" is the schema-compliant way to track it. check-docker-hub
 # reports "is a newer tag available" (equality against the most-recently-
 # updated tag name), not "is there a newer semver release."
+#
+# claude-skills-225: this usage never transitions (see docker_tag example
+# below for a source that actually reports drift for a specific pin).
 # ----------------------------------------------------------------------------
 # [[sources]]
 # skills = ["act"]
@@ -160,6 +167,27 @@ notes = ""
 # last_checked = "2026-08-04"
 # update_priority = "low"
 # notes = "skill content pins node:16-buster-slim; check for a newer tag manually against the pinned major"
+
+# ----------------------------------------------------------------------------
+# Example: Docker Hub image tag with drift detection (claude-skills-225).
+# Setting docker_tag switches the check to the per-tag endpoint, comparing
+# the pinned tag's content DIGEST instead of the newest tag's name — this
+# actually transitions when the pinned tag is re-pushed (patched base
+# image, rebuilt binary). current_version stores the last-observed digest,
+# not a version string.
+# ----------------------------------------------------------------------------
+# [[sources]]
+# skills = ["act"]
+# name = "node-docker-image-pinned"
+# url = "https://hub.docker.com/_/node"
+# check_method = "docker-hub"
+# docker_image = "library/node"
+# docker_tag = "24-alpine"
+# current_version = "sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43"
+# version_constraint = "rolling"
+# last_checked = "2026-08-04"
+# update_priority = "low"
+# notes = "skill content pins node:24-alpine; drift means the tag was re-pushed since last_checked"
 
 # ----------------------------------------------------------------------------
 # Example: endoflife.date product (claude-skills-210). Reports the newest

--- a/test/validate-sources.nu
+++ b/test/validate-sources.nu
@@ -70,6 +70,19 @@ const SEMVER_RE = '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'
 # rejected — see SKILL.md's field table for the reasoning.
 const VERSION_SHAPE_RE = '^[A-Za-z]{0,10}[-.]?\d+((\.\d+){1,4}([-+][0-9A-Za-z.-]+)?|([-+][0-9A-Za-z.]+)?)$'
 
+# claude-skills-225 F1: check-docker-hub-tag (sources-lib.nu) records
+# current_version as a Docker Hub content digest, not a version string, when
+# a source sets docker_tag — the digest-comparator usage this constant's
+# comment used to claim (falsely) VERSION_SHAPE_RE "never applies to". A
+# `sha256:<64 hex>` value can never match VERSION_SHAPE_RE (the colon isn't
+# in its alphabet), so b3_version_shape rejected the ONLY value the digest
+# comparator can legitimately write — the feature was adoptable at the
+# library level but not through this validator. Scoped to `docker_tag`
+# entries specifically (rather than widening VERSION_SHAPE_RE itself) so a
+# `sha256:...`-shaped typo under a non-docker_tag check_method still fails
+# loudly instead of silently passing as a coincidental digest.
+const DOCKER_DIGEST_RE = '^sha256:[0-9a-f]{64}$'
+
 # Returns [{rule, severity, message}] for ONE plugin. severity is "fail" or
 # "info"; main exits 1 only on "fail". Pure: no filesystem, no network —
 # every input is an argument, so the self-test feeds literal TOML through
@@ -420,11 +433,13 @@ def check-sources [
                         message: $"($plugin)/($name): current_version is a ($raw_t), expected a QUOTED version string or 'unknown' — an unquoted numeric records a different value \(1.10 becomes 1.1\)"
                     })
                 } else if not ($entry.current_version == "unknown"
-                               or ($entry.current_version =~ $VERSION_SHAPE_RE)) {
+                               or ($entry.current_version =~ $VERSION_SHAPE_RE)
+                               or (($entry.docker_tag? | default "" | is-not-empty)
+                                   and ($entry.current_version =~ $DOCKER_DIGEST_RE))) {
                     $findings = ($findings | append {
                         rule: "b3_version_shape"
                         severity: "fail"
-                        message: $"($plugin)/($name): current_version '($entry.current_version)' is neither a recognizable version string nor 'unknown'"
+                        message: $"($plugin)/($name): current_version '($entry.current_version)' is neither a recognizable version string, a docker_tag content digest, nor 'unknown'"
                     })
                 }
             }
@@ -1473,10 +1488,9 @@ notes = "pinned tag tracked in skill content is node:16-buster-slim; Docker Hub 
             # claude-skills-225: docker_tag is an OPTIONAL key (not in
             # ENTRY_REQUIRED_ALWAYS, not in ENTRY_NETWORK_KEYS, no
             # conditional-required rule) — only needs to be a known key so
-            # b1_entry_unknown doesn't reject it. current_version here is a
-            # digest, not a version string, which is why version_constraint
-            # stays "rolling" (VERSION_SHAPE_RE never applies to docker-hub's
-            # digest-comparator usage, same as the plain-tag usage above).
+            # b1_entry_unknown doesn't reject it. current_version here is
+            # "unknown", the same schema-compliant placeholder any other
+            # check_method accepts before a first real check has run.
             label: "docker-hub entry with docker_tag is a known key, not an error"
             toml: '
 [meta]
@@ -1501,6 +1515,75 @@ notes = "digest-tracked pin"
             version: "1.0.0"
             md: "demo-source is documented here"
             want: []
+        }
+        {
+            # F1 (claude-skills-225 Gate 3 follow-up): a docker_tag source's
+            # current_version is a Docker Hub content digest — NOT a version
+            # string — once check-docker-hub-tag has recorded a real reading.
+            # Corrected claim: VERSION_SHAPE_RE does NOT special-case
+            # docker-hub at all (see validate-sources.nu:402-430 — the rule
+            # applies unconditionally, digest or not); this test proves the
+            # digest passes because b3_version_shape now also accepts
+            # DOCKER_DIGEST_RE, scoped to entries with docker_tag set. The
+            # digest below is the live value captured for library/node's
+            # 24-alpine tag (2026-08-04), matching templates/sources.toml's
+            # worked example byte-for-byte — a colon-bearing "sha256:..."
+            # value can never match VERSION_SHAPE_RE, so before this fix no
+            # value an author could write for a docker_tag entry passed once
+            # a real digest was recorded.
+            label: "docker-hub entry with docker_tag and a real digest current_version passes"
+            toml: '
+[meta]
+plugin = "demo"
+reviewed_at_plugin_version = "1.0.0"
+last_full_check = "2026-01-01"
+[[sources]]
+skills = ["a"]
+name = "demo-source"
+url = "https://hub.docker.com/_/node"
+check_method = "docker-hub"
+docker_image = "library/node"
+docker_tag = "24-alpine"
+current_version = "sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43"
+version_constraint = "rolling"
+last_checked = "2026-08-04"
+update_priority = "low"
+notes = "digest-tracked pin"
+'
+            dirs: ["a"]
+            plugin: "demo"
+            version: "1.0.0"
+            md: "demo-source is documented here"
+            want: []
+        }
+        {
+            # F1: the digest carve-out is scoped to docker_tag entries —
+            # a sha256:-shaped current_version WITHOUT docker_tag set is
+            # still rejected, so a typo under a non-digest check_method
+            # fails loudly instead of silently passing as a coincidental
+            # digest match.
+            label: "sha256-shaped current_version without docker_tag still fails b3_version_shape"
+            toml: '
+[meta]
+plugin = "demo"
+reviewed_at_plugin_version = "1.0.0"
+last_full_check = "2026-01-01"
+[[sources]]
+skills = ["a"]
+name = "demo-source"
+url = "https://hub.docker.com/_/node"
+check_method = "docker-hub"
+docker_image = "library/node"
+current_version = "sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43"
+version_constraint = "rolling"
+last_checked = "2026-08-04"
+update_priority = "low"
+'
+            dirs: ["a"]
+            plugin: "demo"
+            version: "1.0.0"
+            md: "demo-source is documented here"
+            want: ["b3_version_shape"]
         }
         {
             # claude-skills-210: endoflife.date requires eol_product (the

--- a/test/validate-sources.nu
+++ b/test/validate-sources.nu
@@ -25,7 +25,7 @@ const META_KEYS = ["plugin" "reviewed_at_plugin_version" "last_full_check"]
 const ENTRY_KEYS = [
     "skills" "name" "url" "releases_url" "check_method"
     "github_repo" "hex_package" "crate_name"
-    "npm_package" "docker_image" "eol_product"
+    "npm_package" "docker_image" "docker_tag" "eol_product"
     "current_version" "version_constraint" "last_checked"
     "update_priority" "breaking_changes_likely" "notes"
 ]
@@ -1462,6 +1462,39 @@ version_constraint = "rolling"
 last_checked = "2026-01-01"
 update_priority = "medium"
 notes = "pinned tag tracked in skill content is node:16-buster-slim; Docker Hub tags are not semver-shaped so no discrete current_version is recorded here"
+'
+            dirs: ["a"]
+            plugin: "demo"
+            version: "1.0.0"
+            md: "demo-source is documented here"
+            want: []
+        }
+        {
+            # claude-skills-225: docker_tag is an OPTIONAL key (not in
+            # ENTRY_REQUIRED_ALWAYS, not in ENTRY_NETWORK_KEYS, no
+            # conditional-required rule) — only needs to be a known key so
+            # b1_entry_unknown doesn't reject it. current_version here is a
+            # digest, not a version string, which is why version_constraint
+            # stays "rolling" (VERSION_SHAPE_RE never applies to docker-hub's
+            # digest-comparator usage, same as the plain-tag usage above).
+            label: "docker-hub entry with docker_tag is a known key, not an error"
+            toml: '
+[meta]
+plugin = "demo"
+reviewed_at_plugin_version = "1.0.0"
+last_full_check = "2026-01-01"
+[[sources]]
+skills = ["a"]
+name = "demo-source"
+url = "https://hub.docker.com/_/node"
+check_method = "docker-hub"
+docker_image = "library/node"
+docker_tag = "24-alpine"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-01-01"
+update_priority = "medium"
+notes = "digest-tracked pin"
 '
             dirs: ["a"]
             plugin: "demo"


### PR DESCRIPTION
- fix six worked nushell examples in version-check-methods.md that used a `[args] -> type` signature — does not parse on nu 0.113.1, needs `[args]: input -> type` (claude-skills-227); repo-wide sweep found no other instances
- add an optional `docker_tag` field: `check-docker-hub-tag` compares a specific pinned tag's content digest instead of the newest tag overall, which transitions correctly for a realistically pinned image (claude-skills-225)
- add `check-endoflife-status` alongside the unchanged `check-endoflife-date`: surfaces the newest cycle's own `eol` field so a fully-EOL product (e.g. centos) no longer reports its last patch as "latest" with no sentinel (claude-skills-226)
- add an informational `latest=` line to `fence-freshness.nu`'s report (github-releases and docker-hub only), importing and using `check-github-releases`/`check-docker-hub`; rename the `ok` badge to `exists` (claude-skills-229). Note: `check-github-releases` was not actually a dead import on current main — only `catch-http-error` was imported — but it is genuinely wired up and used now regardless
- register `docker_tag` as a known sources.toml key in `test/validate-sources.nu` and document both docker-hub usages in `templates/sources.toml`