### PR TITLE
test(claude-code): close self-test mutation-coverage gaps in validate-plugin.nu

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.119",
+      "version": "0.4.120",
       "category": "meta",
       "keywords": [
         "skills",
@@ -119,7 +119,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
-      "version": "0.2.59",
+      "version": "0.2.60",
       "category": "tools",
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.119",
+  "version": "0.4.120",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
+++ b/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
@@ -1151,7 +1151,7 @@ def self-test [] {
     }
     {
       name: "top_level_version_malformed_warns"
-      why: "claude-skills-238 — is-semver (the plugin.json top-level 'version' field, distinct from the dependency RANGE check above) had zero fixture coverage; mutating it to always-true passed the pre-fix 30-case suite unchanged"
+      why: "claude-skills-238 — is-semver (the plugin.json top-level 'version' field, distinct from the dependency RANGE check above) had zero fixture coverage; mutating it to always-true passed the pre-fix 34-case suite unchanged"
       plugin: { name: "my-plugin", version: "not-a-version", description: "test fixture", license: "MIT" }
       expect_errors: 0
       expect_warnings: 1
@@ -1230,7 +1230,7 @@ def self-test [] {
   # — no case in $cases above carries a `skills` entry, so a mutation
   # replacing the whole function body with an unconditional error (or with
   # `{ errors: [], warnings: [] }`, the always-pass direction the bee is
-  # actually about) passed the pre-fix 30-case suite unchanged. Called
+  # actually about) passed the pre-fix 34-case suite unchanged. Called
   # directly against real temp SKILL.md files, the same pattern as
   # agent_model_cases above, rather than threaded through a full plugin.json
   # + skills-array + on-disk-directory round trip — that indirection buys
@@ -1434,6 +1434,23 @@ def self-test [] {
   # `nu::shell::error` / "EOF while parsing an object").
   "{\"name\": \"broken\"" | save --force $cli_invalid_json_path
 
+  # claude-skills-238 Gate 3 review — the description/keywords marketplace-
+  # agreement check itself (validate-plugin.nu's has_marketplace_context
+  # blocks, claude-skills-170's deletion-is-a-failure rule) had ZERO
+  # reject-direction fixture coverage: neutering either block to `if false`
+  # left the pre-fix suite green. cli_marketplace_valid_local_plugin_exit_0
+  # above only exercises the AGREE direction. Two dedicated plugin dirs
+  # (rather than reusing my-plugin) keep these isolated from a compounding
+  # "Name mismatch" error, since plugin.json's own 'name' must equal the
+  # marketplace entry's lookup name for that error to stay silent here.
+  let cli_desc_mismatch_dir = ($cli_temp_dir | path join "desc-mismatch-plugin")
+  mkdir ($cli_desc_mismatch_dir | path join ".claude-plugin")
+  { name: "desc-mismatch-plugin", version: "1.0.0", description: "test fixture", keywords: ["alpha", "beta"], license: "MIT" } | save --force ($cli_desc_mismatch_dir | path join ".claude-plugin" "plugin.json")
+
+  let cli_keywords_mismatch_dir = ($cli_temp_dir | path join "keywords-mismatch-plugin")
+  mkdir ($cli_keywords_mismatch_dir | path join ".claude-plugin")
+  { name: "keywords-mismatch-plugin", version: "1.0.0", description: "test fixture", keywords: ["alpha", "beta"], license: "MIT" } | save --force ($cli_keywords_mismatch_dir | path join ".claude-plugin" "plugin.json")
+
   let cli_marketplace_dir = ($cli_temp_dir | path join ".claude-plugin")
   mkdir $cli_marketplace_dir
   let cli_marketplace_path = ($cli_marketplace_dir | path join "marketplace.json")
@@ -1450,6 +1467,12 @@ def self-test [] {
       # validate-from-marketplace's local-source success path.
       { name: "my-plugin", source: "./my-plugin", description: "test fixture" }
       { name: "external-plugin", source: { source: "npm", package: "not-github" } }
+      # Deliberately WRONG description — plugin.json says "test fixture",
+      # keywords agree, so only the description-mismatch branch fires.
+      { name: "desc-mismatch-plugin", source: "./desc-mismatch-plugin", description: "a totally different description", keywords: ["alpha", "beta"] }
+      # Deliberately WRONG keywords — description agrees, so only the
+      # keywords-mismatch branch fires.
+      { name: "keywords-mismatch-plugin", source: "./keywords-mismatch-plugin", description: "test fixture", keywords: ["gamma", "delta"] }
     ]
   } | save --force $cli_marketplace_path
 
@@ -1503,6 +1526,20 @@ def self-test [] {
       args: ["my-plugin", "--marketplace", $cli_marketplace_path]
       expect_exit: 0
       why: "validate-from-marketplace's local-source success path, end to end through main"
+    }
+    {
+      name: "cli_marketplace_description_mismatch_exit_1"
+      args: ["desc-mismatch-plugin", "--marketplace", $cli_marketplace_path]
+      expect_exit: 1
+      expect_output_contains: "description mismatch"
+      why: "claude-skills-238 Gate 3 finding — the description-agreement check (claude-skills-170, validate-plugin.nu's has_marketplace_context block around the pj_description comparison) had zero reject-direction coverage; neutering that block to `if false` left the pre-fix suite green"
+    }
+    {
+      name: "cli_marketplace_keywords_mismatch_exit_1"
+      args: ["keywords-mismatch-plugin", "--marketplace", $cli_marketplace_path]
+      expect_exit: 1
+      expect_output_contains: "keywords mismatch"
+      why: "claude-skills-238 Gate 3 finding — same gap for the keywords-agreement check's has_marketplace_context block"
     }
     {
       name: "cli_marketplace_unsupported_external_source_exit_1"

--- a/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
+++ b/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
@@ -237,7 +237,7 @@ def validate-plugin-content [
     let name = $plugin.name
 
     # Validate kebab-case
-    if not ($name =~ '^[a-z0-9]+(-[a-z0-9]+)*$') {
+    if not (is-kebab-case $name) {
       $errors = ($errors | append $"Invalid name format: '($name)' \(must be kebab-case\)")
     }
 
@@ -611,7 +611,7 @@ def validate-skill-md [skill_md_path: string, skill_name: string, verbose: bool]
     if $name_len > 64 {
       $errors = ($errors | append $"SKILL.md 'name' exceeds 64 characters: ($skill_name) - ($name_len) chars")
     }
-    if not ($name =~ '^[a-z0-9]+(-[a-z0-9]+)*$') {
+    if not (is-kebab-case $name) {
       $errors = ($errors | append $"SKILL.md 'name' must be kebab-case: ($skill_name)")
     }
   }
@@ -677,7 +677,7 @@ def validate-agent-md [agent_path: string, agent_name: string, verbose: bool] {
   if $name == null {
     $errors = ($errors | append $"Agent missing 'name' field: ($agent_name)")
   } else {
-    if not ($name =~ '^[a-z0-9]+(-[a-z0-9]+)*$') {
+    if not (is-kebab-case $name) {
       $errors = ($errors | append $"Agent 'name' must be kebab-case: ($agent_name)")
     }
   }
@@ -1149,6 +1149,27 @@ def self-test [] {
       expect_errors: 1
       expect_warnings: 0
     }
+    {
+      name: "top_level_version_malformed_warns"
+      why: "claude-skills-238 — is-semver (the plugin.json top-level 'version' field, distinct from the dependency RANGE check above) had zero fixture coverage; mutating it to always-true passed the pre-fix 30-case suite unchanged"
+      plugin: { name: "my-plugin", version: "not-a-version", description: "test fixture", license: "MIT" }
+      expect_errors: 0
+      expect_warnings: 1
+    }
+    {
+      name: "top_level_version_v_prefixed_warns"
+      why: "claude-skills-238 — is-semver is the EXACT-version grammar, not the dependency range grammar; a v-prefixed string like 'v1.0.0' is valid as a RANGE but not as this exact top-level field, so it must still warn here — this is also the SKILL.md-documented example ('version': 'v1.0.0' // warned)"
+      plugin: { name: "my-plugin", version: "v1.0.0", description: "test fixture", license: "MIT" }
+      expect_errors: 0
+      expect_warnings: 1
+    }
+    {
+      name: "plugin_name_bad_kebab_case_errors"
+      why: "claude-skills-238 — is-kebab-case (the plugin.json top-level 'name' field) had zero fixture coverage of the reject direction; every existing case uses a valid kebab-case name. Also exercises the is-kebab-case helper now that it's wired into this call site instead of a duplicated inline regex"
+      plugin: { name: "My_Plugin", version: "1.0.0", description: "test fixture", license: "MIT" }
+      expect_errors: 2  # invalid name format, AND name mismatch (fixture always passes plugin_name="my-plugin" as expected — see the loop below)
+      expect_warnings: 0
+    }
   ]
 
   let temp_dir = (mktemp -d)
@@ -1205,6 +1226,306 @@ def self-test [] {
   }
   rm -rf $agent_temp_dir
 
+  # claude-skills-238: validate-skill-md had ZERO fixture coverage before this
+  # — no case in $cases above carries a `skills` entry, so a mutation
+  # replacing the whole function body with an unconditional error (or with
+  # `{ errors: [], warnings: [] }`, the always-pass direction the bee is
+  # actually about) passed the pre-fix 30-case suite unchanged. Called
+  # directly against real temp SKILL.md files, the same pattern as
+  # agent_model_cases above, rather than threaded through a full plugin.json
+  # + skills-array + on-disk-directory round trip — that indirection buys
+  # nothing extra here since validate-skill-md takes a file path directly.
+  let skill_md_cases = [
+    {
+      name: "valid"
+      content: "---\nname: my-skill\ndescription: Use when testing skill validation.\n---\n\nbody\n"
+      expect_errors: 0
+      expect_warnings: 0
+      why: "baseline: a correct SKILL.md must pass cleanly — this is also the regression guard for the reject-direction cases below"
+    }
+    {
+      name: "missing_frontmatter"
+      content: "no frontmatter here\njust plain text\n"
+      expect_errors: 1
+      expect_warnings: 0
+      why: "no opening '---' — must be rejected, not silently treated as a bodiless skill"
+    }
+    {
+      name: "missing_closing_delimiter"
+      content: "---\nname: my-skill\ndescription: Use when testing.\n"
+      expect_errors: 1
+      expect_warnings: 0
+      why: "opens '---' but never closes it — the frontmatter parser must not run off the end of the file"
+    }
+    {
+      name: "missing_name_field"
+      content: "---\ndescription: Use when testing.\n---\n\nbody\n"
+      expect_errors: 1
+      expect_warnings: 0
+      why: "SKILL.md missing 'name' field must error"
+    }
+    {
+      name: "name_bad_kebab_case"
+      content: "---\nname: My_Skill\ndescription: Use when testing.\n---\n\nbody\n"
+      expect_errors: 1
+      expect_warnings: 0
+      why: "SKILL.md 'name' must be kebab-case — also exercises is-kebab-case's reject direction from this call site"
+    }
+    {
+      name: "name_too_long"
+      content: $"---\nname: (('a' | fill -c 'a' -w 65))\ndescription: Use when testing.\n---\n\nbody\n"
+      expect_errors: 1
+      expect_warnings: 0
+      why: "SKILL.md 'name' exceeds 64 characters — a single 65-char run of 'a' is still valid kebab-case, so only the length check fires, isolating this specific error"
+    }
+    {
+      name: "missing_description_field"
+      content: "---\nname: my-skill\n---\n\nbody\n"
+      expect_errors: 1
+      expect_warnings: 0
+      why: "SKILL.md missing 'description' field must error"
+    }
+    {
+      name: "description_missing_trigger_phrase"
+      content: "---\nname: my-skill\ndescription: does something without the required trigger phrase.\n---\n\nbody\n"
+      expect_errors: 0
+      expect_warnings: 1
+      why: "missing 'Use when'/'Activate when' is a warning, not an error"
+    }
+    {
+      name: "allowed_tools_present"
+      content: "---\nname: my-skill\ndescription: Use when testing.\nallowed-tools: Bash, Read\n---\n\nbody\n"
+      expect_errors: 1
+      expect_warnings: 0
+      why: "skills must not set allowed-tools — tool allowlists belong on the invoking agent, not the skill"
+    }
+  ]
+  let skill_md_temp_dir = (mktemp -d)
+  for c in $skill_md_cases {
+    let skill_md_path = ($skill_md_temp_dir | path join $"($c.name).md")
+    $c.content | save --force $skill_md_path
+    let result = (validate-skill-md $skill_md_path "fixture-skill" false)
+    if ($result.errors | length) != $c.expect_errors {
+      $failures = ($failures | append $"skill_md_($c.name): expected ($c.expect_errors) errors, got (($result.errors | length)): ($result.errors | to nuon) -- ($c.why)")
+    }
+    if ($result.warnings | length) != $c.expect_warnings {
+      $failures = ($failures | append $"skill_md_($c.name): expected ($c.expect_warnings) warnings, got (($result.warnings | length)): ($result.warnings | to nuon) -- ($c.why)")
+    }
+  }
+  rm -rf $skill_md_temp_dir
+
+  # claude-skills-238: validate-agent-md's NON-MODEL checks had zero
+  # reject-direction fixture coverage — the agent_model_cases block above
+  # only varies `model`, on manifests that are otherwise always valid.
+  let agent_md_cases = [
+    {
+      name: "valid"
+      content: "---\nname: my-agent\ndescription: test fixture\ntools: Bash, Read\nmodel: opus\n---\n\nbody\n"
+      expect_errors: 0
+      why: "baseline: a correct agent frontmatter must pass cleanly"
+    }
+    {
+      name: "missing_frontmatter"
+      content: "no frontmatter here\n"
+      expect_errors: 1
+      why: "no opening '---' — must be rejected"
+    }
+    {
+      name: "missing_closing_delimiter"
+      content: "---\nname: my-agent\ndescription: test fixture\n"
+      expect_errors: 1
+      why: "opens '---' but never closes it"
+    }
+    {
+      name: "missing_name_field"
+      content: "---\ndescription: test fixture\n---\n\nbody\n"
+      expect_errors: 1
+      why: "Agent missing 'name' field must error"
+    }
+    {
+      name: "name_bad_kebab_case"
+      content: "---\nname: My_Agent\ndescription: test fixture\n---\n\nbody\n"
+      expect_errors: 1
+      why: "Agent 'name' must be kebab-case — also exercises is-kebab-case's reject direction from this call site"
+    }
+    {
+      name: "missing_description_field"
+      content: "---\nname: my-agent\n---\n\nbody\n"
+      expect_errors: 1
+      why: "Agent missing 'description' field must error"
+    }
+    {
+      name: "tools_as_yaml_list"
+      content: "---\nname: my-agent\ndescription: test fixture\ntools:\n  - Bash\n  - Read\n---\n\nbody\n"
+      expect_errors: 1
+      why: "tools must be a comma-separated string, not a YAML array — the bee's own 'tools given as a YAML list' example"
+    }
+    {
+      name: "tools_wrong_type"
+      content: "---\nname: my-agent\ndescription: test fixture\ntools: 42\n---\n\nbody\n"
+      expect_errors: 1
+      why: "tools must be a string; a bare number is neither the list-shape nor the string-shape branch"
+    }
+  ]
+  let agent_md_temp_dir = (mktemp -d)
+  for c in $agent_md_cases {
+    let agent_md_path = ($agent_md_temp_dir | path join $"($c.name).md")
+    $c.content | save --force $agent_md_path
+    let result = (validate-agent-md $agent_md_path "fixture-agent" false)
+    if ($result.errors | length) != $c.expect_errors {
+      $failures = ($failures | append $"agent_md_($c.name): expected ($c.expect_errors) errors, got (($result.errors | length)): ($result.errors | to nuon) -- ($c.why)")
+    }
+  }
+  rm -rf $agent_md_temp_dir
+
+  # claude-skills-238: cleanup-temp is a pure filesystem helper with zero
+  # fixture coverage — a mutation that always removes (or never removes)
+  # would pass every existing case silently, since none of them call it
+  # with an assertion on the resulting directory state.
+  let cleanup_temp_cases = [
+    { is_ext: true, expect_removed: true, why: "external plugin's temp clone dir must be removed after use" }
+    { is_ext: false, expect_removed: false, why: "a non-external validation never allocated a temp dir — cleanup must be a no-op, not delete an unrelated path" }
+  ]
+  for c in $cleanup_temp_cases {
+    let probe_dir = (mktemp -d)
+    cleanup-temp $probe_dir $c.is_ext
+    let still_exists = ($probe_dir | path exists)
+    let was_removed = not $still_exists
+    if $was_removed != $c.expect_removed {
+      $failures = ($failures | append $"cleanup_temp_is_ext_($c.is_ext): expected removed=($c.expect_removed), got removed=($was_removed) -- ($c.why)")
+    }
+    if not $was_removed {
+      rm -rf $probe_dir
+    }
+  }
+
+  # claude-skills-238: main, validate-plugin-file, validate-from-marketplace,
+  # and setup-external-plugin's non-network branch are entirely unreached by
+  # every case above, because all of them call `exit` on at least one path —
+  # invoking them in-process would kill the self-test run itself on the
+  # first hit. The only safe way to exercise them is a subprocess: spawn
+  # `nu <this-script> <args>` and assert on its exit code (`^nu ... | complete`
+  # captures the exit code instead of propagating it into this process).
+  # Scope boundary, stated explicitly per claude-skills-238's own request
+  # rather than left implicit: setup-external-plugin's actual `git clone`
+  # success and failure paths are NOT covered here. Reaching them needs a
+  # live network call, and self-test must stay network-free — every other
+  # network-touching script in this repo (sources-check.nu, sources-report.nu,
+  # sources-stale.nu, fence-freshness.nu) keeps live calls out of --self-test
+  # for the same reason. The one setup-external-plugin branch that requires
+  # no network — "source is an object but not github, or a github source with
+  # an empty repo path" — IS covered below (cli_marketplace_unsupported_external_source_exit_1).
+  let self_path = $env.CURRENT_FILE
+  let cli_temp_dir = (mktemp -d)
+
+  # A minimal valid plugin.json for the direct-file and marketplace-local
+  # success cases below.
+  let cli_plugin_dir = ($cli_temp_dir | path join "my-plugin")
+  mkdir ($cli_plugin_dir | path join ".claude-plugin")
+  { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT" } | save --force ($cli_plugin_dir | path join ".claude-plugin" "plugin.json")
+
+  let cli_invalid_json_path = ($cli_temp_dir | path join "invalid.json")
+  # "not valid json {{{" is NOT actually invalid per nu's own `from json`,
+  # which accepts a JSON5-style bare "quoteless string" and returns it
+  # unchanged (`"not valid json {{{" | from json | describe` => "string") —
+  # verified directly, this made the try/catch in validate-plugin-file a
+  # silent no-op and the case failed on the wrong assertion. A truncated
+  # object is genuinely unparseable to nu's JSON parser (verified: raises
+  # `nu::shell::error` / "EOF while parsing an object").
+  "{\"name\": \"broken\"" | save --force $cli_invalid_json_path
+
+  let cli_marketplace_dir = ($cli_temp_dir | path join ".claude-plugin")
+  mkdir $cli_marketplace_dir
+  let cli_marketplace_path = ($cli_marketplace_dir | path join "marketplace.json")
+  {
+    name: "fixture-marketplace"
+    owner: { name: "fixture" }
+    plugins: [
+      # description here must match the plugin.json fixture's description
+      # above ("test fixture") — validate-plugin-content's marketplace-context
+      # check treats plugin.json as authoritative and errors when the
+      # marketplace entry omits a description plugin.json defines
+      # (claude-skills-170's deletion-is-a-failure rule). Omitting it here
+      # was the actual cause of this case's exit-1 failure, not a defect in
+      # validate-from-marketplace's local-source success path.
+      { name: "my-plugin", source: "./my-plugin", description: "test fixture" }
+      { name: "external-plugin", source: { source: "npm", package: "not-github" } }
+    ]
+  } | save --force $cli_marketplace_path
+
+  let cli_empty_marketplace_path = ($cli_temp_dir | path join "empty-marketplace.json")
+  { name: "fixture-marketplace", owner: { name: "fixture" }, plugins: [] } | save --force $cli_empty_marketplace_path
+
+  let cli_cases = [
+    {
+      name: "cli_valid_plugin_file_exit_0"
+      args: [($cli_plugin_dir | path join ".claude-plugin" "plugin.json")]
+      expect_exit: 0
+      why: "validate-plugin-file's success path — main + validate-plugin-file together"
+    }
+    {
+      name: "cli_missing_file_exit_1"
+      args: [($cli_temp_dir | path join "does-not-exist.json")]
+      expect_exit: 1
+      expect_output_contains: "File not found"
+      why: "validate-plugin-file's file-not-found branch"
+    }
+    {
+      name: "cli_invalid_json_exit_1"
+      args: [$cli_invalid_json_path]
+      expect_exit: 1
+      expect_output_contains: "Invalid JSON syntax"
+      why: "validate-plugin-file's JSON-parse-failure branch"
+    }
+    {
+      name: "cli_no_target_exit_1"
+      args: []
+      expect_exit: 1
+      expect_output_contains: "target is required"
+      why: "main's missing-target branch, with neither a target nor --self-test"
+    }
+    {
+      name: "cli_marketplace_missing_exit_1"
+      args: ["somename", "--marketplace", ($cli_temp_dir | path join "does-not-exist-marketplace.json")]
+      expect_exit: 1
+      expect_output_contains: "Marketplace not found"
+      why: "validate-from-marketplace's marketplace-file-missing branch"
+    }
+    {
+      name: "cli_marketplace_plugin_not_found_exit_1"
+      args: ["missing-plugin", "--marketplace", $cli_empty_marketplace_path]
+      expect_exit: 1
+      expect_output_contains: "not found in marketplace"
+      why: "validate-from-marketplace's plugin-not-in-marketplace branch"
+    }
+    {
+      name: "cli_marketplace_valid_local_plugin_exit_0"
+      args: ["my-plugin", "--marketplace", $cli_marketplace_path]
+      expect_exit: 0
+      why: "validate-from-marketplace's local-source success path, end to end through main"
+    }
+    {
+      name: "cli_marketplace_unsupported_external_source_exit_1"
+      args: ["external-plugin", "--marketplace", $cli_marketplace_path]
+      expect_exit: 1
+      expect_output_contains: "Unsupported external source format"
+      why: "setup-external-plugin's non-github-object branch — the one setup-external-plugin path reachable without a live git clone"
+    }
+  ]
+
+  for c in $cli_cases {
+    let result = (do { ^nu $self_path ...$c.args } | complete)
+    if $result.exit_code != $c.expect_exit {
+      $failures = ($failures | append $"($c.name): expected exit ($c.expect_exit), got ($result.exit_code) -- ($c.why)")
+    }
+    let expect_contains = ($c | get -o expect_output_contains)
+    if ($expect_contains != null) and not ($result.stdout | str contains $expect_contains) {
+      $failures = ($failures | append $"($c.name): expected stdout to contain '($expect_contains)', got: ($result.stdout) -- ($c.why)")
+    }
+  }
+
+  rm -rf $cli_temp_dir
+
   rm -rf $temp_dir
 
   if ($failures | length) > 0 {
@@ -1215,5 +1536,6 @@ def self-test [] {
     exit 1
   }
 
-  print $"(ansi green_bold)✅ validate-plugin.nu self-test passed \((($cases | length) + ($agent_model_cases | length)) cases\)(ansi reset)"
+  let total_cases = ($cases | length) + ($agent_model_cases | length) + ($skill_md_cases | length) + ($agent_md_cases | length) + ($cleanup_temp_cases | length) + ($cli_cases | length)
+  print $"(ansi green_bold)✅ validate-plugin.nu self-test passed \(($total_cases) cases\)(ansi reset)"
 }

--- a/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
+++ b/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
@@ -1164,10 +1164,24 @@ def self-test [] {
       expect_warnings: 1
     }
     {
+      name: "top_level_version_two_segment_warns"
+      why: "claude-skills-238 Gate 3 (team-lead's independent review) — a stub is-semver reading '^[0-9]' (starts-with-digit) survived the pre-fix 66-case suite unchanged, because both existing reject fixtures ('not-a-version', 'v1.0.0') start with a non-digit and every accept fixture is a full 'X.Y.Z'. A two-segment version like '1.0' starts with a digit (so the stub wrongly accepts it) but is missing the required patch component (so the real check must still warn) — this is the one dimension ('has three dot-separated numeric segments', not merely 'starts with a digit') the prior fixtures never isolated"
+      plugin: { name: "my-plugin", version: "1.0", description: "test fixture", license: "MIT" }
+      expect_errors: 0
+      expect_warnings: 1
+    }
+    {
       name: "plugin_name_bad_kebab_case_errors"
       why: "claude-skills-238 — is-kebab-case (the plugin.json top-level 'name' field) had zero fixture coverage of the reject direction; every existing case uses a valid kebab-case name. Also exercises the is-kebab-case helper now that it's wired into this call site instead of a duplicated inline regex"
       plugin: { name: "My_Plugin", version: "1.0.0", description: "test fixture", license: "MIT" }
       expect_errors: 2  # invalid name format, AND name mismatch (fixture always passes plugin_name="my-plugin" as expected — see the loop below)
+      expect_warnings: 0
+    }
+    {
+      name: "plugin_name_snake_case_errors"
+      why: "claude-skills-238 Gate 3 (team-lead's independent review) — a stub is-kebab-case reading '^[a-z0-9_]+(-[a-z0-9_]+)*\$' (accepting underscores) survived the pre-fix 66-case suite unchanged, because the only reject fixture, 'My_Plugin', carries BOTH an uppercase letter AND an underscore — the uppercase alone is enough to fail it under the stub too, so the fixture never isolated which rule actually rejected it. 'my_plugin' is lowercase (so the stub's uppercase-tolerant claim is moot) and differs from valid kebab-case in exactly the underscore dimension"
+      plugin: { name: "my_plugin", version: "1.0.0", description: "test fixture", license: "MIT" }
+      expect_errors: 2  # invalid name format, AND name mismatch (same shape as plugin_name_bad_kebab_case_errors above — fixture always passes plugin_name="my-plugin" as expected)
       expect_warnings: 0
     }
   ]
@@ -1358,7 +1372,8 @@ def self-test [] {
       name: "tools_as_yaml_list"
       content: "---\nname: my-agent\ndescription: test fixture\ntools:\n  - Bash\n  - Read\n---\n\nbody\n"
       expect_errors: 1
-      why: "tools must be a comma-separated string, not a YAML array — the bee's own 'tools given as a YAML list' example"
+      expect_error_contains: "comma-separated string, not YAML array"
+      why: "tools must be a comma-separated string, not a YAML array — the bee's own 'tools given as a YAML list' example. Message-specificity is pinned (not just the count) because the list branch and the wrong-type branch below both error, so an error-count-only assertion can't tell them apart — a claude-skills-238 Gate 3 finding on this exact PR (team-lead's independent review): neutering the list branch to `if false` left this case's count-only assertion green since the else-if wrong-type fallback still fired"
     }
     {
       name: "tools_wrong_type"
@@ -1374,6 +1389,10 @@ def self-test [] {
     let result = (validate-agent-md $agent_md_path "fixture-agent" false)
     if ($result.errors | length) != $c.expect_errors {
       $failures = ($failures | append $"agent_md_($c.name): expected ($c.expect_errors) errors, got (($result.errors | length)): ($result.errors | to nuon) -- ($c.why)")
+    }
+    let expect_error_contains = ($c | get -o expect_error_contains)
+    if ($expect_error_contains != null) and not ($result.errors | any {|e| $e | str contains $expect_error_contains }) {
+      $failures = ($failures | append $"agent_md_($c.name): expected an error containing '($expect_error_contains)', got: ($result.errors | to nuon) -- ($c.why)")
     }
   }
   rm -rf $agent_md_temp_dir


### PR DESCRIPTION
- Add reject-direction fixture coverage for validate-skill-md (9 cases), is-kebab-case (3 call-site cases), is-semver top-level-version (2 cases), validate-agent-md non-model checks (8 cases), cleanup-temp (2 cases), and CLI-level cases reaching main/validate-plugin-file/validate-from-marketplace/setup-external-plugin's non-network branch
- Fix cli_invalid_json_exit_1 fixture: "not valid json {{{" parses cleanly as a JSON5-style bare string under nu's own `from json`, so the intended catch branch was never exercised — replaced with genuinely truncated JSON that nu's parser rejects
- Fix cli_marketplace_valid_local_plugin_exit_0 fixture: the marketplace entry was missing a `description` field that plugin.json defines, tripping the intentional claude-skills-170 deletion-is-a-failure check — added the matching description
- Verify by mutation per function (neuter to always-pass, confirm failures, restore, confirm green): is-kebab-case (3/3 reject cases fail), is-semver (2/2), validate-skill-md (8/9 non-baseline cases fail), validate-agent-md non-model checks (7/8 non-baseline cases fail)
- Bump claude-code 0.2.59 -> 0.2.60 and all-skills 0.4.119 -> 0.4.120