### PR TITLE
fix(claude-code): classify sources-validate-urls errors and fix dead links

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.118",
+      "version": "0.4.119",
       "category": "meta",
       "keywords": [
         "skills",
@@ -119,7 +119,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
-      "version": "0.2.58",
+      "version": "0.2.59",
       "category": "tools",
       "keywords": [
         "claude-code",
@@ -143,7 +143,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
-      "version": "0.2.56",
+      "version": "0.2.57",
       "category": "development",
       "keywords": [
         "git",
@@ -433,7 +433,7 @@
       "source": "./plugins/tools/slidev",
       "strict": true,
       "description": "Slidev presentation skills: strategy, branding, interactive demos, markdown slides, syntax, code blocks, export, and troubleshooting",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "category": "tools",
       "keywords": [
         "slidev",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.118",
+  "version": "0.4.119",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -707,7 +707,7 @@ Install the plugin to build your own plugins:
 - **Agent Skills Blog Post**: https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills
 - **Building Skills Guide (PDF)**: https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf
 - **Improving Skill Creator Blog**: https://claude.com/blog/improving-skill-creator-test-measure-and-refine-agent-skills
-- **Agent Skills Specification**: https://github.com/anthropics/skills/blob/main/agent_skills_spec.md
+- **Agent Skills Specification**: https://agentskills.io/specification
 - **Claude Code Plugins**: https://code.claude.com/docs/en/plugins
 - **Plugin Marketplaces**: https://code.claude.com/docs/en/plugin-marketplaces
 

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ You can contribute skills to existing plugins or create new ones:
 
 4. Document sources in the plugin's `skills/sources.md`
 
-See the [Agent Skills Specification](https://github.com/anthropics/skills/blob/main/agent_skills_spec.md) for complete guidelines.
+See the [Agent Skills Specification](https://agentskills.io/specification) for complete guidelines.
 
 ## Plugin Development
 
@@ -620,7 +620,7 @@ MIT License - see [LICENSE](LICENSE) file for details.
 - **Agent Skills Blog Post**: https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills
 - **Building Skills Guide (PDF)**: https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf
 - **Improving Skill Creator Blog**: https://claude.com/blog/improving-skill-creator-test-measure-and-refine-agent-skills
-- **Agent Skills Specification**: https://github.com/anthropics/skills/blob/main/agent_skills_spec.md
+- **Agent Skills Specification**: https://agentskills.io/specification
 - **Claude Code Plugins**: https://code.claude.com/docs/en/plugins
 - **Plugin Marketplaces**: https://code.claude.com/docs/en/plugin-marketplaces
 

--- a/mise.toml
+++ b/mise.toml
@@ -295,6 +295,14 @@ let scripts_dir = ($repo_root | path join "plugins" "tools" "claude-code" "skill
 nu ($scripts_dir | path join "sources-check.nu") --self-test
 nu ($scripts_dir | path join "sources-report.nu") --self-test
 nu ($scripts_dir | path join "sources-stale.nu") --self-test
+nu ($scripts_dir | path join "sources-lib.nu") --self-test
+
+# claude-skills-220: same rationale as the four self-tests above — the URL
+# validator's HEAD/GET checks are live network calls with no place in a
+# credential-less CI run, but its classification logic (404 vs
+# rate-limited vs private-repo vs generic error, plus the 405-GET-fallback
+# decision) is pure and self-tested offline.
+nu ($scripts_dir | path join "sources-validate-urls.nu") --self-test
 """
 
 [tasks."test:security-hook"]

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.56",
+  "version": "0.2.57",
   "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/sources.md
+++ b/plugins/core/skills/sources.md
@@ -253,7 +253,7 @@ Structured tracking: [sources.toml](sources.toml) — versions, check methods, a
 
 ### The Three Laws of TDD
 - **Author**: Robert C. Martin
-- **URL**: https://www.butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd
+- **URL**: http://web.archive.org/web/20260719201717/http://www.butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd
 - **Purpose**: Concise formalization of Beck's TDD constraints into three strict laws
 
 ### Software Craftsmanship Manifesto

--- a/plugins/core/skills/sources.toml
+++ b/plugins/core/skills/sources.toml
@@ -256,14 +256,14 @@ notes = "Steve Freeman & Nat Pryce, 'Growing Object-Oriented Software, Guided by
 [[sources]]
 skills = ["tdd"]
 name = "three-laws-of-tdd"
-url = "https://www.butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd"
+url = "http://web.archive.org/web/20260719201717/http://www.butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd"
 check_method = "manual"
 current_version = "unknown"
 version_constraint = "rolling"
-last_checked = "unknown"
+last_checked = "2026-08-04"
 update_priority = "low"
 breaking_changes_likely = false
-notes = "Robert C. Martin's concise formalization of Beck's TDD constraints into three strict laws. No access date recorded in sources.md."
+notes = "claude-skills-220: butunclebob.com is dead (confirmed 2026-08-04: TCP connection refused, not a transient timeout) — the original wiki host appears to be gone entirely, not just this one page. Repointed to a Wayback Machine snapshot (confirmed 200, 2026-08-04, captured 2026-07-19 while the site was still live) as a durable substitute; no live canonical replacement was found. Robert C. Martin's concise formalization of Beck's TDD constraints into three strict laws."
 
 [[sources]]
 skills = ["tdd"]

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.58",
+  "version": "0.2.59",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/claude-skills/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-skills/SKILL.md
@@ -205,5 +205,5 @@ For more information:
 - **Improving Skill Creator Blog**: https://claude.com/blog/improving-skill-creator-test-measure-and-refine-agent-skills
 - **Example Skills**: https://github.com/anthropics/skills
 - **Skills Cookbook**: https://github.com/anthropics/claude-cookbooks/tree/main/skills
-- **Skill Creator Guide**: https://github.com/anthropics/skills/blob/main/skill-creator/SKILL.md
-- **Agent Skills Specification**: https://github.com/anthropics/skills/blob/main/agent_skills_spec.md
+- **Skill Creator Guide**: https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md
+- **Agent Skills Specification**: https://agentskills.io/specification

--- a/plugins/tools/claude-code/skills/skill-update/scripts/sources-lib.nu
+++ b/plugins/tools/claude-code/skills/skill-update/scripts/sources-lib.nu
@@ -152,7 +152,11 @@ export def sanitize-notes-cell [notes: string, max_len: int]: nothing -> string 
 
 # ---- network boundary -------------------------------------------------
 
-const USER_AGENT = "claude-skills-sources/1.0 (github.com/vinnie357/claude-skills)"
+# claude-skills-220: exported so sources-validate-urls.nu can send the same
+# identity on its HEAD/GET checks instead of nushell's unadorned default
+# (the literal string "nushell" — verified live against httpbin.org/headers,
+# 2026-08-04), which crates.io's API rejects as insufficiently informative.
+export const USER_AGENT = "claude-skills-sources/1.0 (github.com/vinnie357/claude-skills)"
 
 # Check latest version via github-releases API
 export def check-github-releases [repo: string] {

--- a/plugins/tools/claude-code/skills/skill-update/scripts/sources-validate-urls.nu
+++ b/plugins/tools/claude-code/skills/skill-update/scripts/sources-validate-urls.nu
@@ -1,11 +1,150 @@
 #!/usr/bin/env nu
 
 # Validate all source URLs in sources.toml files are accessible
-# Uses HTTP HEAD requests and reports status per URL
+# Uses HTTP HEAD requests (falling back to GET on a 405) and reports a
+# classified status per URL.
 #
 # Usage: nu sources-validate-urls.nu [--plugin <name>]
+#        nu sources-validate-urls.nu --self-test
 #
 # Output: table with columns: plugin | skill | source | url | status | notes
+#
+# claude-skills-220: the summary line used to bucket every non-2xx/3xx result
+# into one undifferentiated "error" count. Two independent agents both read
+# that bucket as "pre-existing crates.io rate limiting" in one session — a
+# wrong inference the tool made easy, because a genuine 404 (a dead link,
+# actionable) and a generic network failure (transient, not actionable) both
+# rendered identically. Root cause: nushell's http client sets $err.msg to a
+# generic "Network failure" for EVERY caught error, including 404s — the
+# specific status text only survives in $err.debug. This mirrors the bug
+# claude-skills-176/212 fixed in sources-lib.nu's classify-fetch-error /
+# catch-http-error, applied there to the check/report/stale path but never to
+# this URL validator. This revision imports that same classification (see
+# the `use sources-lib.nu [...]` below) instead of re-deriving it, and adds
+# three validator-specific concerns sources-lib.nu has no reason to carry: a
+# HEAD-to-GET fallback (some hosts, e.g. m3.material.io, reject HEAD with 405
+# but serve GET fine), a known-private-repo allowlist (an unauthenticated
+# check against a private GitHub repo 404s regardless of whether the content
+# exists — see plugins/tools/runex/skills/sources.toml's own notes for the
+# precedent this mirrors), and a crates.io API cross-check.
+#
+# claude-skills-220 Gate 3 (F1): an earlier revision of this file classified
+# every crates.io/crates/<name> 404 as "dead". That was WRONG, not just
+# imprecise — verified live (2026-08-04) that api.crates.io/api/v1/crates/
+# serde returns 200 with real, current data (`{"name":"serde",
+# "max_version":"1.0.229"}`) via the identical User-Agent, from the identical
+# egress, at the same time the website path 404s. curl reproduces the same
+# split: a bare/empty UA gets a 403 whose body names crates.io's own
+# data-access policy explicitly ("in violation of our API data access
+# policy"), a browser UA gets an empty-body 404 from heroku-router, and
+# WebFetch gets the real SPA shell. That is bot detection reacting to
+# request fingerprints the website tier applies to ALL non-browser clients —
+# not evidence the crate page is gone. A validator that reports "dead" here
+# is reporting its own inability to pass a bot check as if it were upstream
+# link rot, which is exactly the wrong inference this file exists to
+# prevent. check-url below cross-checks any crates.io/crates/<name> 404
+# against the API before finalizing "dead"; a crates.io URL with no crate
+# name to check (crates.io/policies has no API-shaped equivalent — verified
+# crates.io/data-access also 404s the same way) relabels to "blocked"
+# instead, since the host is proven unreliable to automated clients but the
+# validator has no way to confirm content status either way.
+use sources-lib.nu [classify-fetch-error, USER_AGENT]
+
+# Repos where an unauthenticated HTTP check is EXPECTED to 404/403 regardless
+# of whether the linked content exists — GitHub returns 404 (not 403) for a
+# private repo specifically to avoid confirming its existence to an
+# unauthenticated caller. Today's one instance: plugins/tools/runex/skills/
+# sources.toml's own notes field documents this exact behavior for
+# vinnie357/runex (confirmed live via `curl api.github.com/repos/
+# vinnie357/runex` -> 404, unauthenticated). Extend this list if a future
+# sources.toml entry hits the same case — do not infer "private" from a bare
+# 404 alone, that would misclassify every genuinely dead github.com link.
+const KNOWN_PRIVATE_REPOS = ["vinnie357/runex"]
+
+# Pure: does `url` point at (or under) a known-private GitHub repo? Matches
+# the bare repo URL and any path under it (tree/, blob/, releases, etc.) —
+# not a substring match, so "vinnie357/runex-extra" does not collide with
+# "vinnie357/runex".
+export def is-known-private-repo-url [url: string]: nothing -> bool {
+    $KNOWN_PRIVATE_REPOS | any {|repo|
+        let base = $"https://github.com/($repo)"
+        $url == $base or ($url | str starts-with $"($base)/")
+    }
+}
+
+# Pure: does this caught error text indicate the server rejected HEAD with
+# 405 Method Not Allowed? Verified live against nu 0.113.1 hitting
+# m3.material.io (which HEADs 405 but GETs 200): the shape is
+# `Cannot make request to "<url>". Error is "405 Method Not Allowed"` — no
+# parens around the digits, matching the same no-parens shape sources-lib.nu
+# documents for 401/429/500. Matching the literal phrase (not bare "405")
+# avoids the byte-offset-span collision classify-fetch-error's own docs warn
+# about — a Span[...] never contains this phrase.
+export def needs-get-fallback [err_text: string]: nothing -> bool {
+    $err_text | str contains "405 Method Not Allowed"
+}
+
+# Pure: classify a caught HEAD/GET error into a validator-specific status.
+# Delegates the 404/403/429/rate-limit-text pattern matching to
+# sources-lib.nu's classify-fetch-error (proven against real nu 0.113.1
+# error shapes there) and relabels its three outcomes for this URL-existence
+# context, where "no-releases" (a check-latest-version sentinel) doesn't fit:
+#   no-releases  -> dead          (a genuine 404 — actionable link rot)
+#   rate-limited -> rate-limited  (403/429/"rate limit" text — retry later)
+#   error        -> error         (DNS/connection/timeout/other — not a
+#                                   content judgment either way)
+# A "dead" result against a known-private-repo URL is further relabeled
+# "private" — GitHub's documented 404-instead-of-403 behavior for private
+# repos means this specific 404 is expected, not link rot.
+#
+# claude-skills-220 Gate 3 (F1): this function alone is NOT the final word on
+# "dead" for crates.io — see the crates.io API cross-check in check-url
+# below, which can further relabel a "dead" result here to "pass" (confirmed
+# live via the API) or "blocked" (host-known-unreliable from automation,
+# unconfirmed either way). classify-url-error stays pure (no network) and
+# reports what the HTTP layer said; the network-dependent override lives in
+# check-url, the only place in this file allowed to make a second call.
+export def classify-url-error [err_text: string, url: string]: nothing -> string {
+    let base = classify-fetch-error $err_text
+    let mapped = match $base {
+        "no-releases" => "dead"
+        "rate-limited" => "rate-limited"
+        _ => "error"
+    }
+    if $mapped == "dead" and (is-known-private-repo-url $url) {
+        "private"
+    } else {
+        $mapped
+    }
+}
+
+# Pure: extract the crate name from a bare crates.io crate-page URL
+# (`https://crates.io/crates/<name>`), or null if `url` isn't that shape.
+# Scoped deliberately narrow (no trailing slash/subpath) — every current
+# sources.toml entry of this kind uses the bare form; a URL this doesn't
+# match falls through to the is-crates-io-host "blocked" relabel instead of
+# a false-positive crate-name extraction.
+export def crates-io-crate-name [url: string]: nothing -> any {
+    let prefix = "https://crates.io/crates/"
+    if ($url | str starts-with $prefix) {
+        let rest = ($url | str substring ($prefix | str length)..)
+        if ($rest | is-empty) or ($rest | str contains "/") {
+            null
+        } else {
+            $rest
+        }
+    } else {
+        null
+    }
+}
+
+# Pure: is this a crates.io URL at all (crate page, /policies, or anything
+# else on the host)? Used to relabel a "dead" crates.io result that has no
+# crate name to cross-check (e.g. crates.io/policies) as "blocked" rather
+# than "dead" — see the F1 finding below.
+export def is-crates-io-url [url: string]: nothing -> bool {
+    ($url | str starts-with "https://crates.io/") or ($url == "https://crates.io")
+}
 
 # Resolve the repo root relative to this script's location
 def repo-root [] {
@@ -31,54 +170,97 @@ def resolve-plugin-path [repo: string, source: any] {
     }
 }
 
-# Classify HTTP status code into a human-readable status
-def classify-status [code: int] {
-    if $code >= 200 and $code < 300 {
-        "pass"
-    } else if $code >= 300 and $code < 400 {
-        "redirect"
+# Cross-check a "dead" crates.io result before it's final (claude-skills-220
+# Gate 3, F1). Returns an overriding {status, notes} record, or null when no
+# override applies (leaves the caller's original classification alone).
+#   - crate-name URL, API confirms it live -> pass (bypassed the bot-gated
+#     website check)
+#   - crate-name URL, API check ALSO fails -> blocked (still can't confirm,
+#     but crates.io's website tier is proven unreliable to automation, so
+#     "dead" would overstate what we know)
+#   - any other crates.io URL (e.g. /policies, no crate name to check) ->
+#     blocked, same reasoning, no cross-check possible
+def crates-io-dead-override [url: string, headers: list]: nothing -> any {
+    let name = crates-io-crate-name $url
+    if $name != null {
+        let api_url = $"https://crates.io/api/v1/crates/($name)"
+        try {
+            let response = (http get $api_url -H $headers)
+            let live_name = ($response.crate?.name? | default "")
+            if $live_name == $name {
+                {
+                    status: "pass"
+                    notes: $"OK \(crates.io website 404s automated clients; confirmed live via ($api_url)\)"
+                }
+            } else {
+                { status: "blocked", notes: $"crates.io website 404; API cross-check returned an unexpected body from ($api_url)" }
+            }
+        } catch {
+            { status: "blocked", notes: $"crates.io website 404; API cross-check at ($api_url) also failed — cannot confirm either way" }
+        }
+    } else if (is-crates-io-url $url) {
+        { status: "blocked", notes: "crates.io website 404 with no crate name to cross-check via the API (e.g. a policy/docs page) — host is known-unreliable to automated clients, cannot confirm content status" }
     } else {
-        "fail"
+        null
     }
 }
 
-# Perform an HTTP HEAD check on a URL and return a result record
+# Perform an HTTP check on a URL (HEAD first, falling back to GET on a 405)
+# and return a classified result record. Always sends the shared
+# claude-skills User-Agent (sources-lib.nu's $USER_AGENT) — nushell's
+# unadorned default is the literal string "nushell", which some hosts (e.g.
+# crates.io's API) treat as insufficiently informative and reject outright.
 def check-url [plugin: string, skill: string, source_name: string, url: string] {
     if ($url | is-empty) {
         return null
     }
 
-    let result = try {
-        # http head returns headers as a record; a successful return means 2xx
-        http head $url
-        {
-            plugin: $plugin
-            skill:  $skill
-            source: $source_name
-            url:    $url
-            status: "pass"
-            notes:  "OK"
-        }
+    let headers = [User-Agent $USER_AGENT]
+
+    let head_result = try {
+        http head $url -H $headers
+        { ok: true }
     } catch { |err|
-        let msg = $err.msg? | default "request failed"
-        let status = if ($msg | str contains "redirect") {
-            "redirect"
-        } else if ($msg | str contains "404") or ($msg | str contains "not found") {
-            "fail"
-        } else {
-            "error"
+        { ok: false, text: ($err.debug? | default ($err.msg? | default "")) }
+    }
+
+    let result = if $head_result.ok {
+        { status: "pass", notes: "OK" }
+    } else if (needs-get-fallback $head_result.text) {
+        # Some hosts reject HEAD (405) but serve GET fine — retry once
+        # before concluding anything about reachability.
+        try {
+            http get $url -H $headers
+            { status: "pass", notes: "OK (GET fallback after HEAD 405)" }
+        } catch { |err|
+            let get_text = ($err.debug? | default ($err.msg? | default ""))
+            {
+                status: (classify-url-error $get_text $url)
+                notes: ($get_text | str substring 0..80)
+            }
         }
+    } else {
         {
-            plugin: $plugin
-            skill:  $skill
-            source: $source_name
-            url:    $url
-            status: $status
-            notes:  ($msg | str substring 0..80)
+            status: (classify-url-error $head_result.text $url)
+            notes: ($head_result.text | str substring 0..80)
         }
     }
 
-    $result
+    let final_result = if $result.status == "dead" {
+        let override = (crates-io-dead-override $url $headers)
+        if $override != null { $override } else { $result }
+    } else {
+        $result
+    }
+
+    {
+        plugin: $plugin
+        skill:  $skill
+        source: $source_name
+        url:    $url
+        status: $final_result.status
+        notes:  $final_result.notes
+    }
 }
 
 # Process a single sources.toml file and return URL check results
@@ -100,7 +282,7 @@ def process-sources-toml [toml_path: string, plugin_name: string] {
         let releases_url = $src.releases_url? | default ""
 
         if not ($url | is-empty) {
-            print $"  HEAD ($url)"
+            print $"  CHECK ($url)"
             let row = check-url $plugin_name $skill $name $url
             if $row != null {
                 $rows = ($rows | append $row)
@@ -108,7 +290,7 @@ def process-sources-toml [toml_path: string, plugin_name: string] {
         }
 
         if not ($releases_url | is-empty) {
-            print $"  HEAD ($releases_url)"
+            print $"  CHECK ($releases_url)"
             let row = check-url $plugin_name $skill $"($name) [releases]" $releases_url
             if $row != null {
                 $rows = ($rows | append $row)
@@ -119,7 +301,7 @@ def process-sources-toml [toml_path: string, plugin_name: string] {
     $rows
 }
 
-def main [--plugin: string = ""] {
+def run-checks [plugin_filter: string] {
     let repo = repo-root
 
     print $"(ansi cyan_bold)Source URL Validation(ansi reset)"
@@ -129,15 +311,15 @@ def main [--plugin: string = ""] {
     let marketplace = load-marketplace $repo
     let plugins = $marketplace.plugins? | default []
 
-    let filtered = if ($plugin | is-empty) {
+    let filtered = if ($plugin_filter | is-empty) {
         $plugins
     } else {
-        $plugins | where name == $plugin
+        $plugins | where name == $plugin_filter
     }
 
     if ($filtered | is-empty) {
-        if not ($plugin | is-empty) {
-            print $"(ansi red)No plugin found with name: ($plugin)(ansi reset)"
+        if not ($plugin_filter | is-empty) {
+            print $"(ansi red)No plugin found with name: ($plugin_filter)(ansi reset)"
             exit 1
         }
         print $"(ansi yellow)No plugins found in marketplace.(ansi reset)"
@@ -171,16 +353,187 @@ def main [--plugin: string = ""] {
         exit 0
     }
 
-    # Summary counts
-    let total    = $all_rows | length
-    let passing  = $all_rows | where status == "pass"     | length
-    let redirect = $all_rows | where status == "redirect" | length
-    let failing  = $all_rows | where status == "fail"     | length
-    let errors   = $all_rows | where status == "error"    | length
+    # Summary counts — one bucket per classification, so "N error" can no
+    # longer silently absorb dead links, rate-limiting, and expected-private
+    # 404s into one homogeneous number (claude-skills-220). "blocked" (F1,
+    # Gate 3) is distinct from "dead": a dead crates.io result that survived
+    # the API cross-check (or had no crate name to cross-check) — host known
+    # to bot-gate automated clients, content status genuinely unconfirmed
+    # either way, so it must not read as actionable link rot the way "dead"
+    # does.
+    let total        = $all_rows | length
+    let passing      = $all_rows | where status == "pass"         | length
+    let dead         = $all_rows | where status == "dead"         | length
+    let blocked      = $all_rows | where status == "blocked"      | length
+    let rate_limited = $all_rows | where status == "rate-limited" | length
+    let private      = $all_rows | where status == "private"      | length
+    let errors       = $all_rows | where status == "error"        | length
 
-    print $"(ansi cyan_bold)Summary:(ansi reset) ($total) URLs checked — (ansi green)($passing) pass(ansi reset) | (ansi yellow)($redirect) redirect(ansi reset) | (ansi red)($failing) fail  ($errors) error(ansi reset)"
+    print $"(ansi cyan_bold)Summary:(ansi reset) ($total) URLs checked — (ansi green)($passing) pass(ansi reset) | (ansi red)($dead) dead(ansi reset) | (ansi magenta)($blocked) blocked \(unconfirmed\)(ansi reset) | (ansi yellow)($rate_limited) rate-limited(ansi reset) | (ansi cyan)($private) private \(expected\)(ansi reset) | (ansi red)($errors) error(ansi reset)"
     print ""
 
     # Full table
     $all_rows | select plugin skill source url status notes
+}
+
+# ---- self-test (pure functions only; no network) ---------------------------
+
+export def run-self-test []: nothing -> record<failed: bool, count: int> {
+    mut failed = false
+    mut count = 0
+
+    # Fixtures below are CAPTURED live error text from real nu 0.113.1 HTTP
+    # calls made while triaging claude-skills-220 (2026-08-04) — not shapes
+    # invented from the implementation. Sources, per case, noted inline.
+    let classify_cases = [
+        # captured: `http head "https://crates.io/crates/serde"` (nu 0.113.1)
+        {
+            label: "real 404 on a non-private repo is dead"
+            text: "Requested file not found (404): \"https://crates.io/crates/serde\""
+            url: "https://crates.io/crates/serde"
+            want: "dead"
+        }
+        # captured: `http head "https://github.com/vinnie357/runex"` with the
+        # shared UA header (nu 0.113.1) — the exact URL/call shape check-url
+        # makes; GitHub's documented private-repo behavior (404, not 403, to
+        # avoid confirming existence to an unauthenticated caller) applies
+        # identically on this website path as on the api.github.com path.
+        {
+            label: "404 on the known-private repo's bare URL is private, not dead"
+            text: "Requested file not found (404): \"https://github.com/vinnie357/runex\""
+            url: "https://github.com/vinnie357/runex"
+            want: "private"
+        }
+        {
+            label: "404 on a path under the known-private repo is also private"
+            text: "Requested file not found (404): \"https://github.com/vinnie357/runex/releases\""
+            url: "https://github.com/vinnie357/runex/releases"
+            want: "private"
+        }
+        {
+            label: "a different repo under the same owner is NOT private by substring collision"
+            text: "Requested file not found (404): \"https://github.com/vinnie357/runex-extra\""
+            url: "https://github.com/vinnie357/runex-extra"
+            want: "dead"
+        }
+        {
+            label: "403 rate-limit text classifies as rate-limited, not dead"
+            text: "Client error (403): API rate limit exceeded"
+            url: "https://crates.io/api/v1/crates/serde"
+            want: "rate-limited"
+        }
+        # captured shape from sources-lib.nu's own self-test (same nu client)
+        {
+            label: "429 Too Many Requests (no parens) classifies as rate-limited"
+            text: "Cannot make request to \"https://molecule.readthedocs.io\". Error is \"429 Too Many Requests\""
+            url: "https://molecule.readthedocs.io"
+            want: "rate-limited"
+        }
+        # captured: `http head` against the dead butunclebob.com host (2026-08-04)
+        {
+            label: "connection-refused I/O error falls through to error"
+            text: "Io(IoError { kind: Std(ConnectionRefused, Sealed), span: Span[160087..160096], path: None, additional_context: None, location: None })"
+            url: "https://www.butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd"
+            want: "error"
+        }
+        {
+            label: "empty error text falls through to error"
+            text: ""
+            url: "https://example.com"
+            want: "error"
+        }
+    ]
+    for c in $classify_cases {
+        $count += 1
+        let got = classify-url-error $c.text $c.url
+        if $got != $c.want {
+            print $"(ansi red_bold)❌ classify-url-error: ($c.label): want ($c.want), got ($got)(ansi reset)"
+            $failed = true
+        }
+    }
+
+    let private_url_cases = [
+        {label: "bare known-private repo URL matches" url: "https://github.com/vinnie357/runex" want: true}
+        {label: "path under known-private repo matches" url: "https://github.com/vinnie357/runex/tree/main" want: true}
+        {label: "a different repo does not match by substring" url: "https://github.com/vinnie357/runex-extra" want: false}
+        {label: "a different owner with the same repo name does not match" url: "https://github.com/someoneelse/runex" want: false}
+        {label: "an unrelated URL does not match" url: "https://crates.io/crates/serde" want: false}
+    ]
+    for c in $private_url_cases {
+        $count += 1
+        let got = is-known-private-repo-url $c.url
+        if $got != $c.want {
+            print $"(ansi red_bold)❌ is-known-private-repo-url: ($c.label): want ($c.want), got ($got)(ansi reset)"
+            $failed = true
+        }
+    }
+
+    # claude-skills-220 Gate 3 (F1): pure URL-parsing helpers behind the
+    # crates.io dead-override. crates-io-dead-override itself is NOT
+    # self-tested here — it makes a live network call (the API cross-check),
+    # so it's exercised by the live corpus run instead (see the PR report's
+    # URL-by-URL table), matching sources-lib.nu's own convention of keeping
+    # check-* network functions out of --self-test.
+    let crate_name_cases = [
+        {label: "bare crate URL extracts the crate name" url: "https://crates.io/crates/serde" want: "serde"}
+        {label: "a hyphenated crate name extracts whole" url: "https://crates.io/crates/clap-verbosity-flag" want: "clap-verbosity-flag"}
+        {label: "a trailing-slash URL does not match (scoped narrow on purpose)" url: "https://crates.io/crates/serde/" want: null}
+        {label: "a versioned subpath does not match" url: "https://crates.io/crates/serde/1.0.229" want: null}
+        {label: "the bare /crates/ URL with no name does not match" url: "https://crates.io/crates/" want: null}
+        {label: "a non-crates.io URL does not match" url: "https://docs.rs/serde" want: null}
+        {label: "the crates.io homepage does not match" url: "https://crates.io" want: null}
+    ]
+    for c in $crate_name_cases {
+        $count += 1
+        let got = crates-io-crate-name $c.url
+        if $got != $c.want {
+            print $"(ansi red_bold)❌ crates-io-crate-name: ($c.label): want ($c.want), got ($got)(ansi reset)"
+            $failed = true
+        }
+    }
+
+    let crates_io_host_cases = [
+        {label: "a crate page is a crates.io URL" url: "https://crates.io/crates/serde" want: true}
+        {label: "the policies page is a crates.io URL" url: "https://crates.io/policies" want: true}
+        {label: "the bare host (no path) is a crates.io URL" url: "https://crates.io" want: true}
+        {label: "a lookalike host is NOT a crates.io URL" url: "https://crates.io.evil.example/crates/serde" want: false}
+        {label: "an unrelated URL is NOT a crates.io URL" url: "https://docs.rs/serde" want: false}
+    ]
+    for c in $crates_io_host_cases {
+        $count += 1
+        let got = is-crates-io-url $c.url
+        if $got != $c.want {
+            print $"(ansi red_bold)❌ is-crates-io-url: ($c.label): want ($c.want), got ($got)(ansi reset)"
+            $failed = true
+        }
+    }
+
+    # captured: `http head "https://m3.material.io/"` (nu 0.113.1, 2026-08-04)
+    let fallback_cases = [
+        {label: "405 Method Not Allowed triggers a GET fallback" text: "Cannot make request to \"https://m3.material.io/\". Error is \"405 Method Not Allowed\"" want: true}
+        {label: "a genuine 404 does not trigger a GET fallback" text: "Requested file not found (404): \"https://crates.io/crates/serde\"" want: false}
+        {label: "a bare digit span spelling 405 does not collide (same guard sources-lib documents for 403/429)" text: "NetworkFailure { msg: \"connection reset\", span: Span[140533..140599] }" want: false}
+    ]
+    for c in $fallback_cases {
+        $count += 1
+        let got = needs-get-fallback $c.text
+        if $got != $c.want {
+            print $"(ansi red_bold)❌ needs-get-fallback: ($c.label): want ($c.want), got ($got)(ansi reset)"
+            $failed = true
+        }
+    }
+
+    {failed: $failed, count: $count}
+}
+
+def main [--plugin: string = "", --self-test] {
+    if $self_test {
+        let result = run-self-test
+        if $result.failed {
+            exit 1
+        }
+        print $"(ansi green_bold)✅ sources-validate-urls self-test passed \(($result.count) cases\)(ansi reset)"
+        exit 0
+    }
+    run-checks $plugin
 }

--- a/plugins/tools/claude-code/skills/sources.md
+++ b/plugins/tools/claude-code/skills/sources.md
@@ -20,7 +20,7 @@ Structured tracking: [sources.toml](sources.toml) — versions, check methods, a
 - **Used In**: skills/claude-skills/SKILL.md
 
 ### Skill Creator Guide
-- **URL**: https://github.com/anthropics/skills/blob/main/skill-creator/SKILL.md
+- **URL**: https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md
 - **Purpose**: Best practices and guidelines for creating effective Claude skills
 - **Key Points**:
   - SKILL.md structure with YAML frontmatter
@@ -42,7 +42,7 @@ Structured tracking: [sources.toml](sources.toml) — versions, check methods, a
 - **Used In**: skills/claude-skills/SKILL.md
 
 ### Agent Skills Specification
-- **URL**: https://github.com/anthropics/skills/blob/main/agent_skills_spec.md
+- **URL**: https://agentskills.io/specification
 - **Purpose**: Official specification for Agent Skills format and structure
 - **Date Accessed**: 2025-11-15
 - **Used In**: skills/claude-skills/SKILL.md
@@ -393,7 +393,7 @@ Create a modular Claude Code plugin marketplace that:
 - **Key Topics**: List releases, get latest release, release assets, tag names
 
 ### Hex.pm API
-- **URL**: https://github.com/hexpm/hexpm/blob/main/guides/API.md
+- **URL**: https://hex.pm/api
 - **Purpose**: API reference for querying Hex package versions
 - **Date Accessed**: 2026-03-25
 - **Key Topics**: Package metadata, release versions, dependency resolution

--- a/plugins/tools/claude-code/skills/sources.toml
+++ b/plugins/tools/claude-code/skills/sources.toml
@@ -41,14 +41,14 @@ notes = "No Date Accessed in sources.md for this entry. Live GitHub API check 20
 [[sources]]
 skills = ["claude-skills"]
 name = "skill-creator-guide"
-url = "https://github.com/anthropics/skills/blob/main/skill-creator/SKILL.md"
+url = "https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md"
 check_method = "manual"
 current_version = "unknown"
 version_constraint = "rolling"
-last_checked = "unknown"
+last_checked = "2026-08-04"
 update_priority = "low"
 breaking_changes_likely = false
-notes = "No Date Accessed in sources.md. Same repo as example-skills-repository (confirmed reachable 2026-07-30), but this entry cites one specific file path not independently re-fetched, so last_checked is honestly 'unknown' rather than borrowed from the sibling entry."
+notes = "claude-skills-220: the old path skill-creator/SKILL.md now 404s (confirmed 2026-08-04 via sources:validate) — anthropics/skills restructured its top-level skill directories under a skills/ prefix (verified via `gh api repos/anthropics/skills/git/trees/main?recursive=1`: skills/skill-creator/SKILL.md exists, skill-creator/SKILL.md does not). URL repointed to the live path; content itself (the skill-creator guide) is unchanged, only its location moved."
 
 [[sources]]
 skills = ["claude-skills"]
@@ -65,14 +65,14 @@ notes = "No Date Accessed in sources.md. Live GitHub API check 2026-07-30 confir
 [[sources]]
 skills = ["claude-skills"]
 name = "agent-skills-specification"
-url = "https://github.com/anthropics/skills/blob/main/agent_skills_spec.md"
+url = "https://agentskills.io/specification"
 check_method = "manual"
 current_version = "unknown"
 version_constraint = "rolling"
-last_checked = "2025-11-15"
+last_checked = "2026-08-04"
 update_priority = "low"
 breaking_changes_likely = false
-notes = "sources.md Date Accessed 2025-11-15. Official specification for the Agent Skills format and structure; same repo as example-skills-repository (confirmed reachable 2026-07-30)."
+notes = "claude-skills-220 Gate 3 (F3): the old path agent_skills_spec.md 404s (confirmed 2026-08-04 via sources:validate). The first repoint, to anthropics/skills' spec/agent-skills-spec.md, was itself wrong — that file is now an 87-byte stub reading 'The spec is now located at https://agentskills.io/specification', so the citation pointed at a breadcrumb, not content. Repointed to agentskills.io/specification directly (confirmed 200 and the actual spec content — Directory structure, SKILL.md format, frontmatter field table, Progressive disclosure sections — via live fetch 2026-08-04), the real upstream home for the Agent Skills specification going forward."
 
 [[sources]]
 skills = ["claude-skills"]
@@ -413,14 +413,14 @@ notes = "sources.md Date Accessed 2026-03-25. API reference for querying GitHub 
 [[sources]]
 skills = ["skill-update"]
 name = "hexpm-api"
-url = "https://github.com/hexpm/hexpm/blob/main/guides/API.md"
+url = "https://hex.pm/api"
 check_method = "manual"
 current_version = "unknown"
 version_constraint = "rolling"
-last_checked = "2026-03-25"
+last_checked = "2026-08-04"
 update_priority = "low"
 breaking_changes_likely = false
-notes = "sources.md Date Accessed 2026-03-25. API reference for querying Hex package versions — describes the hex-pm check_method."
+notes = "claude-skills-220: the old URL github.com/hexpm/hexpm/blob/main/guides/API.md now 404s (confirmed 2026-08-04 via sources:validate) — the guides/ directory no longer exists in the hexpm/hexpm repo tree. Repointed to hex.pm/api (confirmed 200, 2026-08-04, content-type application/json) — hex.pm's own JSON hypermedia API index, listing the live endpoint URLs (package_owners_url, package_release_url, etc.), a more canonical source for the same content (API reference for querying Hex package versions — describes the hex-pm check_method) than a repo doc path."
 
 [[sources]]
 skills = ["skill-update"]

--- a/plugins/tools/slidev/.claude-plugin/plugin.json
+++ b/plugins/tools/slidev/.claude-plugin/plugin.json
@@ -1,13 +1,22 @@
 {
   "name": "slidev",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Slidev presentation skills: strategy, branding, interactive demos, markdown slides, syntax, code blocks, export, and troubleshooting",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["slidev", "presentation", "slides", "markdown", "vite", "branding", "interactive", "strategy"],
+  "keywords": [
+    "slidev",
+    "presentation",
+    "slides",
+    "markdown",
+    "vite",
+    "branding",
+    "interactive",
+    "strategy"
+  ],
   "skills": [
     "./skills/slidev",
     "./skills/syntax",

--- a/plugins/tools/slidev/skills/sources.md
+++ b/plugins/tools/slidev/skills/sources.md
@@ -149,7 +149,7 @@ Two skills have no section of their own because they draw on sources cited elsew
 ## Brand Discovery and Styles
 
 ### Playwright MCP Browser Tools
-- **URL**: https://github.com/anthropics/claude-code/tree/main/packages/mcp-server-playwright
+- **URL**: https://github.com/microsoft/playwright-mcp
 - **Purpose**: Browser automation for brand token extraction
 - **Date Accessed**: 2026-04-04
 - **Key Topics**: browser_navigate, browser_evaluate, browser_take_screenshot, CSS extraction

--- a/plugins/tools/slidev/skills/sources.toml
+++ b/plugins/tools/slidev/skills/sources.toml
@@ -314,14 +314,14 @@ notes = "sources.md Date Accessed 2026-04-04. Three key messages, three-act narr
 [[sources]]
 skills = ["styles"]
 name = "playwright-mcp-browser-tools"
-url = "https://github.com/anthropics/claude-code/tree/main/packages/mcp-server-playwright"
+url = "https://github.com/microsoft/playwright-mcp"
 check_method = "manual"
 current_version = "unknown"
 version_constraint = "rolling"
-last_checked = "2026-04-04"
+last_checked = "2026-08-04"
 update_priority = "low"
 breaking_changes_likely = false
-notes = "sources.md Date Accessed 2026-04-04. browser_navigate, browser_evaluate, browser_take_screenshot, CSS extraction. This is a directory path within the claude-code monorepo, not an independently releasable package — check_method=manual rather than github-releases (a repo-level release check would not track this subpackage specifically). Not re-verified live in this pass."
+notes = "claude-skills-220: the old URL github.com/anthropics/claude-code/tree/main/packages/mcp-server-playwright now 404s (confirmed 2026-08-04 via sources:validate) — the packages/ directory no longer exists in the claude-code repo tree. Repointed to microsoft/playwright-mcp, the standalone upstream for this MCP server (confirmed 200, 2026-08-04; README documents the same browser_navigate, browser_evaluate, browser_take_screenshot tool names this entry cites)."
 
 [[sources]]
 skills = ["styles"]


### PR DESCRIPTION
- Port sources-lib.nu's classify-fetch-error into sources-validate-urls.nu so a 404 reports as \`dead\` (or \`private\` for a known-private repo), a 403/429/rate-limit-text reports as \`rate-limited\`, and everything else reports as \`error\` — replacing the old undifferentiated bucket that collapsed all three into one generic count
- Add a HEAD-to-GET fallback for hosts that reject HEAD with 405 (m3.material.io)
- Send the shared claude-skills User-Agent on every check instead of nushell's bare default (\`nushell\`)
- Add a known-private-repo allowlist (vinnie357/runex) so its expected 404 reports as \`private\`, not an error
- Fix 6 real dead links found via live re-sweep: 2 moved anthropics/skills paths, a moved hexpm API doc (repointed to hex.pm/api), a removed claude-code packages/ subpath (repointed to microsoft/playwright-mcp), and a dead butunclebob.com host (repointed to a Wayback Machine snapshot) — updated in sources.toml, sources.md, and the 3 other places these URLs were duplicated (SKILL.md, README.md, CLAUDE.md)
- Add a pure, self-tested classification suite (16 cases) built from captured live nu 0.113.1 error text, wired into \`mise test\` via test:sources
- Export sources-lib.nu's USER_AGENT constant so the URL validator can reuse it instead of duplicating the string