### PR TITLE
test(claude-code): close remaining array-type and path-existence mutation gaps

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.121",
+      "version": "0.4.122",
       "category": "meta",
       "keywords": [
         "skills",
@@ -119,7 +119,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
-      "version": "0.2.61",
+      "version": "0.2.62",
       "category": "tools",
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.121",
+  "version": "0.4.122",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.61",
+  "version": "0.2.62",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
+++ b/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
@@ -1418,6 +1418,154 @@ def self-test [] {
     }
   }
 
+  # claude-skills-244: the skills/commands/agents array-type checks and the
+  # path-existence / recommended-file checks below them had ZERO
+  # reject-direction fixture coverage — a Gate 3 mutation sweep on PR #221
+  # found all 11 of them always-pass-neuterable. Two on-disk roots isolate
+  # the path-existence pair per team-lead's independent-review guidance: a
+  # fixture whose path is both MISSING and MALFORMED proves nothing about
+  # which rule fired. root_b's "present-without-md" directory genuinely
+  # EXISTS (so "Skill path not found" can't be what's firing) but lacks
+  # SKILL.md (so the missing-SKILL.md check is what's isolated); the
+  # "does-not-exist" skill entry genuinely does NOT exist (so the opposite
+  # check is isolated). Both roots also carry (or omit) skills/sources.md
+  # deliberately, so the sources.md-missing warning doesn't leak into cases
+  # that aren't testing it.
+  let array_path_temp_dir = (mktemp -d)
+
+  # root_a: no skills/sources.md, one skill dir that's fully valid (exists,
+  # has a well-formed SKILL.md) — used only to isolate the sources.md warning.
+  let root_a = ($array_path_temp_dir | path join "root-a")
+  mkdir ($root_a | path join "my-plugin" "skills" "present-with-md")
+  "---\nname: present-with-md\ndescription: Use when testing.\n---\n\nbody\n" | save --force ($root_a | path join "my-plugin" "skills" "present-with-md" "SKILL.md")
+
+  # root_b: skills/sources.md present (suppresses that warning here), one
+  # skill dir that exists but has no SKILL.md — used to isolate the
+  # missing-SKILL.md error and the skill-path-not-found warning (the latter
+  # via a skill entry that deliberately doesn't exist under this root).
+  # Also doubles as the root for the command/agent path-not-found cases
+  # (that check doesn't reference sources.md at all, so reuse is harmless)
+  # and for the array-type and missing-recommended-field cases (none of
+  # which reach path-resolution code, so the on-disk layout is inert noise
+  # for them).
+  let root_b = ($array_path_temp_dir | path join "root-b")
+  mkdir ($root_b | path join "my-plugin" "skills" "present-without-md")
+  "# Sources\n" | save --force ($root_b | path join "my-plugin" "skills" "sources.md")
+  # commands/ and agents/ PARENT dirs exist but the specific referenced file
+  # inside each does not — a non-equivalent mutation that checks
+  # `$command_path | path dirname | path exists` instead of `$command_path |
+  # path exists` (same bug shape for agents) coincidentally produced the
+  # same not-found result when the parent dir ALSO didn't exist, so this
+  # split is required to distinguish "the file is missing" from "the whole
+  # directory is missing" — found and killed during claude-skills-244's own
+  # non-equivalent mutation pass.
+  mkdir ($root_b | path join "my-plugin" "commands")
+  mkdir ($root_b | path join "my-plugin" "agents")
+
+  let array_path_cases = [
+    {
+      name: "keywords_not_array_errors"
+      root: $root_b
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", keywords: "not-an-array" }
+      expect_errors: 1
+      expect_warnings: 0
+      why: "claude-skills-244 — 'keywords' must be an array had zero reject-direction coverage; a string value isolates the type-check dimension alone"
+    }
+    {
+      name: "skills_not_array_errors"
+      root: $root_b
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", skills: "not-an-array" }
+      expect_errors: 1
+      expect_warnings: 0
+      why: "claude-skills-244 — skills must be an array had zero reject-direction coverage (distinct from the 'skills field must be an array or omitted entirely (not null)' null-branch, out of this bee's named 11)"
+    }
+    {
+      name: "commands_not_array_errors"
+      root: $root_b
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", commands: "not-an-array" }
+      expect_errors: 1
+      expect_warnings: 0
+      why: "claude-skills-244 — commands must be an array had zero reject-direction coverage"
+    }
+    {
+      name: "agents_not_array_errors"
+      root: $root_b
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", agents: "not-an-array" }
+      expect_errors: 1
+      expect_warnings: 0
+      why: "claude-skills-244 — agents must be an array had zero reject-direction coverage"
+    }
+    {
+      name: "missing_description_warns"
+      root: $root_b
+      plugin: { name: "my-plugin", version: "1.0.0", license: "MIT" }
+      expect_errors: 0
+      expect_warnings: 1
+      why: "claude-skills-244 — 'Missing recommended field: description' had zero reject-direction coverage in isolation (existing missing-name fixture drops 3 fields at once and doesn't assert warning counts)"
+    }
+    {
+      name: "missing_license_warns"
+      root: $root_b
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture" }
+      expect_errors: 0
+      expect_warnings: 1
+      why: "claude-skills-244 — 'Missing recommended field: license' had zero reject-direction coverage in isolation"
+    }
+    {
+      name: "skill_dir_exists_no_skill_md_errors"
+      root: $root_b
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", skills: ["skills/present-without-md"] }
+      expect_errors: 1
+      expect_warnings: 0
+      why: "claude-skills-244 — 'Skill directory ... missing SKILL.md file' had zero coverage; skills/present-without-md genuinely EXISTS under root_b (so the path-not-found warning can't be what's firing) but has no SKILL.md, and root_b carries sources.md so that warning doesn't leak in"
+    }
+    {
+      name: "skill_path_missing_warns"
+      root: $root_b
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", skills: ["skills/does-not-exist"] }
+      expect_errors: 0
+      expect_warnings: 1
+      why: "claude-skills-244 — 'Skill path not found' had zero coverage; skills/does-not-exist genuinely does NOT exist under root_b, isolating this from the missing-SKILL.md case above which points at a path that DOES exist"
+    }
+    {
+      name: "sources_md_missing_warns"
+      root: $root_a
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", skills: ["skills/present-with-md"] }
+      expect_errors: 0
+      expect_warnings: 1
+      why: "claude-skills-244 — 'Missing recommended file: skills/sources.md' had zero coverage; root_a's skills/present-with-md genuinely exists with a fully valid SKILL.md (no errors/warnings of its own), isolating the sources.md-missing warning alone"
+    }
+    {
+      name: "command_path_missing_warns"
+      root: $root_b
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", commands: ["commands/does-not-exist.md"] }
+      expect_errors: 0
+      expect_warnings: 1
+      why: "claude-skills-244 — 'Command path not found' had zero coverage"
+    }
+    {
+      name: "agent_path_missing_warns"
+      root: $root_b
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", agents: ["agents/does-not-exist.md"] }
+      expect_errors: 0
+      expect_warnings: 1
+      why: "claude-skills-244 — 'Agent path not found' had zero coverage"
+    }
+  ]
+
+  for c in $array_path_cases {
+    let plugin_path = ($array_path_temp_dir | path join $"($c.name).json")
+    $c.plugin | save --force $plugin_path
+    let result = (validate-plugin-content $plugin_path $c.root "my-plugin" "my-plugin" false false false)
+    if ($result.errors | length) != $c.expect_errors {
+      $failures = ($failures | append $"array_path_($c.name): expected ($c.expect_errors) errors, got (($result.errors | length)): ($result.errors | to nuon) -- ($c.why)")
+    }
+    if ($result.warnings | length) != $c.expect_warnings {
+      $failures = ($failures | append $"array_path_($c.name): expected ($c.expect_warnings) warnings, got (($result.warnings | length)): ($result.warnings | to nuon) -- ($c.why)")
+    }
+  }
+  rm -rf $array_path_temp_dir
+
   # claude-skills-238: main, validate-plugin-file, validate-from-marketplace,
   # and setup-external-plugin's non-network branch are entirely unreached by
   # every case above, because all of them call `exit` on at least one path —
