### PR TITLE
fix(claude-code): remove unverified null==false claim from mutation-probe comment

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.137",
+      "version": "0.4.138",
       "category": "meta",
       "keywords": [
         "skills",
@@ -119,7 +119,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
-      "version": "0.2.74",
+      "version": "0.2.75",
       "category": "tools",
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.137",
+  "version": "0.4.138",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.74",
+  "version": "0.2.75",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/claude-plugins/scripts/mutation-probe.nu
+++ b/plugins/tools/claude-code/skills/claude-plugins/scripts/mutation-probe.nu
@@ -184,12 +184,13 @@ def main [] {
 
   print ($results | select name status | table)
 
-  # `ok? != true` (not `ok == false`) so a result missing the `ok` column or
-  # carrying `ok: null` both count as a gap, the same as an explicit
-  # `ok: false` — every append site above does set `ok` to a literal bool
-  # today, but only `!= true` fails closed for all three "not clearly ok"
-  # shapes; `== false` only catches an explicit `false` and lets `null`
-  # (which `== false` treats as not-equal, not as a match) through.
+  # `ok? != true`: verified directly (piped through both `length` and a
+  # plain print, not just counted) that a result missing the `ok` column, one
+  # carrying `ok: null`, and one carrying `ok: false` are all selected here,
+  # and one carrying `ok: true` is not. Every append site above does set
+  # `ok` to a literal bool today, so none of the first three shapes is
+  # reachable yet — this is what keeps a future append site that forgets to
+  # set `ok` from silently passing.
   let gaps = ($results | where ok? != true)
   if ($gaps | length) > 0 {
     print $"\n(ansi red_bold)($gaps | length) of (($probes | length)) probes did not cleanly confirm coverage — see non-ok rows above.(ansi reset)"


### PR DESCRIPTION
- Follow-up to #238 (already merged) — Gate 3's block on the comment's false `null == false` mechanism crossed with the merge itself; that exact quoted text was already removed before merge, but self-verifying it surfaced a real residual inaccuracy in what landed
- `mutation-probe.nu`'s gap-filter comment claimed "`== false` only catches an explicit `false`" — false: measured `where ok == false` on a record missing the `ok` column returns 1 via `length` (it IS caught), though it crashes on direct table rendering (`nu::shell::column_not_found`) — a genuinely fragile, hard-to-honestly-summarize behavior
- Rewrote the comment to make zero claims about the discarded `== false` alternative and state only what's fully verified about the actual shipped expression (`ok? != true`): missing/null/false all selected, `true` excluded — verified via both `length` and direct print for all four shapes, not just counted
- Re-verified end to end: self-test 199/199, harness 10/10 (each via its expected case), real-file sha unchanged before/after, and a freshly-injected stale probe still exits 1
- Bump `claude-code` 0.2.74→0.2.75, `all-skills` 0.4.137→0.4.138 (re-derived against live `origin/main` immediately before push)