### PR TITLE
chore(skills): add earned anti-fabrication pointers for campaign-verified skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.140",
+      "version": "0.4.141",
       "category": "meta",
       "keywords": [
         "skills",
@@ -85,7 +85,7 @@
       "source": "./plugins/tools/ansible",
       "strict": true,
       "description": "Ansible automation skills: playbooks, inventory, roles, vault secrets, and Molecule testing",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "category": "tools",
       "keywords": [
         "ansible",
@@ -180,7 +180,7 @@
       "source": "./plugins/design",
       "strict": true,
       "description": "Framework-agnostic standards and design systems: accessibility (WCAG) and Material Design 3 — what you review an implementation against, and plan a compliant new one from",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "category": "frontend",
       "keywords": [
         "design",
@@ -385,7 +385,7 @@
       "source": "./plugins/tools/runex",
       "strict": true,
       "description": "Runex workflow engine: API, bundles, step logs, and debugging",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "category": "tools",
       "keywords": [
         "runex",
@@ -433,7 +433,7 @@
       "source": "./plugins/tools/slidev",
       "strict": true,
       "description": "Slidev presentation skills: strategy, branding, interactive demos, markdown slides, syntax, code blocks, export, and troubleshooting",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "category": "tools",
       "keywords": [
         "slidev",
@@ -501,7 +501,7 @@
       "source": "./plugins/wasm",
       "strict": true,
       "description": "WebAssembly skills: wasmtime runtime, component model, guest compilation, and host embedding",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "category": "language",
       "keywords": [
         "wasm",
@@ -537,7 +537,7 @@
       "source": "./plugins/languages/zig",
       "strict": true,
       "description": "Zig programming skills: build system, comptime, allocators, error handling, C interop, testing, and troubleshooting",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "category": "language",
       "keywords": [
         "zig",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.140",
+  "version": "0.4.141",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/design/.claude-plugin/plugin.json
+++ b/plugins/design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "design",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Framework-agnostic standards and design systems: accessibility (WCAG) and Material Design 3 — what you review an implementation against, and plan a compliant new one from",
   "author": {
     "name": "vinnie357"

--- a/plugins/design/skills/accessibility/SKILL.md
+++ b/plugins/design/skills/accessibility/SKILL.md
@@ -17,6 +17,19 @@ Use this skill when:
 - Conducting code reviews with accessibility considerations
 - Refactoring existing interfaces for better accessibility
 
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. The claim area is the WCAG version cited and
+the ARIA Authoring Practices Guide (APG) pattern attributions. Verified against W3C's
+live WCAG22 quickref and the APG patterns index (claude-skills-223): the WCAG citation
+was bumped from 2.1 to 2.2 (2.2 became a Recommendation 2023-10-05, and per its own text
+"content that conforms to WCAG 2.2 also conforms to WCAG 2.0 and WCAG 2.1" — compatibility
+runs 2.2-to-2.1, not the reverse this skill previously implied); and "skip links" was
+corrected from an APG pattern to what it actually is, a WCAG bypass-blocks technique — the
+APG index lists 30 named patterns and skip links is not one of them. Re-verify against
+`w3.org/TR/WCAG22/` before citing a WCAG version or success-criterion number this skill
+doesn't cover.
+
 ## Core Principles (POUR)
 
 Web accessibility is organized around four foundational principles:

--- a/plugins/design/skills/material-design/SKILL.md
+++ b/plugins/design/skills/material-design/SKILL.md
@@ -17,6 +17,20 @@ Use this skill when:
 - Creating Material components
 - Reviewing designs for Material Design compliance
 
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. The claim area is the tonal-palette, type-
+scale, and layout-breakpoint numbers, which come from a living spec rather than a
+versioned release. Verified against m3.material.io plus the first-party
+material-color-utilities source (claude-skills-223), three corrections: tonal palettes
+have 13 tones (0,10,20...90,95,99,100 per `commonTones`), not "50-99 tones per color";
+the type scale is 5 categories x 3 sizes = 15 styles total, not "5 display sizes and 9
+text sizes" (the sp values 57/32/16/11 were already correct); and MD3 now defines 5
+window-size classes, not 3 — Expanded is capped at 1199dp, with Large and Extra-large
+added above it. Re-verify against `m3.material.io` before asserting a token count or
+breakpoint this skill doesn't cover — Google updates this spec continuously, with no
+versioned release to pin against.
+
 ## What is Material Design 3?
 
 Material Design 3 (Material You) represents Google's latest design system with:

--- a/plugins/languages/zig/.claude-plugin/plugin.json
+++ b/plugins/languages/zig/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zig",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Zig programming skills: build system, comptime, allocators, error handling, C interop, testing, and troubleshooting",
   "author": {
     "name": "vinnie357"

--- a/plugins/languages/zig/skills/allocators/SKILL.md
+++ b/plugins/languages/zig/skills/allocators/SKILL.md
@@ -16,3 +16,13 @@ Activate when:
 - Writing allocator-aware library code
 
 For allocator types, patterns, and examples, see `references/allocators.md`.
+
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. Verified against zig 0.16.0 (locally
+installed, claude-skills-204): `references/allocators.md`'s `DebugAllocator` snippets
+compile and pass as `zig test` — this file already had the correct `init` form
+(`pub const init: Self = .{};`, a value, not a function call); a contradicting
+function-call form was found and fixed in the troubleshooting skill instead, not here.
+Re-verify against a locally installed `zig test` before asserting an allocator API this
+skill doesn't cover — `std.heap`'s allocator-init pattern changed between 0.15 and 0.16.

--- a/plugins/languages/zig/skills/build/SKILL.md
+++ b/plugins/languages/zig/skills/build/SKILL.md
@@ -17,3 +17,15 @@ Activate when:
 - Managing build.zig.zon dependencies
 
 For detailed build.zig patterns, API methods, and examples, see `references/build.md`.
+
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. Verified against zig 0.16.0 (locally
+installed, claude-skills-204): `references/build.md`'s `build.zig` + `build.zig.zon`
+sample builds, tests, and runs end to end, and the documented flags (`--watch`,
+`-fincremental`, `--time-report`, `-Doptimize`, `-Dtarget`) are all present in
+`zig build --help` — no corrections needed. Re-verify against a locally installed
+`zig build --help` and a real build before asserting a flag or API this skill doesn't
+cover — Zig is pre-1.0 and the build system has broken across minor releases before
+(0.15's Writergate, 0.16's `root_source_file`/`.fingerprint` changes this file already
+documents).

--- a/plugins/languages/zig/skills/c-interop/SKILL.md
+++ b/plugins/languages/zig/skills/c-interop/SKILL.md
@@ -17,3 +17,14 @@ Activate when:
 - Linking C libraries in build.zig
 
 For type mappings, linking patterns, and string interop examples, see `references/c-interop.md`.
+
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. Verified against zig 0.16.0 (locally
+installed, claude-skills-204): `references/c-interop.md`'s type mappings and linking
+snippets compile as documented — no corrections needed here. A related claim, that
+`@cImport` emits a deprecation warning, was found wrong and corrected, but that
+claim lived in the troubleshooting skill's compiler-error catalog, not in this file.
+Re-verify against a locally installed `zig build-exe` with a real C header before
+asserting a type mapping this skill doesn't cover — Zig is pre-1.0 and `translate-c`
+behavior has changed across minor releases.

--- a/plugins/languages/zig/skills/language/SKILL.md
+++ b/plugins/languages/zig/skills/language/SKILL.md
@@ -16,6 +16,17 @@ Activate when:
 - Working with slices, arrays, pointers, and strings
 - Using defer/errdefer for resource cleanup
 
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. Verified against zig 0.16.0 (locally
+installed, claude-skills-204) by compiling the documented snippets:
+`references/language.md`'s `defer` example opened a file with `std.fs.cwd()`, which does
+not exist at 0.16.0 — rewritten against `std.Io.Dir.cwd().openFile(io, ...)` /
+`file.close(io)`, with the pre-0.16 form kept as a note for readers on older
+toolchains. Re-verify against a locally installed `zig version` before asserting a
+`std` API this skill doesn't cover — Zig is pre-1.0 and `std` breaks across minor
+releases.
+
 ## Key Topics
 
 For detailed syntax, patterns, and examples, see `references/language.md`.

--- a/plugins/languages/zig/skills/testing/SKILL.md
+++ b/plugins/languages/zig/skills/testing/SKILL.md
@@ -17,3 +17,11 @@ Activate when:
 - Skipping platform-specific tests
 
 For assertion functions, test allocator patterns, and build integration, see `references/testing.md`.
+
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. Verified against zig 0.16.0 (locally
+installed, claude-skills-204): `references/testing.md`'s snippets compile and pass as
+`zig test` — no corrections needed. Re-verify against a locally installed `zig test`
+before asserting a testing-framework API this skill doesn't cover — Zig is pre-1.0 and
+`std` breaks across minor releases.

--- a/plugins/languages/zig/skills/troubleshooting/SKILL.md
+++ b/plugins/languages/zig/skills/troubleshooting/SKILL.md
@@ -17,3 +17,17 @@ Activate when:
 - Understanding error return traces
 
 For error catalogs, debugging patterns, and common pitfalls, see `references/troubleshooting.md`.
+
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. This file carried three of the six
+corrections found across the plugin (claude-skills-204, verified against zig 0.16.0
+locally installed by compiling the documented snippets): `references/
+troubleshooting.md` called `std.heap.DebugAllocator(.{}).init(...)` a function call —
+at 0.16.0 `init` is a constant, not callable, so the snippet did not compile; it listed
+`@cImport` deprecation warnings as an observed error, but `@cImport` compiles silently
+at 0.16.0 (the deprecation is release-notes-only); and it read `std.process.Child` as
+removed in favor of `std.process.spawn`, when `Child` still exists as the handle type
+`spawn` returns — only `Child.run`/`Child.init` moved to free functions. All three
+reworded. Re-verify against a locally installed `zig build-exe` reproducing the actual
+error before asserting a diagnostic this skill doesn't cover.

--- a/plugins/languages/zig/skills/zig/SKILL.md
+++ b/plugins/languages/zig/skills/zig/SKILL.md
@@ -15,6 +15,20 @@ Activate when:
 - Migrating a project between Zig versions
 - Unsure which specific Zig skill to load
 
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. Zig is pre-1.0 with every minor release
+breaking `std` and build APIs, so version-migration claims are the highest-risk content
+in this plugin. Verified against zig 0.16.0 (locally installed, claude-skills-204) by
+compiling the documented snippets: `references/migration-0.16.md`'s claim that
+`std.c.arc4random_buf` is BSD/Darwin-only was refuted by its own citation (`lib/std/c.zig`
+covers Linux/Android too) and corrected to a compile-probed target table, and
+`references/version-history.md`'s listing of `fmt.bufPrintZ` under "Renamed" was
+corrected — it is still present, deprecated in favor of `bufPrintSentinel`. Re-verify
+against a locally installed `zig version` before asserting a `std` API claim this skill
+doesn't cover — see `plugins/languages/zig/skills/sources.md` for the full per-claim
+record.
+
 ## Available Skills
 
 This plugin provides focused skills for specific Zig topics:

--- a/plugins/tools/ansible/.claude-plugin/plugin.json
+++ b/plugins/tools/ansible/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ansible",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Ansible automation skills: playbooks, inventory, roles, vault secrets, and Molecule testing",
   "author": {
     "name": "rginnow"

--- a/plugins/tools/ansible/skills/ansible-inventory/SKILL.md
+++ b/plugins/tools/ansible/skills/ansible-inventory/SKILL.md
@@ -8,6 +8,23 @@ license: MIT
 
 Activate when defining which hosts Ansible should manage, grouping hosts, setting connection parameters, or configuring dynamic inventory sources like AWS or Azure.
 
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. The claim area is `references/dynamic-
+inventory.md`'s three dynamic-inventory plugin option tables — aws_ec2, azure_rm,
+gcp_compute — plus the `--limit` pattern syntax and connection-vars table, all
+independently verified against live-installed collections (claude-skills-223):
+aws_ec2/constructed against ansible-core 2.21.2; azure_rm against azure.azcollection
+3.21.0 via `ansible-doc -t inventory azure.azcollection.azure_rm` (3 corrections —
+`exclude_vm_resource_groups` does not exist, `hostnames: [default]` hashes the name
+rather than using it plain, `auth_source: auto`'s precedence comment omitted a step);
+gcp_compute against google.cloud 1.14.0 via `ansible-doc -t inventory
+google.cloud.gcp_compute` plus its source (1 correction — `auth_kind` is required with
+no default). One item stays explicitly unverified: whether GCP's `aggregatedList`
+filter needs quoted string label values — no live GCP project was available to test.
+Re-verify against a current `ansible-doc -t inventory` for the plugin in question before
+asserting an option this skill doesn't cover.
+
 ## What Is Inventory
 
 An inventory maps the control node's knowledge of managed nodes. At minimum it lists hostnames or IP addresses. Inventory also defines groups, per-host and per-group variables, and connection parameters.

--- a/plugins/tools/ansible/skills/ansible-roles/SKILL.md
+++ b/plugins/tools/ansible/skills/ansible-roles/SKILL.md
@@ -8,6 +8,18 @@ license: MIT
 
 Activate when creating reusable role structures, using `import_role:` or `include_role:`, writing Jinja2 templates, or working with Ansible Galaxy collections and roles.
 
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. The claim area is role directory conventions,
+`meta/main.yml` fields, and the Jinja2 filters used in role templates. Verified against
+ansible-core 2.21.2 (pipx-installed live, claude-skills-223): the `default()` filter's
+boolean-argument semantics and `flatten`'s default-level behavior were both found
+backwards from what the skill documented and corrected — this is exactly the kind of
+inverted claim a docs-only read misses. The role directory layout itself is stable
+Ansible convention, low risk. `ansible-galaxy` hub-doc conventions (requirements.yml,
+collection installs) were last checked 2026-05-06, not re-verified this pass — treat
+those as lower-confidence than the filter/role corrections above.
+
 ## What Are Roles
 
 A role is a self-contained directory of tasks, handlers, variables, templates, and files organized for reuse. Instead of copying tasks between playbooks, extract them into a role and apply the role wherever needed.

--- a/plugins/tools/ansible/skills/ansible-vault/SKILL.md
+++ b/plugins/tools/ansible/skills/ansible-vault/SKILL.md
@@ -8,6 +8,18 @@ license: MIT
 
 Activate when encrypting secrets, managing vault passwords, configuring vault IDs, or applying security hardening to Ansible playbooks and variable files.
 
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. The `ansible-vault` CLI commands are stable
+core-Ansible surface, low risk. The real claim area is `references/secret-backends.md`'s
+HashiCorp Vault lookup plugin options (`url`, `token`, `auth_method`, `role_id`,
+`secret_id`, `return_format`). Verified against community.hashi_vault 7.1.0
+(ansible-galaxy-installed live, claude-skills-223) via `ansible-doc -t lookup -j`: those
+option names and the `auth_method` choices (token/userpass/ldap/approle/aws_iam/azure/
+jwt/cert/gcp/none) all exist as documented. Re-verify against a current
+`ansible-doc community.hashi_vault.hashi_vault` before asserting an option this skill
+doesn't cover — the collection version-pins independently of ansible-core.
+
 ## Why Vault Exists
 
 Secrets (passwords, API keys, certificates) must never be committed to version control in plaintext. Ansible Vault encrypts secrets at rest using AES-256 so they can be safely committed to git while remaining usable by Ansible at runtime.

--- a/plugins/tools/ansible/skills/ansible/SKILL.md
+++ b/plugins/tools/ansible/skills/ansible/SKILL.md
@@ -8,6 +8,18 @@ license: MIT
 
 Activate when working with Ansible playbooks, tasks, variables, handlers, conditionals, loops, or setting up an Ansible project from scratch.
 
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. The claim area is playbook/task/variable
+behavior — precedence order, module params, CLI flags — which drifts across Ansible
+releases. Verified against ansible-core 2.21.2 (pipx-installed live, claude-skills-223):
+the variable precedence order (role defaults < host_vars < play vars < vars_files <
+extra-vars) was confirmed with four live adjacent-pair test playbooks, not assumed from
+docs, and `when:` list ANDing plus `check_mode: false` were confirmed correct. Re-verify
+against a current `ansible-playbook --version` before asserting a flag or precedence rule
+this skill doesn't cover; see `plugins/tools/ansible/skills/sources.toml` for the full
+per-claim record.
+
 ## What Is Ansible
 
 Ansible is an agentless, push-based automation tool. The control node (your machine) connects to managed nodes (servers) over SSH and runs tasks declared in YAML files called playbooks. There is no agent to install on managed nodes — only Python and SSH access are required.

--- a/plugins/tools/runex/.claude-plugin/plugin.json
+++ b/plugins/tools/runex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "runex",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Runex workflow engine: API, bundles, step logs, and debugging",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/runex/skills/runex/SKILL.md
+++ b/plugins/tools/runex/skills/runex/SKILL.md
@@ -25,6 +25,19 @@ registered as `"runex"` rather than `"runex_sub"`), not a documentation error he
 
 Current documented version: **0.0.7** (`mix.exs @version`). Legacy templates for older deployments remain under `templates/0.1.0/` and `scripts/0.1.0/`.
 
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. Runex is a workspace-owned strategic surface
+with the fastest cadence this marketplace documents, so every claim above the fold is
+checked against the source tree rather than release notes. Verified against runex
+0.0.7 (`mix.exs @version`, re-confirmed 2026-08-04, claude-skills-223): the driver list
+was corrected from 8 to the real 14 registered in `Runex.Driver.@drivers`, and workflow
+path resolution was corrected from 3 to the real 4 search roots in `Paths.workflows_dirs/
+0`. A Gate 3 pass then caught the `execution_class/1` naming-drift documented above as an
+upstream bug, not a doc error (filed separately, claude-skills-239). Re-verify against
+the live `lib/runex/driver.ex` and `mix.exs @version` before asserting a driver name or
+version this skill doesn't cover — this is the fastest-moving source in the repo.
+
 ## When to Use This Skill
 
 Activate when:

--- a/plugins/tools/slidev/.claude-plugin/plugin.json
+++ b/plugins/tools/slidev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slidev",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Slidev presentation skills: strategy, branding, interactive demos, markdown slides, syntax, code blocks, export, and troubleshooting",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/slidev/skills/code/SKILL.md
+++ b/plugins/tools/slidev/skills/code/SKILL.md
@@ -19,3 +19,19 @@ Activate when:
 - Importing code snippets from external files
 
 For code block syntax, highlighting options, and editor configuration, see `references/code.md`.
+
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. Verified claim-by-claim against live
+slidevjs/slidev source (claude-skills-223, 2026-08-05) — line-highlighting and Magic
+Move against `docs/features/line-highlighting.md` and `docs/features/shiki-magic-move.md`
+(added the undocumented `{hide}`/`{none}` line values and Magic Move's `{at:}`/`duration`/
+title-bar options); code groups against `docs/features/code-groups.md` (corrected: groups
+require `comark: true`, not `mdc: true` — `mdc` is a deprecated-but-working alias);
+Monaco editor against `docs/features/monaco-editor.md` and `packages/types/src/
+frontmatter.ts` (all confirmed, no changes); import-snippet against `docs/features/
+import-snippet.md` (confirmed exact match including the "since v0.47.0" version claim).
+The `finally` code-block option was independently re-verified against source
+(`CodeBlockWrapper.vue`'s prop declaration) after two earlier revisions of this pass
+wrongly called it nonexistent from a docs-only search. Re-verify against a fresh
+`slidevjs/slidev` clone before asserting a code-block feature this skill doesn't cover.

--- a/plugins/tools/slidev/skills/export/SKILL.md
+++ b/plugins/tools/slidev/skills/export/SKILL.md
@@ -17,3 +17,17 @@ Activate when:
 - Troubleshooting Playwright dependencies for export
 
 For export commands, format options, CLI flags, and build configuration, see `references/export.md`.
+
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. Verified claim-by-claim against live
+slidevjs/slidev source (claude-skills-223, 2026-08-05): the export CLI flags against
+`packages/slidev/node/commands/export.ts` (`getExportOptions`) — all existing defaults
+confirmed (`format=pdf`, `timeout=30000`, `dark=false`, `omit-background=false`,
+`wait-until=networkidle`), `--wait`'s documented default corrected from blank to `0`,
+and `--per-slide`/`--scale` added as real flags the skill previously omitted; the dev/
+build/eject CLI against `packages/slidev/node/cli.ts` — added the entirely undocumented
+`export-notes` command plus `--base`/`--log`/`--inspect`/`--tunnel` for the dev server
+and `--router-mode` for build. Re-verify against `slidev export --help` / `slidev build
+--help` on a current install before asserting a flag this skill doesn't cover — Slidev's
+CLI surface grows between minor versions.

--- a/plugins/wasm/.claude-plugin/plugin.json
+++ b/plugins/wasm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "WebAssembly skills: wasmtime runtime, component model, guest compilation, and host embedding",
   "author": {
     "name": "vinnie357"

--- a/plugins/wasm/skills/wasmtime/SKILL.md
+++ b/plugins/wasm/skills/wasmtime/SKILL.md
@@ -18,6 +18,19 @@ Activate when:
 - Building plugin systems with WebAssembly sandboxing
 - Optimizing wasm module size or runtime performance
 
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. Wasmtime ships major-version bumps roughly
+monthly, so pinned versions and API paths are high-risk. Verified against wasmtime
+47.0.3 (crates.io, claude-skills-204): the host/guest Rust examples were pinned to a
+stale "29" and used the pre-reorg `wasmtime_wasi` API — corrected to the `p1::`/`p2::`
+submodule layout confirmed against docs.rs/wasmtime-wasi/latest, and `WasiView::ctx()`
+was corrected to return a single `WasiCtxView<'_>` rather than separate `ctx()`/`table()`
+methods. WASI 0.3.0 native-async coverage (stream/future in the Component Model,
+requires Wasmtime 46+) was added, confirmed against wasi.dev and bytecodealliance.org.
+Re-verify against `docs.rs/wasmtime/latest` before asserting an API this skill doesn't
+cover — this crate changes fast enough that a stale example compiles against nothing.
+
 ## Core Concepts
 
 | Concept | Purpose |

--- a/plugins/wasm/skills/wit/SKILL.md
+++ b/plugins/wasm/skills/wit/SKILL.md
@@ -21,6 +21,16 @@ Activate when:
 - Structuring packages and namespaces for wasm components
 - Composing components via shared interfaces
 
+## Anti-fabrication
+
+This skill follows `core:anti-fabrication`. The claim area is the WIT type system and
+package syntax (packages, interfaces, worlds, records/variants/enums/flags, resources,
+`use` declarations, `result<T,E>`, `borrow<T>`), shared with wasmtime under the same
+Bytecode Alliance umbrella. Re-verified live 2026-08-04 (claude-skills-204) against
+component-model.bytecodealliance.org's design/wit.html: no drift found in the documented
+syntax. Re-verify against that page, or `wasm-tools component wit`, before asserting a
+type-system feature this skill doesn't cover — the Component Model is still evolving.
+
 ## WIT File Structure
 
 A WIT file contains one or more of: package declaration, interfaces, worlds, and use declarations.

--- a/test/quality-baseline.json
+++ b/test/quality-baseline.json
@@ -1,36 +1,8 @@
 {
-  "_comment": "Ratchet baseline for test/validate-skills-quality.nu. Each allowed_failures entry is a record: key (plugin/skill:check; corpus-wide duplicate groups use dupe/<md5-8 of the sorted member file set>:duplicate_block — the validator prints each group's member paths; syntax-vs-usage vocabulary findings use syntax/<format>:vocab_disjoint for the formats commands/agents/hooks — the validator prints both vocabularies), class (BUG | DEBT | CHECK_DEFECT — CHECK_DEFECT means the check itself is defective; the entry's issue field names the tracker item for the check fix), issue (tracker id the waiver is filed under), first_seen (ISO date, or the literal 'migrated' for entries predating the schema), detail_count (integer for detail-producing checks: lines/links/orphans/invocations/version_pin/ref_depth/duplicate_block/vocab_disjoint/fm_schema; null otherwise). Entries are pre-existing failures allowed to keep failing at their recorded count. Do not add entries for new code; fix the skill instead. When a fix lands or a count drops, the validator requires shrinking the baseline. Regenerate: nu test/validate-skills-quality.nu --update-baseline (shrink-only — removes fixed keys and lowers counts; errors instead of adding keys, never raises a count). Known residual: the ratchet bounds the NUMBER of findings per waived check, not their identity, so a same-commit swap of one finding for another of equal size passes.",
+  "_comment": "Ratchet baseline for test/validate-skills-quality.nu. Each allowed_failures entry is a record: key (plugin/skill:check; corpus-wide duplicate groups use dupe/<md5-8 of the sorted member file set>:duplicate_block — the validator prints each group's member paths; syntax-vs-usage vocabulary findings use syntax/<format>:vocab_disjoint for the formats commands/agents/hooks — the validator prints both vocabularies), class (BUG | DEBT | CHECK_DEFECT | ACCEPTED — CHECK_DEFECT means the check itself is defective, entry's issue field names the tracker item for the check fix; ACCEPTED means a reviewed, closed verdict that the finding stays permanently by design rather than outstanding debt, entry's issue field names the tracker item the verdict was decided under — both are excluded from the burn-down total and reported separately so neither exclusion reads as progress), issue (tracker id the waiver is filed under), first_seen (ISO date, or the literal 'migrated' for entries predating the schema), detail_count (integer for detail-producing checks: lines/links/orphans/invocations/version_pin/ref_depth/duplicate_block/vocab_disjoint/fm_schema; null otherwise). Entries are pre-existing failures allowed to keep failing at their recorded count. Do not add entries for new code; fix the skill instead. When a fix lands or a count drops, the validator requires shrinking the baseline. Regenerate: nu test/validate-skills-quality.nu --update-baseline (shrink-only — removes fixed keys and lowers counts; errors instead of adding keys, never raises a count). Known residual: the ratchet bounds the NUMBER of findings per waived check, not their identity, so a same-commit swap of one finding for another of equal size passes.",
   "allowed_failures": [
     {
-      "key": "ansible/ansible-inventory:anti_fab",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "ansible/ansible-roles:anti_fab",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
       "key": "ansible/ansible-testing:anti_fab",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "ansible/ansible-vault:anti_fab",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "ansible/ansible:anti_fab",
       "class": "DEBT",
       "issue": "claude-skills-144",
       "first_seen": "migrated",
@@ -79,22 +51,8 @@
       "detail_count": null
     },
     {
-      "key": "design/accessibility:anti_fab",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "design/material-design:anti_fab",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
       "key": "dupe/28ccd32d:duplicate_block",
-      "class": "DEBT",
+      "class": "ACCEPTED",
       "issue": "claude-skills-148",
       "first_seen": "2026-07-26",
       "detail_count": 7
@@ -136,27 +94,6 @@
     },
     {
       "key": "elixir/tidewave:anti_fab",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "runex/runex:anti_fab",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "slidev/code:anti_fab",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "slidev/export:anti_fab",
       "class": "DEBT",
       "issue": "claude-skills-144",
       "first_seen": "migrated",
@@ -206,69 +143,6 @@
     },
     {
       "key": "ui/daisyui:anti_fab",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "wasm/wasmtime:anti_fab",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "wasm/wit:anti_fab",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "zig/allocators:anti_fab",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "zig/build:anti_fab",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "zig/c-interop:anti_fab",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "zig/language:anti_fab",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "zig/testing:anti_fab",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "zig/troubleshooting:anti_fab",
-      "class": "DEBT",
-      "issue": "claude-skills-144",
-      "first_seen": "migrated",
-      "detail_count": null
-    },
-    {
-      "key": "zig/zig:anti_fab",
       "class": "DEBT",
       "issue": "claude-skills-144",
       "first_seen": "migrated",

--- a/test/validate-skills-quality.nu
+++ b/test/validate-skills-quality.nu
@@ -670,12 +670,12 @@ def run-braced-claude-self-test [] {
 # Validate the baseline's allowed_failures entries. Records only — a bare
 # string entry (the pre-claude-skills-132 shape) is a hard failure, because a
 # hand-added string would bypass class/issue/detail_count permanently.
-# Required: key, class (BUG|DEBT|CHECK_DEFECT), issue. first_seen is an ISO
-# date for new entries or the literal "migrated" for pre-schema ones.
+# Required: key, class (BUG|DEBT|CHECK_DEFECT|ACCEPTED), issue. first_seen is
+# an ISO date for new entries or the literal "migrated" for pre-schema ones.
 # detail_count must be an integer for detail-producing checks (DETAIL_CHECKS),
 # null otherwise. Returns a list of error strings; empty means valid.
 def validate-baseline-entries [entries: list] {
-    let valid_classes = ["BUG" "DEBT" "CHECK_DEFECT"]
+    let valid_classes = ["BUG" "DEBT" "CHECK_DEFECT" "ACCEPTED"]
     mut errors = []
     for entry in $entries {
         let kind = ($entry | describe)
@@ -694,9 +694,9 @@ def validate-baseline-entries [entries: list] {
         }
         let class = ($entry | get -o class | default "")
         if ($class | is-empty) {
-            $errors = ($errors | append $"($key): missing required 'class' \(BUG | DEBT | CHECK_DEFECT\)")
+            $errors = ($errors | append $"($key): missing required 'class' \(BUG | DEBT | CHECK_DEFECT | ACCEPTED\)")
         } else if ($class not-in $valid_classes) {
-            $errors = ($errors | append $"($key): invalid class '($class)' — must be BUG, DEBT, or CHECK_DEFECT")
+            $errors = ($errors | append $"($key): invalid class '($class)' — must be BUG, DEBT, CHECK_DEFECT, or ACCEPTED")
         }
         if (($entry | get -o issue | default "") | is-empty) {
             $errors = ($errors | append $"($key): missing required 'issue' \(tracker id the waiver is filed under\)")
@@ -825,13 +825,21 @@ def accumulate-findings [failing_keys: list, failing_counts: list, entries: list
     {failing_keys: $fk, failing_counts: $fc}
 }
 
-# Burn-down split for the summary line: CHECK_DEFECT entries are defects in
-# the checks themselves (each entry's issue field names the tracker item),
-# not skill debt — they must be reported separately so their exclusion
-# cannot read as progress.
+# Burn-down split for the summary line. Two classes are excluded from the
+# burn total, for different reasons, and both must be reported separately so
+# neither exclusion can read as progress:
+# - CHECK_DEFECT: defects in the checks themselves (each entry's issue field
+#   names the tracker item), not skill debt.
+# - ACCEPTED (claude-skills-259): a reviewed, closed verdict that the finding
+#   stays — e.g. dupe/28ccd32d's assess-no-dedupe call under claude-skills-148
+#   (21 shared lines vs core:git's 222, ~20:1 against; cross-plugin
+#   self-containment rules out a pointer). Permanent by design, not
+#   outstanding debt still to burn down; counting it in the burn total made
+#   the total not shrink even after the verdict was final.
 def burn-down-counts [baseline: list] {
     let excluded = ($baseline | where {|e| ($e | get -o class) == "CHECK_DEFECT"} | length)
-    {burn: (($baseline | length) - $excluded), excluded: $excluded}
+    let accepted = ($baseline | where {|e| ($e | get -o class) == "ACCEPTED"} | length)
+    {burn: (($baseline | length) - $excluded - $accepted), excluded: $excluded, accepted: $accepted}
 }
 
 # Embedded self-test for the baseline schema + count ratchet
@@ -914,14 +922,15 @@ def run-baseline-self-test [] {
         $failed = true
     }
 
-    # Case 10: CHECK_DEFECT entries excluded from the burn-down total but
-    # reported in the excluded figure
+    # Case 10: CHECK_DEFECT and ACCEPTED entries both excluded from the
+    # burn-down total but reported in their own separate figures
     let bd = (burn-down-counts [
         {key: "a/b:anti_fab", class: "DEBT", issue: "i"}
         {key: "c/d:reserved", class: "CHECK_DEFECT", issue: "claude-skills-130"}
+        {key: "e/f:duplicate_block", class: "ACCEPTED", issue: "claude-skills-148"}
     ])
-    if not ($bd.burn == 1 and $bd.excluded == 1) {
-        print $"(ansi red_bold)❌ baseline self-test: burn-down split wrong \(burn ($bd.burn), excluded ($bd.excluded)\)(ansi reset)"
+    if not ($bd.burn == 1 and $bd.excluded == 1 and $bd.accepted == 1) {
+        print $"(ansi red_bold)❌ baseline self-test: burn-down split wrong \(burn ($bd.burn), excluded ($bd.excluded), accepted ($bd.accepted)\)(ansi reset)"
         $failed = true
     }
 
@@ -2857,7 +2866,7 @@ def main [--update-baseline, --self-test] {
     if ($baseline_errors | is-not-empty) {
         print $"(ansi red_bold)❌ ($baseline_errors | length) invalid baseline entries in ($baseline_path):(ansi reset)"
         for e in $baseline_errors { print $"  ($e)" }
-        print "Every allowed_failures entry must be a record: {key, class (BUG|DEBT|CHECK_DEFECT), issue, first_seen, detail_count}."
+        print "Every allowed_failures entry must be a record: {key, class (BUG|DEBT|CHECK_DEFECT|ACCEPTED), issue, first_seen, detail_count}."
         exit 1
     }
     let baseline_keys = ($baseline | each {|e| $e.key})
@@ -3513,7 +3522,7 @@ def main [--update-baseline, --self-test] {
             }
             | sort-by key)
         {
-            "_comment": "Ratchet baseline for test/validate-skills-quality.nu. Each allowed_failures entry is a record: key (plugin/skill:check; corpus-wide duplicate groups use dupe/<md5-8 of the sorted member file set>:duplicate_block — the validator prints each group's member paths; syntax-vs-usage vocabulary findings use syntax/<format>:vocab_disjoint for the formats commands/agents/hooks — the validator prints both vocabularies), class (BUG | DEBT | CHECK_DEFECT — CHECK_DEFECT means the check itself is defective; the entry's issue field names the tracker item for the check fix), issue (tracker id the waiver is filed under), first_seen (ISO date, or the literal 'migrated' for entries predating the schema), detail_count (integer for detail-producing checks: lines/links/orphans/invocations/version_pin/ref_depth/duplicate_block/vocab_disjoint/fm_schema; null otherwise). Entries are pre-existing failures allowed to keep failing at their recorded count. Do not add entries for new code; fix the skill instead. When a fix lands or a count drops, the validator requires shrinking the baseline. Regenerate: nu test/validate-skills-quality.nu --update-baseline (shrink-only — removes fixed keys and lowers counts; errors instead of adding keys, never raises a count). Known residual: the ratchet bounds the NUMBER of findings per waived check, not their identity, so a same-commit swap of one finding for another of equal size passes."
+            "_comment": "Ratchet baseline for test/validate-skills-quality.nu. Each allowed_failures entry is a record: key (plugin/skill:check; corpus-wide duplicate groups use dupe/<md5-8 of the sorted member file set>:duplicate_block — the validator prints each group's member paths; syntax-vs-usage vocabulary findings use syntax/<format>:vocab_disjoint for the formats commands/agents/hooks — the validator prints both vocabularies), class (BUG | DEBT | CHECK_DEFECT | ACCEPTED — CHECK_DEFECT means the check itself is defective, entry's issue field names the tracker item for the check fix; ACCEPTED means a reviewed, closed verdict that the finding stays permanently by design rather than outstanding debt, entry's issue field names the tracker item the verdict was decided under — both are excluded from the burn-down total and reported separately so neither exclusion reads as progress), issue (tracker id the waiver is filed under), first_seen (ISO date, or the literal 'migrated' for entries predating the schema), detail_count (integer for detail-producing checks: lines/links/orphans/invocations/version_pin/ref_depth/duplicate_block/vocab_disjoint/fm_schema; null otherwise). Entries are pre-existing failures allowed to keep failing at their recorded count. Do not add entries for new code; fix the skill instead. When a fix lands or a count drops, the validator requires shrinking the baseline. Regenerate: nu test/validate-skills-quality.nu --update-baseline (shrink-only — removes fixed keys and lowers counts; errors instead of adding keys, never raises a count). Known residual: the ratchet bounds the NUMBER of findings per waived check, not their identity, so a same-commit swap of one finding for another of equal size passes."
             allowed_failures: $shrunk
         } | to json --indent 2 | save -f $baseline_path
         print ""
@@ -3560,11 +3569,14 @@ def main [--update-baseline, --self-test] {
     if $exit_code == 0 {
         print ""
         let bd = (burn-down-counts $baseline)
+        mut suffix = ""
         if $bd.excluded > 0 {
-            print $"Skill quality validation complete! ($bd.burn) debt/bug entries to burn down + ($bd.excluded) check-defects excluded \(see each entry's issue field\)"
-        } else {
-            print $"Skill quality validation complete! ($bd.burn) debt/bug entries to burn down"
+            $suffix = $suffix + $" + ($bd.excluded) check-defects excluded \(see each entry's issue field\)"
         }
+        if $bd.accepted > 0 {
+            $suffix = $suffix + $" + ($bd.accepted) accepted-by-design \(see each entry's issue field\)"
+        }
+        print $"Skill quality validation complete! ($bd.burn) debt/bug entries to burn down($suffix)"
     }
 
     exit $exit_code


### PR DESCRIPTION
- Add scoped `## Anti-fabrication` pointers to 18 SKILL.md files whose content was actually verified claim-by-claim under claude-skills-204/223: ansible (ansible, ansible-roles, ansible-vault, ansible-inventory — not ansible-testing), design (accessibility, material-design), runex (runex), wasm (wasmtime, wit), zig (all 7), slidev (code, export only — the other 6 slidev skills still carry genuinely unverified sources per sources.toml)
- Remove the corresponding 18 keys from `test/quality-baseline.json` (39 → 21 allowed_failures entries)
- Add an `ACCEPTED` baseline class alongside `BUG`/`DEBT`/`CHECK_DEFECT` in `test/validate-skills-quality.nu`, and reclassify `dupe/28ccd32d:duplicate_block` (claude-skills-148's permanent assess-no-dedupe verdict) to it, so it stops inflating the "N debt/bug entries to burn down" burn-down total; extends `burn-down-counts`, the summary print, the schema self-test, and the `_comment` documentation
- Bump patch versions for ansible, design, runex, wasm, zig, slidev, and all-skills in both `plugin.json` and `marketplace.json`; run `mise update-all-skills`