@@ -1592,6 +1740,6 @@ def self-test [] {
     exit 1
   }
 
-  let total_cases = ($cases | length) + ($agent_model_cases | length) + ($skill_md_cases | length) + ($agent_md_cases | length) + ($cleanup_temp_cases | length) + ($cli_cases | length)
+  let total_cases = ($cases | length) + ($agent_model_cases | length) + ($skill_md_cases | length) + ($agent_md_cases | length) + ($cleanup_temp_cases | length) + ($array_path_cases | length) + ($cli_cases | length)
   print $"(ansi green_bold)✅ validate-plugin.nu self-test passed \(($total_cases) cases\)(ansi reset)"
 }

--- a/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
+++ b/plugins/tools/claude-code/skills/claude-plugins/scripts/validate-plugin.nu
@@ -498,6 +498,26 @@ def validate-plugin-content [
 
         if not ($agent_path | path exists) {
           $warnings = ($warnings | append $"Agent path not found: ($agent)")
+        } else if ($agent_path | path type) != "file" {
+          # claude-skills-244 Gate 3 — validate-agent-md calls `open
+          # $agent_path --raw`, which crashes the WHOLE self-test (and a
+          # real `claude plugin validate` run) with an uncaught
+          # nu::shell::io::is_a_directory error when an agents array entry
+          # resolves to a directory instead of a file. Reproduced with zero
+          # mutation: {agents: ["agents"]} against an on-disk "agents/"
+          # directory. Report a clean error instead of crashing — a crash
+          # here would suppress every already-recorded failure and every
+          # remaining self-test case, since failures are accumulated and
+          # printed only at the end.
+          # Guards on `!= "file"` rather than `== "dir"` on purpose: `path
+          # type` returns EMPTY (neither "dir" nor "file", no error) for a
+          # path that `path exists` claimed was there but isn't actually a
+          # file — the shape a broken/mutated existence check produces, not
+          # just a genuine directory. `!= "file"` catches both without a
+          # second crash-prone branch.
+          let agent_path_type = ($agent_path | path type)
+          let type_desc = if $agent_path_type == "dir" { "a directory" } else { $"an unexpected path type \(($agent_path_type)\)" }
+          $errors = ($errors | append $"Agent path is ($type_desc), not a file: ($agent)")
         } else {
           # Validate agent file content
           let validation = (validate-agent-md $agent_path $agent $verbose)
@@ -1469,7 +1489,8 @@ def self-test [] {
       plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", keywords: "not-an-array" }
       expect_errors: 1
       expect_warnings: 0
-      why: "claude-skills-244 — 'keywords' must be an array had zero reject-direction coverage; a string value isolates the type-check dimension alone"
+      expect_error_contains: "'keywords' must be an array"
+      why: "claude-skills-244 — 'keywords' must be an array had zero reject-direction coverage; a string value isolates the type-check dimension alone. plugin-schema.md documents keywords as array-only, so no doc divergence here (unlike commands/agents below)"
     }
     {
       name: "skills_not_array_errors"
@@ -1477,7 +1498,8 @@ def self-test [] {
       plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", skills: "not-an-array" }
       expect_errors: 1
       expect_warnings: 0
-      why: "claude-skills-244 — skills must be an array had zero reject-direction coverage (distinct from the 'skills field must be an array or omitted entirely (not null)' null-branch, out of this bee's named 11)"
+      expect_error_contains: "skills must be an array"
+      why: "claude-skills-244 — skills must be an array had zero reject-direction coverage (distinct from the 'skills field must be an array or omitted entirely (not null)' null-branch, out of this bee's named 11). plugin-schema.md documents skills as array-only, so no doc divergence here (unlike commands/agents below)"
     }
     {
       name: "commands_not_array_errors"
@@ -1485,7 +1507,8 @@ def self-test [] {
       plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", commands: "not-an-array" }
       expect_errors: 1
       expect_warnings: 0
-      why: "claude-skills-244 — commands must be an array had zero reject-direction coverage"
+      expect_error_contains: "commands must be an array"
+      why: "claude-skills-244 — commands must be an array had zero reject-direction coverage. KNOWN VALIDATOR/DOC DIVERGENCE (Gate 3, team-lead's independent review): references/plugin-schema.md:21 and SKILL.md:50 document 'commands' as accepting a bare STRING (a directory to scan, e.g. './commands'), not array-only — this fixture's string value is rejected under CURRENT (pre-existing, unchanged by this PR) validator behavior, which this fixture intentionally continues to assert. Resolving the divergence needs directory-scan semantics the validator doesn't implement today (glob-matching .md files under the string path) — a real feature addition, not a self-test coverage gap, so it's recorded rather than rushed here. See claude-skills-244's BEES REQUESTS for the follow-up: fix the validator to implement the documented string form, OR narrow the docs to array-only."
     }
     {
       name: "agents_not_array_errors"
@@ -1493,7 +1516,8 @@ def self-test [] {
       plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", agents: "not-an-array" }
       expect_errors: 1
       expect_warnings: 0
-      why: "claude-skills-244 — agents must be an array had zero reject-direction coverage"
+      expect_error_contains: "agents must be an array"
+      why: "claude-skills-244 — agents must be an array had zero reject-direction coverage. Same KNOWN VALIDATOR/DOC DIVERGENCE as commands_not_array_errors above: plugin-schema.md:22/95 and SKILL.md:52 document 'agents' as accepting a bare STRING directory too. Recorded, not resolved, for the same reason — see that fixture's why: and claude-skills-244's BEES REQUESTS."
     }
     {
       name: "missing_description_warns"
@@ -1501,6 +1525,7 @@ def self-test [] {
       plugin: { name: "my-plugin", version: "1.0.0", license: "MIT" }
       expect_errors: 0
       expect_warnings: 1
+      expect_warning_contains: "Missing recommended field: description"
       why: "claude-skills-244 — 'Missing recommended field: description' had zero reject-direction coverage in isolation (existing missing-name fixture drops 3 fields at once and doesn't assert warning counts)"
     }
     {
@@ -1509,6 +1534,7 @@ def self-test [] {
       plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture" }
       expect_errors: 0
       expect_warnings: 1
+      expect_warning_contains: "Missing recommended field: license"
       why: "claude-skills-244 — 'Missing recommended field: license' had zero reject-direction coverage in isolation"
     }
     {
@@ -1517,6 +1543,7 @@ def self-test [] {
       plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", skills: ["skills/present-without-md"] }
       expect_errors: 1
       expect_warnings: 0
+      expect_error_contains: "missing SKILL.md file"
       why: "claude-skills-244 — 'Skill directory ... missing SKILL.md file' had zero coverage; skills/present-without-md genuinely EXISTS under root_b (so the path-not-found warning can't be what's firing) but has no SKILL.md, and root_b carries sources.md so that warning doesn't leak in"
     }
     {
@@ -1525,6 +1552,7 @@ def self-test [] {
       plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", skills: ["skills/does-not-exist"] }
       expect_errors: 0
       expect_warnings: 1
+      expect_warning_contains: "Skill path not found"
       why: "claude-skills-244 — 'Skill path not found' had zero coverage; skills/does-not-exist genuinely does NOT exist under root_b, isolating this from the missing-SKILL.md case above which points at a path that DOES exist"
     }
     {
@@ -1533,6 +1561,7 @@ def self-test [] {
       plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", skills: ["skills/present-with-md"] }
       expect_errors: 0
       expect_warnings: 1
+      expect_warning_contains: "Missing recommended file: skills/sources.md"
       why: "claude-skills-244 — 'Missing recommended file: skills/sources.md' had zero coverage; root_a's skills/present-with-md genuinely exists with a fully valid SKILL.md (no errors/warnings of its own), isolating the sources.md-missing warning alone"
     }
     {
@@ -1541,7 +1570,8 @@ def self-test [] {
       plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", commands: ["commands/does-not-exist.md"] }
       expect_errors: 0
       expect_warnings: 1
-      why: "claude-skills-244 — 'Command path not found' had zero coverage"
+      expect_warning_contains: "Command path not found: commands/does-not-exist.md"
+      why: "claude-skills-244 — 'Command path not found' had zero coverage. Substring pins the FULL message (including the path), not just severity+count, per Gate 3's 'right check, wrong report' finding: a mutation at line 472 that swapped the literal to 'Agent path not found: ($command)' kept the same warning count and passed 79/79 until this assertion was added"
     }
     {
       name: "agent_path_missing_warns"
@@ -1549,7 +1579,17 @@ def self-test [] {
       plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", agents: ["agents/does-not-exist.md"] }
       expect_errors: 0
       expect_warnings: 1
-      why: "claude-skills-244 — 'Agent path not found' had zero coverage"
+      expect_warning_contains: "Agent path not found: agents/does-not-exist.md"
+      why: "claude-skills-244 — 'Agent path not found' had zero coverage. Substring pins the full message for the same 'right check, wrong report' reason as command_path_missing_warns above"
+    }
+    {
+      name: "agent_path_is_directory_errors"
+      root: $root_b
+      plugin: { name: "my-plugin", version: "1.0.0", description: "test fixture", license: "MIT", agents: ["agents"] }
+      expect_errors: 1
+      expect_warnings: 0
+      expect_error_contains: "Agent path is a directory, not a file"
+      why: "claude-skills-244 Gate 3 finding — reachable with ZERO mutation on real production code: an agents array entry resolving to a directory (root_b/my-plugin/agents, empty, created above) hit validate-agent-md's `open $agent_path --raw` and crashed the entire self-test run with an uncaught nu::shell::io::is_a_directory error, silently discarding every already-recorded failure and every case queued after it. Fixed with a `path type` guard reporting a clean error instead of crashing; this fixture is the regression guard for that fix, not just a coverage gap"
     }
   ]
 
@@ -1559,6 +1599,14 @@ def self-test [] {
     let result = (validate-plugin-content $plugin_path $c.root "my-plugin" "my-plugin" false false false)
     if ($result.errors | length) != $c.expect_errors {
       $failures = ($failures | append $"array_path_($c.name): expected ($c.expect_errors) errors, got (($result.errors | length)): ($result.errors | to nuon) -- ($c.why)")
+    }
+    let expect_error_contains = ($c | get -o expect_error_contains)
+    if ($expect_error_contains != null) and not ($result.errors | any {|e| $e | str contains $expect_error_contains }) {
+      $failures = ($failures | append $"array_path_($c.name): expected an error containing '($expect_error_contains)', got: ($result.errors | to nuon) -- ($c.why)")
+    }
+    let expect_warning_contains = ($c | get -o expect_warning_contains)
+    if ($expect_warning_contains != null) and not ($result.warnings | any {|w| $w | str contains $expect_warning_contains }) {
+      $failures = ($failures | append $"array_path_($c.name): expected a warning containing '($expect_warning_contains)', got: ($result.warnings | to nuon) -- ($c.why)")
     }
     if ($result.warnings | length) != $c.expect_warnings {
       $failures = ($failures | append $"array_path_($c.name): expected ($c.expect_warnings) warnings, got (($result.warnings | length)): ($result.warnings | to nuon) -- ($c.why)")


### PR DESCRIPTION
- Add reject-direction fixtures for the 11 always-pass-neuterable checks Gate 3 found on PR #221: keywords/skills/commands/agents-must-be-an-array (4), missing recommended description/license (2), skill-path-not-found, skill-directory-missing-SKILL.md, sources.md-missing, command-path-not-found, agent-path-not-found (5)
- Two on-disk fixture roots isolate the path-existence checks along exactly one dimension each: one directory that genuinely exists but lacks SKILL.md, one that genuinely doesn't exist at all, one with skills/sources.md present vs one without
- Verify every check by mutation, twice: the obvious always-pass neuter (11/11 killed) AND a non-equivalent mutation per check — wrong field, wrong constant, off-by-one path, inverted exemption logic (11/11 killed, closing two that survived on the first fixture design and required pre-creating parent directories to distinguish "file missing" from "whole directory missing")
- No mutation-probe harness added — declining stands per the restraint reasoning already recorded on PR #221, unchanged
- Bump claude-code 0.2.61 -> 0.2.62 and all-skills 0.4.121 -> 0.4.122