### PR TITLE
chore(ansible,slidev): verify claims against live tools, correct 13 errors

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.125",
+      "version": "0.4.126",
       "category": "meta",
       "keywords": [
         "skills",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -85,7 +85,7 @@
       "source": "./plugins/tools/ansible",
       "strict": true,
       "description": "Ansible automation skills: playbooks, inventory, roles, vault secrets, and Molecule testing",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "category": "tools",
       "keywords": [
         "ansible",
@@ -433,7 +433,7 @@
       "source": "./plugins/tools/slidev",
       "strict": true,
       "description": "Slidev presentation skills: strategy, branding, interactive demos, markdown slides, syntax, code blocks, export, and troubleshooting",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "category": "tools",
       "keywords": [
         "slidev",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.125",
+  "version": "0.4.126",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/ansible/.claude-plugin/plugin.json
+++ b/plugins/tools/ansible/.claude-plugin/plugin.json
@@ -1,13 +1,22 @@
 {
   "name": "ansible",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Ansible automation skills: playbooks, inventory, roles, vault secrets, and Molecule testing",
   "author": {
     "name": "rginnow"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["ansible", "automation", "configuration-management", "devops", "playbooks", "molecule", "roles", "vault"],
+  "keywords": [
+    "ansible",
+    "automation",
+    "configuration-management",
+    "devops",
+    "playbooks",
+    "molecule",
+    "roles",
+    "vault"
+  ],
   "skills": [
     "./skills/ansible",
     "./skills/ansible-inventory",

--- a/plugins/tools/ansible/skills/ansible-roles/references/jinja2-filters.md
+++ b/plugins/tools/ansible/skills/ansible-roles/references/jinja2-filters.md
@@ -26,7 +26,8 @@
 {{ list | sort }}                     {# sort ascending #}
 {{ list | reverse | list }}           {# reverse order #}
 {{ list | unique }}                   {# remove duplicates #}
-{{ list | flatten }}                  {# flatten nested lists one level #}
+{{ list | flatten }}                  {# flatten ALL levels of nesting (unbounded) — verified live: [[1,2],[3,[4,5]]] | flatten → [1,2,3,4,5] #}
+{{ list | flatten(levels=1) }}        {# flatten only 1 level — [[1,2],[3,[4,5]]] | flatten(levels=1) → [1,2,3,[4,5]] #}
 {{ list | flatten(levels=2) }}        {# flatten 2 levels deep #}
 {{ list | min }}                      {# smallest value #}
 {{ list | max }}                      {# largest value #}
@@ -80,7 +81,7 @@
 {{ "nginx.conf" | splitext }}                 {# ["nginx", ".conf"] #}
 {{ path | expanduser }}                       {# expand ~ #}
 {{ path | realpath }}                         {# resolve symlinks #}
-{{ "/etc" | path_join("nginx", "conf.d") }}   {# "/etc/nginx/conf.d" #}
+{{ ['/etc', 'nginx', 'conf.d'] | path_join }} {# "/etc/nginx/conf.d" — path_join takes ONE piped-in list (not filter args); verified live that "/etc" | path_join("nginx","conf.d") errors: "path_join() takes 1 positional argument but 3 were given" #}
 ```
 
 ## Type Conversion Filters
@@ -101,10 +102,13 @@
 ## Default and Fallback Filters
 
 ```jinja
-{# Return default if variable is undefined or empty #}
+{# Return default ONLY if variable is undefined — an empty string stays empty.
+   Verified live: '' | default('fallback') → '' (not 'fallback') #}
 {{ my_var | default('fallback') }}
 
-{# Return default only if variable is undefined (not if empty string) #}
+{# With boolean=true, return default if variable is undefined OR falsy
+   (empty string, 0, false, [], {}) — the OPPOSITE of the no-arg form above.
+   Verified live: '' | default('fallback', true) → 'fallback' #}
 {{ my_var | default('fallback', boolean=true) }}
 
 {# Omit the key entirely from a module call if variable is undefined #}

--- a/plugins/tools/ansible/skills/ansible-testing/SKILL.md
+++ b/plugins/tools/ansible/skills/ansible-testing/SKILL.md
@@ -19,16 +19,19 @@ Molecule provides a framework to spin up a test environment, run your role again
 
 ## Molecule Test Phases
 
-Molecule runs these phases in order when you execute `molecule test`:
+Molecule runs these phases in order when you execute `molecule test` — verified live against molecule 26.6.0's own `molecule test --help`, which prints its phase list directly: `Test (dependency, cleanup, destroy, syntax, create, prepare, converge, idempotence, side_effect, verify, cleanup, destroy)`. There is no standalone `lint` phase or `molecule lint` command in current Molecule — `ansible-lint`/`yamllint` are no longer a first-class Molecule action; run them directly (see "Linting" below) or wire them into CI alongside `molecule test`.
 
 | Phase | What it does |
 |-------|-------------|
-| `lint` | Run `ansible-lint` and `yamllint` on your role |
+| `dependency` | Install role/collection dependencies (per `dependency:` config) |
+| `cleanup` | Optional: cleanup tasks before destroy |
 | `destroy` | Remove any leftover test instances |
+| `syntax` | Syntax-check the converge playbook |
 | `create` | Spin up fresh test instances (containers or VMs) |
 | `prepare` | Optional: run a prepare playbook before converge |
 | `converge` | Apply your role to the test instances |
-| `idempotency` | Run converge again — assert zero changes |
+| `idempotence` | Run converge again — assert zero changes |
+| `side_effect` | Optional: apply changes to test failure/recovery scenarios |
 | `verify` | Run your test assertions against live instances |
 | `cleanup` | Optional: cleanup tasks before destroy |
 | `destroy` | Tear down all test instances |
@@ -40,7 +43,7 @@ molecule converge     # apply role (keep instance running)
 molecule verify       # run assertions only
 molecule login        # SSH into the test instance
 molecule destroy      # tear down
-molecule test         # full cycle: destroy → create → converge → verify → destroy
+molecule test         # full cycle above: dependency → cleanup → destroy → syntax → create → prepare → converge → idempotence → side_effect → verify → cleanup → destroy
 ```
 
 ## Install Molecule
@@ -57,9 +60,11 @@ From inside an existing role directory:
 
 ```bash
 cd roles/my_role
-molecule init scenario --driver-name docker         # default scenario
-molecule init scenario staging --driver-name podman  # named scenario
+molecule init scenario           # default scenario
+molecule init scenario staging   # named scenario
 ```
+
+`molecule init scenario` takes only an optional scenario-name argument — verified live against molecule 26.6.0 (`molecule init scenario --help` shows no other options) and by running it: `--driver-name docker` errors `Error: No such option '--driver-name'.` The driver is no longer chosen at scaffold time; it's configured (or auto-selected) separately — see "molecule.yml Structure" below.
 
 This creates:
 
@@ -67,53 +72,78 @@ This creates:
 roles/my_role/
 └── molecule/
     └── default/             # scenario name
-        ├── molecule.yml     # driver, platforms, verifier config
+        ├── molecule.yml     # scenario config (see below)
+        ├── create.yml       # playbook that provisions test instances
         ├── converge.yml     # playbook Molecule runs against instances
-        ├── verify.yml       # assertions (if using ansible verifier)
-        └── prepare.yml      # optional: pre-role setup
+        ├── destroy.yml      # playbook that tears instances down
+        └── verify.yml       # assertions (if using the ansible verifier)
 ```
+
+Verified live via `molecule init scenario` with molecule 26.6.0 + molecule-plugins[docker] installed — exactly these 5 files are generated, no `prepare.yml` (the running scenario's `molecule.yml` references a `prepare.yml` playbook path but does not create the file; add it by hand if your role needs a prepare step).
 
 ## molecule.yml Structure
 
+**This schema changed from the classic `driver:`/`platforms:`/`provisioner:`/`verifier:`/`lint:` top-level keys documented in older Molecule guides.** Verified live (molecule 26.6.0, both with and without `molecule-plugins[docker]` installed — same result either way) — `molecule init scenario`'s actual default output is:
+
 ```yaml
-# molecule/default/molecule.yml
+# molecule/default/molecule.yml — captured verbatim from a live `molecule init scenario` run, molecule 26.6.0
 ---
 dependency:
   name: galaxy
   options:
-    requirements-file: requirements.yml   # install Galaxy deps before testing
+    ignore-certs: false
+    ignore-errors: false
+    role-file: requirements.yml
+    requirements-file: requirements.yml
 
-driver:
-  name: docker                            # docker, podman, delegated
-
-platforms:
-  - name: instance                        # container name
-    image: geerlingguy/docker-ubuntu2204-ansible  # pre-built image with systemd+Python
-    pre_build_image: true
-    command: /lib/systemd/systemd         # init system (for service tests)
-    privileged: true                      # needed for systemd inside Docker
-
-provisioner:
-  name: ansible
-  playbooks:
-    converge: converge.yml
-    prepare: prepare.yml                  # optional
-  config_options:
+ansible:
+  cfg:
     defaults:
-      interpreter_python: auto_silent
-  inventory:
-    group_vars:
-      all:
-        ansible_user: root
+      host_key_checking: false
+      verbosity: 1
+    ssh_connection:
+      pipelining: true
+  env:
+    ANSIBLE_FORCE_COLOR: "1"
+    ANSIBLE_LOAD_CALLBACK_PLUGINS: "1"
+  executor:
+    backend: ansible-playbook
+    args:
+      ansible_playbook:
+        - --diff
+        - --force-handlers
+        - --inventory=/path/to/inventory.yml
+      ansible_navigator:
+        - --mode stdout
+        - --pull-policy missing
+        - --execution-environment-image ghcr.io/ansible/community-ansible-dev-tools:latest
+  playbooks:
+    create: create.yml
+    converge: converge.yml
+    destroy: destroy.yml
+    cleanup: cleanup.yml
+    prepare: prepare.yml
+    side_effect: side_effect.yml
+    verify: verify.yml
 
-verifier:
-  name: ansible                           # or: testinfra
-
-lint: |
-  set -e
-  yamllint .
-  ansible-lint
+scenario:
+  name: default
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - side_effect
+    - verify
+    - cleanup
+    - destroy
 ```
+
+There is no `driver:`, `platforms:`, `provisioner:`, `verifier:`, or `lint:` top-level key in this generated template — driver/platform selection and verifier choice now live elsewhere (the `ansible.executor` block above shows both an `ansible-playbook` and an `ansible-navigator`/execution-environment path). **Out of scope for this verification pass**: the exact current mechanism for pinning a specific driver (Docker/Podman) and platform image under this new schema needs a dedicated follow-up — `molecule drivers` (verified live) lists `gce, azure, docker, ec2, containers, openstack, podman, vagrant, default` as installed drivers, but reproducing a full worked docker-platform example against this schema is more than a factual correction and hasn't been re-authored here. Treat the `driver:`/`platforms:` example previously in this section as unverified for molecule 26.6.0 rather than trusting it.
 
 ## converge.yml
 
@@ -196,10 +226,13 @@ Write a playbook of assertion tasks:
 Testinfra is a Python testing library with a pytest interface. More expressive for complex assertions.
 
 ```yaml
-# molecule.yml — switch verifier
+# molecule.yml — switch verifier (same schema caveat as "molecule.yml Structure"
+# above: `verifier:` was not present in a live 26.6.0 scaffold, unverified)
 verifier:
   name: testinfra
 ```
+
+The Testinfra assertion API itself below (module names, properties) IS independently verified — confirmed live against pytest-testinfra 10.2.2's actual source (`package`, `service`, `file`, `socket`, `command` modules; `is_installed`, `is_running`, `is_enabled`, `exists`, `mode`, `user`, `is_listening`, `stdout` all present).
 
 ```python
 # molecule/default/tests/test_nginx.py
@@ -232,10 +265,10 @@ def test_nginx_responds(host):
 ## Linting
 
 ```bash
-# Run all linting (yamllint + ansible-lint)
-molecule lint
-
-# Run ansible-lint directly
+# There is no `molecule lint` command in current Molecule (26.6.0) — verified
+# live: `molecule lint --help` errors "No such command 'lint'." Run the
+# linters directly instead:
+yamllint .
 ansible-lint roles/my_role/
 
 # yamllint config
@@ -257,7 +290,7 @@ profile: production      # safety, shared, production (strictest)
 
 ## Multiple Platforms
 
-Test across OS versions with multiple platform entries:
+Test across OS versions with multiple platform entries. **Same caveat as "molecule.yml Structure" above: this `platforms:` key was not present in a live molecule 26.6.0 scaffold — unverified against the current schema, kept here as the multi-platform intent to preserve rather than a confirmed-working example:**
 
 ```yaml
 platforms:

--- a/plugins/tools/ansible/skills/ansible-testing/SKILL.md
+++ b/plugins/tools/ansible/skills/ansible-testing/SKILL.md
@@ -19,7 +19,7 @@ Molecule provides a framework to spin up a test environment, run your role again
 
 ## Molecule Test Phases
 
-Molecule runs these phases in order when you execute `molecule test` — verified live against molecule 26.6.0's own `molecule test --help`, which prints its phase list directly: `Test (dependency, cleanup, destroy, syntax, create, prepare, converge, idempotence, side_effect, verify, cleanup, destroy)`. There is no standalone `lint` phase or `molecule lint` command in current Molecule — `ansible-lint`/`yamllint` are no longer a first-class Molecule action; run them directly (see "Linting" below) or wire them into CI alongside `molecule test`.
+Molecule runs these phases in order when you execute `molecule test`. `molecule test --help` states the same list (`Test (dependency, cleanup, destroy, syntax, create, prepare, converge, idempotence, side_effect, verify, cleanup, destroy)`), but help text is a claim about behavior, not the behavior itself (this exact gap shipped a broken `bd diff` example in claude-skills-219) — the phase order below is instead cited to molecule 26.6.0's installed `molecule/constants.py`, whose `DEFAULT["scenario"]["test_sequence"]` list matches token-for-token. There is no standalone `lint` phase or `molecule lint` command in current Molecule — `ansible-lint`/`yamllint` are no longer a first-class Molecule action; run them directly (see "Linting" below) or wire them into CI alongside `molecule test`.
 
 | Phase | What it does |
 |-------|-------------|
@@ -331,4 +331,4 @@ Some tasks behave differently in check mode. Mark tasks that must always run reg
 
 ## References
 
-- **[molecule-scenarios.md](references/molecule-scenarios.md)** — Complete annotated `molecule.yml` for Docker, Podman, and delegated drivers; multi-platform test matrix; Testinfra assertion patterns; GitHub Actions CI workflow
+- **[molecule-scenarios.md](references/molecule-scenarios.md)** — Multi-platform test matrix, Testinfra assertion patterns, and GitHub Actions CI workflow examples; its `molecule.yml`/driver/`--driver-name`/`lint:` content documents an older Molecule schema and is stale for 26.6.0 (see the file's own caveat) — use "molecule.yml Structure" above for the current schema

--- a/plugins/tools/ansible/skills/ansible-testing/references/molecule-scenarios.md
+++ b/plugins/tools/ansible/skills/ansible-testing/references/molecule-scenarios.md
@@ -1,5 +1,7 @@
 # Molecule Scenario Reference
 
+**Schema-drift caveat (claude-skills-223 Gate 3, carried over from SKILL.md's "molecule.yml Structure" section): this file was NOT rewritten for molecule 26.6.0 and was out of scope for that verification pass.** Everything below — the `driver:`/`platforms:`/`provisioner:`/`verifier:`/`lint:` top-level molecule.yml keys, the `lint: |` blocks, and `molecule init scenario --driver-name docker`/`--driver-name delegated` — is confirmed STALE the same way SKILL.md's old content was: `--driver-name` errors live (`Error: No such option '--driver-name'.`) and there is no standalone `molecule lint` command in 26.6.0 (`Error: No such command 'lint'.`). Treat this reference as documenting an OLDER Molecule schema, not the current one. SKILL.md's own "molecule.yml Structure" section has the verified-live current schema.
+
 ## Docker Driver — Full Annotated molecule.yml
 
 ```yaml

--- a/plugins/tools/ansible/skills/ansible-vault/references/secret-backends.md
+++ b/plugins/tools/ansible/skills/ansible-vault/references/secret-backends.md
@@ -118,14 +118,14 @@ By default a failed lookup raises an error and stops the play. Handle failures g
 # Provide a fallback default (empty string if secret not found)
 db_password: "{{ lookup('amazon.aws.aws_ssm', '/myapp/db_pass',
     region='us-east-1',
-    errors='warn') | default('') }}"
+    on_missing='warn') | default('') }}"
 
 # Use default() filter to provide a fallback
 api_key: "{{ lookup('env', 'API_KEY') | default(lookup('community.hashi_vault.hashi_vault',
     'secret/data/api api_key'), true) }}"
 ```
 
-Use `errors='warn'` (warn and continue) instead of the default `errors='fatal'` (stop play) when a missing secret is acceptable.
+There is no `errors=` keyword parameter on `amazon.aws.aws_ssm` — verified via `ansible-doc -t lookup -j amazon.aws.aws_ssm` (amazon.aws 11.4.0): it is not in the module's `options`. The real parameters are `on_missing` (action when the named parameter doesn't exist) and `on_denied` (action when access is denied), each with `choices: [error, skip, warn]` and default `error`. Use `on_missing='warn'` (skip the missing parameter and warn, letting `default()` supply the fallback) instead of the default `on_missing='error'` (raises a fatal error and stops the play) when a missing secret is acceptable. For an access-denied case specifically, use `on_denied` instead.
 
 ## Caching Lookup Results
 

--- a/plugins/tools/ansible/skills/sources.toml
+++ b/plugins/tools/ansible/skills/sources.toml
@@ -24,7 +24,13 @@ last_full_check = "2026-08-04"
 # inventory-plugin option tables in dynamic-inventory.md were NOT
 # independently verified this pass (would need azure.azcollection/
 # google.cloud installed) — treat those two sections as carried over from the
-# prior pass, not re-confirmed.
+# prior pass, not re-confirmed. Gate 3 round 2: ansible-testing/references/
+# molecule-scenarios.md was ALSO not touched or re-verified this pass — it
+# still documents the pre-26.6.0 driver:/platforms:/provisioner:/verifier:/
+# lint: molecule.yml schema and the removed `--driver-name`/`molecule lint`
+# commands. Flagged with its own caveat at the top of the file and softened
+# in SKILL.md's References line rather than rewritten (out of scope, same as
+# the SKILL.md schema section itself) or silently left uncaveated.
 
 # ----------------------------------------------------------------------------
 # Ansible core documentation (docs.ansible.com/ansible/latest/) — the shared

--- a/plugins/tools/ansible/skills/sources.toml
+++ b/plugins/tools/ansible/skills/sources.toml
@@ -3,8 +3,28 @@
 
 [meta]
 plugin = "ansible"
-reviewed_at_plugin_version = "0.1.0"
-last_full_check = "2026-07-30"
+reviewed_at_plugin_version = "0.1.5"
+last_full_check = "2026-08-04"
+# claude-skills-223 tier 2: claim-by-claim verification pass for ansible,
+# ansible-roles (+jinja2-filters.md), ansible-vault (+secret-backends.md),
+# and ansible-testing/SKILL.md, using live-installed tools (ansible-core
+# 2.21.2, molecule 26.6.0, ansible-lint 26.6.0, pytest-testinfra 10.2.2,
+# community.hashi_vault 7.1.0, amazon.aws 11.4.0 — all pipx/ansible-galaxy
+# installed at their current-latest versions, matching the "unknown pin,
+# always-latest docs" shape every source below already used). 8 corrections
+# made (default() filter boolean semantics were exactly backwards, flatten's
+# default-level claim was backwards, path_join's filter-args syntax errors
+# live, molecule's phase order/`molecule lint` command/`molecule.yml` schema/
+# `init scenario --driver-name` flag are all stale for molecule 26.6.0, and
+# amazon.aws.aws_ssm's `errors=` param doesn't exist — real params are
+# `on_missing`/`on_denied`). ansible-inventory/SKILL.md + dynamic-inventory.md
+# got a partial pass: CLI flags, --limit pattern syntax (intersection/
+# exclusion/wildcard), connection-vars table, and the aws_ec2/constructed
+# inventory plugin schemas were verified live; the Azure RM and GCP Compute
+# inventory-plugin option tables in dynamic-inventory.md were NOT
+# independently verified this pass (would need azure.azcollection/
+# google.cloud installed) — treat those two sections as carried over from the
+# prior pass, not re-confirmed.
 
 # ----------------------------------------------------------------------------
 # Ansible core documentation (docs.ansible.com/ansible/latest/) — the shared
@@ -19,12 +39,12 @@ url = "https://docs.ansible.com/ansible/latest/"
 releases_url = "https://github.com/ansible/ansible/releases"
 check_method = "github-releases"
 github_repo = "ansible/ansible"
-current_version = "unknown"
+current_version = "2.21.2"
 version_constraint = "semver"
-last_checked = "2026-07-30"
+last_checked = "2026-08-04"
 update_priority = "medium"
 breaking_changes_likely = false
-notes = "Covers docs.ansible.com/ansible/latest/{getting_started/index.html, playbook_guide/playbooks_intro.html, reference_appendices/general_precedence.html} for the ansible skill; {inventory_guide/index.html, inventory_guide/intro_dynamic_inventory.html} for ansible-inventory; {playbook_guide/playbooks_reuse_roles.html, playbook_guide/playbooks_templating.html} for ansible-roles; {vault_guide/index.html} for ansible-vault. All accessed 2026-05-06 per sources.md, no version pinned there. Live GitHub check 2026-07-30: latest ansible/ansible release tag v2.21.2 — not compared against a pinned baseline since none exists."
+notes = "Covers docs.ansible.com/ansible/latest/{getting_started/index.html, playbook_guide/playbooks_intro.html, reference_appendices/general_precedence.html} for the ansible skill; {inventory_guide/index.html, inventory_guide/intro_dynamic_inventory.html} for ansible-inventory; {playbook_guide/playbooks_reuse_roles.html, playbook_guide/playbooks_templating.html} for ansible-roles; {vault_guide/index.html} for ansible-vault. claude-skills-223: current_version now pinned to 2.21.2, the actual live-installed ansible-core version claim-by-claim verified against (pipx install ansible-core, 2026-08-04) — CLI flags (ansible-playbook, ansible-vault, ansible-inventory, ansible-galaxy), ~25 ansible.builtin module/param names, variable precedence order (role defaults < host_vars < play vars < vars_files < extra-vars, confirmed by 4 live adjacent-pair test playbooks), when: list ANDing, and check_mode: false all confirmed correct."
 
 # ----------------------------------------------------------------------------
 # Ansible Galaxy hub docs — separate hosted site from ansible-core docs,
@@ -53,12 +73,12 @@ url = "https://docs.ansible.com/ansible/latest/collections/community/hashi_vault
 releases_url = "https://github.com/ansible-collections/community.hashi_vault/releases"
 check_method = "github-releases"
 github_repo = "ansible-collections/community.hashi_vault"
-current_version = "unknown"
+current_version = "7.1.0"
 version_constraint = "semver"
-last_checked = "2026-07-30"
+last_checked = "2026-08-04"
 update_priority = "low"
 breaking_changes_likely = false
-notes = "Lookup plugin configuration, token auth, AppRole auth for the ansible-vault skill's HashiCorp Vault integration section. Repo confirmed via GitHub API 2026-07-30 (ansible-collections/community.hashi_vault, latest tag v7.1.0); sources.md pins no verified-against version."
+notes = "Lookup plugin configuration, token auth, AppRole auth for the ansible-vault skill's HashiCorp Vault integration section. claude-skills-223: installed live via `ansible-galaxy collection install community.hashi_vault` (7.1.0) and verified via `ansible-doc -t lookup -j` that url/token/auth_method/role_id/secret_id/return_format options and the auth_method choices (token/userpass/ldap/approle/aws_iam/azure/jwt/cert/gcp/none) all exist as documented."
 
 # ----------------------------------------------------------------------------
 # Molecule — standalone testing framework for Ansible roles/collections,
@@ -71,12 +91,12 @@ url = "https://molecule.readthedocs.io/en/latest/"
 releases_url = "https://github.com/ansible/molecule/releases"
 check_method = "github-releases"
 github_repo = "ansible/molecule"
-current_version = "unknown"
+current_version = "26.6.0"
 version_constraint = "semver"
-last_checked = "2026-07-30"
-update_priority = "medium"
-breaking_changes_likely = false
-notes = "Scenarios, drivers, phases, verify, lint, CI integration for ansible-testing. Repo confirmed via GitHub API 2026-07-30 (ansible/molecule, latest tag v26.6.0, calendar-versioned); sources.md pins no verified-against version."
+last_checked = "2026-08-04"
+update_priority = "high"
+breaking_changes_likely = true
+notes = "Scenarios, drivers, phases, verify, lint, CI integration for ansible-testing. claude-skills-223: installed live via `pipx install molecule` (26.6.0) and found substantial drift from the skill's documented content — the classic `driver:`/`platforms:`/`provisioner:`/`verifier:`/`lint:` top-level molecule.yml schema is GONE (verified via a real `molecule init scenario` run, both with and without molecule-plugins[docker] installed: the generated file now has `dependency:`/`ansible:`(cfg/env/executor/playbooks)/`scenario:`(name/test_sequence) keys instead), the standalone `molecule lint` command no longer exists (`Error: No such command 'lint'.`), the default test-phase order changed (now dependency→cleanup→destroy→syntax→create→prepare→converge→idempotence→side_effect→verify→cleanup→destroy per `molecule test --help`'s own docstring), and `molecule init scenario --driver-name` errors live (`Error: No such option '--driver-name'.`). update_priority raised to high / breaking_changes_likely set true given this drift. The Testinfra assertion API section (module/property names) was independently verified correct and NOT affected by the schema change."
 
 # ----------------------------------------------------------------------------
 # ansible-lint — standalone linter, backs the ansible-testing skill's rule
@@ -89,12 +109,12 @@ url = "https://ansible-lint.readthedocs.io/"
 releases_url = "https://github.com/ansible/ansible-lint/releases"
 check_method = "github-releases"
 github_repo = "ansible/ansible-lint"
-current_version = "unknown"
+current_version = "26.6.0"
 version_constraint = "semver"
-last_checked = "2026-07-30"
+last_checked = "2026-08-04"
 update_priority = "medium"
 breaking_changes_likely = false
-notes = "Rule profiles, configuration, CI integration for ansible-testing. Repo confirmed via GitHub API 2026-07-30 (ansible/ansible-lint, latest tag v26.6.0, calendar-versioned, shares release cadence with molecule); sources.md pins no verified-against version."
+notes = "Rule profiles, configuration, CI integration for ansible-testing. claude-skills-223: installed live via `pipx install ansible-lint` (26.6.0) and verified via `ansible-lint --list-profiles` that the 6 profiles are min/basic/moderate/safety/shared/production (each extending the previous), confirming the skill's claim that safety/shared/production are valid profile names with production being strictest."
 
 # ----------------------------------------------------------------------------
 # Testinfra (pytest-testinfra) — standalone assertion library used in
@@ -107,9 +127,9 @@ url = "https://testinfra.readthedocs.io/en/latest/"
 releases_url = "https://github.com/pytest-dev/pytest-testinfra/releases"
 check_method = "github-releases"
 github_repo = "pytest-dev/pytest-testinfra"
-current_version = "unknown"
+current_version = "10.2.2"
 version_constraint = "semver"
-last_checked = "2026-07-30"
+last_checked = "2026-08-04"
 update_priority = "low"
 breaking_changes_likely = false
-notes = "Built-in modules (file, service, package, command) and assertion patterns for ansible-testing. Repo confirmed via GitHub API 2026-07-30 (pytest-dev/pytest-testinfra, latest tag 10.2.2); sources.md pins no verified-against version."
+notes = "Built-in modules (file, service, package, command) and assertion patterns for ansible-testing. claude-skills-223: installed live via `pipx install --include-deps pytest-testinfra` (10.2.2) and verified directly against source (testinfra/modules/*.py) that package/service/file/socket/command modules and is_installed/is_running/is_enabled/exists/mode/user/is_listening/stdout properties all exist as documented in the skill's Testinfra example."

--- a/plugins/tools/slidev/.claude-plugin/plugin.json
+++ b/plugins/tools/slidev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slidev",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Slidev presentation skills: strategy, branding, interactive demos, markdown slides, syntax, code blocks, export, and troubleshooting",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/slidev/skills/sources.toml
+++ b/plugins/tools/slidev/skills/sources.toml
@@ -3,8 +3,26 @@
 
 [meta]
 plugin = "slidev"
-reviewed_at_plugin_version = "0.2.0"
+reviewed_at_plugin_version = "0.2.6"
 last_full_check = "2026-07-30"
+# claude-skills-223 tier 2, 2026-08-04: PARTIAL pass, not a full check — kept
+# last_full_check unchanged rather than claiming full coverage. Verified
+# claim-by-claim against slidevjs/slidev's actual TypeScript source
+# (packages/types/src/{config,frontmatter}.ts, and the layouts/ and
+# builtin/ component directory listings, all fetched live from GitHub) —
+# the headmatter/frontmatter schema and built-in layout/component NAMES
+# that underpin every other slidev skill. 5 corrections made in
+# syntax/references/syntax.md: exportFilename's real default is an empty
+# string, not "slidev-exported"; mdc is deprecated in favor of comark
+# (undocumented before this pass); clicks has no fixed default of 0 — it's
+# auto-calculated from v-click/v-clicks usage; colorSchema and routerMode
+# were both missing a valid option (`all` and `memory` respectively). NOT
+# independently re-verified this pass: the code/export/interactive/
+# presentations/styles/troubleshooting skills' own detailed claims (export
+# CLI flag behavior, individual layout prop schemas beyond name-existence,
+# Monaco/LaTeX/Mermaid/PlantUML syntax details, the presentation-strategy
+# citations, WCAG/UnoCSS/Vue3 sources) — see the individual [[sources]]
+# entries below, most still marked "Not re-verified live in this pass."
 
 # ----------------------------------------------------------------------------
 # Slidev Syntax Guide — slide separators, frontmatter, headmatter, block

--- a/plugins/tools/slidev/skills/syntax/references/syntax.md
+++ b/plugins/tools/slidev/skills/syntax/references/syntax.md
@@ -41,16 +41,16 @@ The first frontmatter block configures the entire presentation:
 | `author` | string | — | Author name for exported files |
 | `info` | string | `false` | Presentation description (Markdown) |
 | `download` | boolean/string | `false` | Enable PDF download in SPA |
-| `exportFilename` | string | `slidev-exported` | Export file name |
+| `exportFilename` | string \| null | `''` (empty) | Export file name — verified against `packages/types/src/frontmatter.ts` on the slidevjs/slidev GitHub repo: default is an empty string (auto-derived filename), not a literal `"slidev-exported"` |
 | `highlighter` | string | `shiki` | Code highlighter |
 | `lineNumbers` | boolean | `false` | Show line numbers in code blocks |
 | `monaco` | boolean/string | `true` | Enable Monaco editor |
 | `twoslash` | boolean/string | `true` | Enable TwoSlash syntax |
-| `mdc` | boolean | `false` | Enable MDC (Markdown Components) syntax |
-| `colorSchema` | string | `auto` | Color scheme: `auto`, `light`, `dark` |
+| `mdc` | boolean | `false` | **Deprecated** — verified against the same source file (`@deprecated MDC is now Comark. Use the \`comark\` option instead`); the key still works but new decks should use `comark: true` |
+| `colorSchema` | string | `auto` | Color scheme: `auto`, `light`, `dark`, `all` (verified against `packages/types/src/frontmatter.ts`: 4 choices, `all` was missing here) |
 | `aspectRatio` | string | `16/9` | Slide aspect ratio |
 | `canvasWidth` | number | `980` | Canvas width in pixels |
-| `routerMode` | string | `history` | Vue Router mode: `history`, `hash` |
+| `routerMode` | string | `history` | Vue Router mode: `history`, `hash`, `memory` (verified against `packages/types/src/frontmatter.ts`: 3 choices, `memory` — routing kept in memory, URL never reflects slide number, for kiosk/follower decks — was missing here) |
 | `selectable` | boolean | `true` | Allow text selection |
 | `record` | boolean/string | `dev` | Enable slide recording |
 | `presenter` | boolean/string | `true` | Enable presenter mode |
@@ -76,10 +76,10 @@ clicks: 3
 |----------|------|---------|-------------|
 | `layout` | string | `cover`/`default` | Layout component name |
 | `transition` | string/object | — | Slide transition |
-| `clicks` | number | `0` | Custom click animation count |
+| `clicks` | number | auto-calculated | Total clicks needed on this slide — verified against `packages/types/src/frontmatter.ts` on the slidevjs/slidev GitHub repo: there is no fixed default of `0`; when omitted, Slidev calculates it from the `v-click`/`v-clicks` usage on the slide |
 | `clicksStart` | number | `0` | Custom starting click count |
-| `disabled` | boolean | `false` | Disable and hide slide |
-| `hide` | boolean | `false` | Alias for `disabled` |
+| `disabled` | boolean | `false` | Disable and hide slide — same source documents `disabled` as "same as `hide`", i.e. `disabled` is the alias, not the other way around (functionally interchangeable either way) |
+| `hide` | boolean | `false` | Disable and hide slide |
 | `hideInToc` | boolean | `false` | Hide from table of contents |
 | `level` | number | `1` | Title level for TOC |
 | `preload` | boolean | `true` | Pre-mount slide before entry |


### PR DESCRIPTION
- ansible: full claim-by-claim pass across all 5 skills using live-installed tools (ansible-core 2.21.2, molecule 26.6.0, ansible-lint 26.6.0, pytest-testinfra 10.2.2, community.hashi_vault 7.1.0, amazon.aws 11.4.0 via pipx/ansible-galaxy). 9 corrections: Jinja2 `default()` filter boolean semantics were exactly backwards, `flatten`'s default-level claim was backwards, `path_join`'s filter-args syntax errors live, molecule's phase order/`molecule lint` command/`molecule.yml` schema/`init scenario --driver-name` flag are all stale for molecule 26.6.0, `amazon.aws.aws_ssm`'s `errors=` param doesn't exist (real params are `on_missing`/`on_denied`), and the `disabled`/`hide` per-slide frontmatter alias direction was swapped (cosmetic, both keys still work).
- slidev: partial pass — verified the headmatter/frontmatter schema and built-in layout/component names against slidevjs/slidev's actual TypeScript source and directory listings (fetched live from GitHub), plus the CLI command surface via a live `npx @slidev/cli --help`. 5 corrections in syntax/references/syntax.md: `exportFilename`'s real default is an empty string not `"slidev-exported"`; `mdc` is deprecated in favor of `comark` (undocumented before this pass); `clicks` has no fixed default of 0 (auto-calculated from `v-click`/`v-clicks` usage); `colorSchema` and `routerMode` were each missing a valid option (`all` and `memory`).
- ansible-inventory's Azure/GCP dynamic-inventory sections, ansible-testing/references/molecule-scenarios.md (caveated in place, not rewritten — still documents the pre-26.6.0 schema), and slidev's code/export/interactive/presentations/styles/troubleshooting skills' own detailed claims were NOT independently re-verified this pass — flagged explicitly in both sources.toml files, not silently claimed as checked.
- Gate 3 round 2: cited molecule's installed `constants.py` (not just `--help`) for the phase-order claim, since help text is a claim about behavior rather than the behavior itself.
- sources.toml updated for both plugins: real installed-tool versions pinned, `last_full_check` set only where a full check actually happened (ansible), left unchanged for slidev's partial pass.