### PR TITLE
feat(claude-code): add redundant When-to-Use lint gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.150",
+      "version": "0.4.151",
       "category": "meta",
       "keywords": [
         "skills",
@@ -33,7 +33,7 @@
       "source": "./plugins/tools/allium",
       "strict": true,
       "description": "Opinionated Allium integration for /core:agent-loop: attach behavioral specs to epics, propagate TDD tests, weed-check semantic divergence post-CI.",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "category": "tools",
       "keywords": [
         "allium",
@@ -49,7 +49,7 @@
       "source": "./plugins/tools/awman",
       "strict": true,
       "description": "awman: parallel AI code agent sessions with container isolation, worktrees, and a REST API",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "category": "tools",
       "keywords": [
         "awman",
@@ -66,7 +66,7 @@
       "source": "./plugins/tools/altana",
       "strict": true,
       "description": "altana CLI wrapper: delegate prompts to sandboxed AI harnesses, run council fan-outs for diverse perspectives, and distribute tasks across harness presets",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "category": "tools",
       "keywords": [
         "altana",
@@ -104,7 +104,7 @@
       "source": "./plugins/tools/beads",
       "strict": true,
       "description": "Beads (bd) distributed git-backed graph issue tracker: task management, dependency tracking, AI agent workflows",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "category": "tools",
       "keywords": [
         "beads",
@@ -119,7 +119,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
-      "version": "0.2.78",
+      "version": "0.2.79",
       "category": "tools",
       "keywords": [
         "claude-code",
@@ -143,7 +143,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
-      "version": "0.2.62",
+      "version": "0.2.63",
       "category": "development",
       "keywords": [
         "git",
@@ -166,7 +166,7 @@
       "source": "./plugins/tools/dagu",
       "strict": true,
       "description": "Dagu workflow orchestration: workflow authoring, web UI, and REST API",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "category": "tools",
       "keywords": [
         "dagu",
@@ -180,7 +180,7 @@
       "source": "./plugins/design",
       "strict": true,
       "description": "Framework-agnostic standards and design systems: accessibility (WCAG) and Material Design 3 — what you review an implementation against, and plan a compliant new one from",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "category": "frontend",
       "keywords": [
         "design",
@@ -197,7 +197,7 @@
       "source": "./plugins/languages/elixir",
       "strict": true,
       "description": "Elixir development skills: Phoenix, OTP, Ports, Ecto, Tidewave MCP, testing, configuration, style, and anti-patterns",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "category": "language",
       "keywords": [
         "elixir",
@@ -215,7 +215,7 @@
       "source": "./plugins/tools/github",
       "strict": true,
       "description": "GitHub Actions, Workflows, act local testing, community health files, Dependabot consolidation, and PR review",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "category": "tools",
       "keywords": [
         "github",
@@ -238,7 +238,7 @@
       "source": "./plugins/tools/graphify",
       "strict": true,
       "description": "Graphify knowledge-graph tool: build a queryable graph of a codebase and query it instead of reading raw files",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "category": "tools",
       "keywords": [
         "graphify",
@@ -256,7 +256,7 @@
       "source": "./plugins/tools/agent-sandboxing",
       "strict": true,
       "description": "Agent sandboxing for AI coding agents: microVM and kernel-isolated execution environments. Index skill (sandbox) routes to substrate-specific paths. Currently covers the kubernetes-sigs/agent-sandbox path on kind, GKE, and kina (Kubernetes-in-Apple-Containers), with Kata, gVisor, and Apple Container microVM substrates. Ships 7 skills + 6 slash commands + nushell scripts. Designed to expand to non-k8s sandboxing paths.",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "category": "tools",
       "keywords": [
         "agent-sandbox",
@@ -278,7 +278,7 @@
       "source": "./plugins/tools/linear",
       "strict": true,
       "description": "Linear project management: MCP/GraphQL API, VantageEx epic authoring, auditing, and grooming",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "category": "tools",
       "keywords": [
         "linear",
@@ -295,7 +295,7 @@
       "source": "./plugins/tools/playwright",
       "strict": true,
       "description": "Playwright MCP browser automation for Claude Code",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "category": "tools",
       "keywords": [
         "playwright",
@@ -311,7 +311,7 @@
       "source": "./plugins/pm",
       "strict": true,
       "description": "Product management toolkit: harvest implementation-agnostic feature specs from prototypes with SDLC guardrails and author PRDs as implementation contracts",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "category": "tools",
       "keywords": [
         "pm",
@@ -349,7 +349,7 @@
       "source": "./plugins/tools/qa",
       "strict": true,
       "description": "QA team that validates a running application against Gherkin user stories using Playwright and Tidewave",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "category": "tools",
       "keywords": [
         "qa",
@@ -385,7 +385,7 @@
       "source": "./plugins/tools/runex",
       "strict": true,
       "description": "Runex workflow engine: API, bundles, step logs, and debugging",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "category": "tools",
       "keywords": [
         "runex",
@@ -401,7 +401,7 @@
       "source": "./plugins/languages/rust",
       "strict": true,
       "description": "Rust programming skills: ownership, borrowing, lifetimes, async, best practices, anti-patterns, CLI apps, and adversarial-TDD worker agents",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "category": "language",
       "keywords": [
         "rust",
@@ -433,7 +433,7 @@
       "source": "./plugins/tools/slidev",
       "strict": true,
       "description": "Slidev presentation skills: strategy, branding, interactive demos, markdown slides, syntax, code blocks, export, and troubleshooting",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "category": "tools",
       "keywords": [
         "slidev",
@@ -452,7 +452,7 @@
       "source": "./plugins/tools/tweag",
       "strict": true,
       "description": "Tweag tools: Topiary universal code formatter and Nickel configuration language",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "category": "tools",
       "keywords": [
         "tweag",
@@ -469,7 +469,7 @@
       "source": "./plugins/languages/typescript",
       "strict": true,
       "description": "TypeScript development skills: language and type system, Vitest/Jest/Playwright testing, ESLint/typescript-eslint/Biome linting, and the Node.js runtime",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "language",
       "keywords": [
         "typescript",
@@ -486,7 +486,7 @@
       "source": "./plugins/ui",
       "strict": true,
       "description": "UI framework skills: daisyUI components, theming, and responsive design",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "category": "frontend",
       "keywords": [
         "ui",
@@ -501,7 +501,7 @@
       "source": "./plugins/wasm",
       "strict": true,
       "description": "WebAssembly skills: wasmtime runtime, component model, guest compilation, and host embedding",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "category": "language",
       "keywords": [
         "wasm",
@@ -518,7 +518,7 @@
       "source": "./plugins/tools/whamm",
       "strict": true,
       "description": "whamm! WebAssembly bytecode instrumentation: install via mise, the instr/info CLI, injection strategies, and the DTrace-inspired .mm monitor DSL",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "category": "tools",
       "keywords": [
         "whamm",
@@ -537,7 +537,7 @@
       "source": "./plugins/languages/zig",
       "strict": true,
       "description": "Zig programming skills: build system, comptime, allocators, error handling, C interop, testing, and troubleshooting",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "category": "language",
       "keywords": [
         "zig",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.150",
+  "version": "0.4.151",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.62",
+  "version": "0.2.63",
   "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/anti-fabrication/SKILL.md
+++ b/plugins/core/skills/anti-fabrication/SKILL.md
@@ -8,16 +8,6 @@ license: MIT
 
 Strict requirements for ensuring factual, measurable, and validated outputs in all work products including documentation, research, reports, and analysis.
 
-## When to Use This Skill
-
-Activate when:
-- Writing documentation or creating research materials
-- Making claims about system capabilities, performance, or features
-- Providing estimates for time, effort, or complexity
-- Reporting test results or analysis outcomes
-- Creating any content that presents factual information
-- Generating metrics, statistics, or performance data
-
 ## Core Principles
 
 ### Evidence-Based Outputs

--- a/plugins/core/skills/bees/SKILL.md
+++ b/plugins/core/skills/bees/SKILL.md
@@ -8,16 +8,6 @@ license: MIT
 
 This skill activates when working with Bees for issue tracking, dependency management, and AI-augmented workflows.
 
-## When to Use This Skill
-
-Activate when:
-- Managing issues with dependencies in a local repository
-- Exporting issue context for AI agents (`bees list --json`, `bees show --json`)
-- Tracking issue hierarchies and dependency graphs
-- Needing SQLite-backed performance for large issue sets
-- Syncing issues to JSONL for portability (`bees sync`)
-- Working with AI agents that need structured task queues
-
 ## What is Bees?
 
 Bees is a lightweight, local-first issue tracker designed for AI-augmented development:

--- a/plugins/core/skills/code-review/SKILL.md
+++ b/plugins/core/skills/code-review/SKILL.md
@@ -7,16 +7,6 @@ description: Guide for conducting code reviews. Use when reviewing pull requests
 
 This skill activates when reviewing code for quality, correctness, security, and maintainability.
 
-## When to Use This Skill
-
-Activate when:
-- Reviewing pull requests
-- Conducting code audits
-- Providing feedback on code quality
-- Identifying security vulnerabilities
-- Suggesting refactoring improvements
-- Checking adherence to coding standards
-
 ## Anti-fabrication
 
 This skill follows `core:anti-fabrication`, but has little to verify against an external

--- a/plugins/core/skills/container/SKILL.md
+++ b/plugins/core/skills/container/SKILL.md
@@ -8,18 +8,6 @@ license: MIT
 
 This skill activates when working with Apple Container for running Linux containers natively on Apple silicon Macs.
 
-## When to Use This Skill
-
-Activate when:
-- Running Linux containers on macOS 26+ with Apple silicon
-- Managing container lifecycle (run, stop, exec, logs, inspect)
-- Building OCI-compatible container images
-- Managing container images (pull, push, tag, save, load)
-- Configuring container networks and volumes
-- Managing the container system service
-- Running long-lived Linux machine environments with `container machine` (1.0.0+)
-- Migrating between Apple Container versions (0.5.x to 1.0.0)
-
 ## What is Apple Container?
 
 Apple Container is a macOS-native tool for running Linux containers as lightweight virtual machines on Apple silicon:

--- a/plugins/core/skills/documentation/SKILL.md
+++ b/plugins/core/skills/documentation/SKILL.md
@@ -7,16 +7,6 @@ description: Guide for writing technical documentation. Use when creating README
 
 This skill activates when writing or improving technical documentation, including README files, API documentation, user guides, and inline code documentation.
 
-## When to Use This Skill
-
-Activate when:
-- Writing README files
-- Creating API documentation
-- Writing user guides or tutorials
-- Documenting code with comments or docstrings
-- Creating architecture or design documents
-- Writing changelogs or release notes
-
 ## Anti-fabrication
 
 This skill follows `core:anti-fabrication`. Most of it is house convention — README

--- a/plugins/core/skills/mise/SKILL.md
+++ b/plugins/core/skills/mise/SKILL.md
@@ -7,16 +7,6 @@ description: Guide for using mise to manage development tools and runtime versio
 
 This skill activates when working with mise for managing tool versions, environment variables, and project tasks.
 
-## When to Use This Skill
-
-Activate when:
-- Setting up development environments
-- Managing tool and runtime versions (Node.js, Python, Ruby, Go, etc.)
-- Configuring environment variables and secrets
-- Defining and running project tasks
-- Creating reproducible development setups
-- Working with monorepos or multiple projects
-
 ## What is mise?
 
 Current stable: v2026.3.15

--- a/plugins/core/skills/security/SKILL.md
+++ b/plugins/core/skills/security/SKILL.md
@@ -70,6 +70,16 @@ If you need to know something about your OWN process's environment, use `test -n
 
 **Recovery.** If an environment dump reaches the transcript despite the above, self-report the exposure immediately and ask the operator to rotate every credential that appeared — do not wait to be asked, and do not attempt to redact it after the fact (the value is already in context/logs).
 
+## When to Use security-review Instead
+
+Use the `security-review` skill for:
+- STRIDE threat modeling
+- Security architecture reviews
+- Vulnerability assessments
+- Security documentation and reports
+- Risk prioritization
+- Attack surface analysis
+
 | Task | Use `security` | Use `security-review` |
 |------|---------------|----------------------|
 | Scan for secrets in code | ✓ | |

--- a/plugins/core/skills/security/SKILL.md
+++ b/plugins/core/skills/security/SKILL.md
@@ -15,16 +15,6 @@ hooks:
 
 This skill activates when performing secret detection, credential scanning, or implementing security checks for leaked sensitive data in code repositories.
 
-## When to Use This Skill
-
-Activate when:
-- Scanning repositories for leaked secrets, API keys, or credentials
-- Setting up pre-commit hooks for secret detection
-- Auditing codebases for exposed passwords or tokens
-- Implementing CI/CD security pipelines
-- Checking git history for accidentally committed secrets
-- Validating that .gitignore excludes sensitive files
-
 ## Pre-Commit Hook (Automatic)
 
 When this skill is loaded, a pre-commit hook automatically scans staged files for secrets before every `git commit` command, providing defense-in-depth by catching secrets before they enter git history. Only staged files are scanned (not the entire working tree); `.gitleaks-baseline.json` and `.gitleaks.toml`, when present, are honored for known false positives and custom rules.
@@ -79,16 +69,6 @@ If you need to know something about your OWN process's environment, use `test -n
 - Treat `-e`/`-E`-shaped flags on any unfamiliar tool as suspect until you've checked what they do; the macOS/Linux split above (`-E` vs bare `e` vs `-e`-means-"all") is exactly the kind of one-letter, cross-platform inconsistency that causes an agent to reach for the wrong flag under the impression it is the safe one.
 
 **Recovery.** If an environment dump reaches the transcript despite the above, self-report the exposure immediately and ask the operator to rotate every credential that appeared — do not wait to be asked, and do not attempt to redact it after the fact (the value is already in context/logs).
-
-## When to Use security-review Instead
-
-Use the `security-review` skill for:
-- STRIDE threat modeling
-- Security architecture reviews
-- Vulnerability assessments
-- Security documentation and reports
-- Risk prioritization
-- Attack surface analysis
 
 | Task | Use `security` | Use `security-review` |
 |------|---------------|----------------------|

--- a/plugins/core/skills/tdd/SKILL.md
+++ b/plugins/core/skills/tdd/SKILL.md
@@ -8,17 +8,6 @@ license: MIT
 
 A discipline for growing software guided by tests, one small step at a time.
 
-## When to Activate
-
-Use this skill when:
-- Writing code test-first for a new feature or module
-- Starting a greenfield project and need a walking skeleton
-- Applying outside-in development from acceptance tests to unit tests
-- Sequencing tests to drive incremental design
-- Creating a test list to plan implementation
-- Reviewing whether tests are giving good design feedback
-- Deciding between Fake It, Obvious Implementation, or Triangulation
-
 ## The TDD Cycle
 
 ### Five Steps

--- a/plugins/core/skills/twelve-factor/SKILL.md
+++ b/plugins/core/skills/twelve-factor/SKILL.md
@@ -8,18 +8,6 @@ license: MIT
 
 Guide for building scalable, maintainable, and portable cloud-native applications following the 12-Factor App principles and modern extensions.
 
-## When to Activate
-
-Use this skill when:
-- Designing or refactoring cloud-native applications
-- Building applications for Kubernetes deployment
-- Setting up CI/CD pipelines
-- Implementing microservices architecture
-- Migrating applications to containers
-- Reviewing architecture for cloud readiness
-- Troubleshooting deployment or scaling issues
-- Working with environment configuration
-
 ## Anti-fabrication
 
 This skill follows `core:anti-fabrication`. The 12 factors themselves are the

--- a/plugins/design/.claude-plugin/plugin.json
+++ b/plugins/design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "design",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Framework-agnostic standards and design systems: accessibility (WCAG) and Material Design 3 — what you review an implementation against, and plan a compliant new one from",
   "author": {
     "name": "vinnie357"

--- a/plugins/design/skills/accessibility/SKILL.md
+++ b/plugins/design/skills/accessibility/SKILL.md
@@ -7,16 +7,6 @@ description: Guide for implementing web accessibility (WCAG). Use when designing
 
 Apply W3C Web Accessibility Initiative (WAI) principles when working on web interfaces to ensure usability for people with disabilities.
 
-## When to Activate
-
-Use this skill when:
-- Designing or implementing user interfaces
-- Reviewing code for accessibility compliance
-- Creating or editing web content (HTML, CSS, JavaScript)
-- Working with forms, navigation, multimedia, or interactive components
-- Conducting code reviews with accessibility considerations
-- Refactoring existing interfaces for better accessibility
-
 ## Anti-fabrication
 
 This skill follows `core:anti-fabrication`. The claim area is the WCAG version cited and

--- a/plugins/design/skills/material-design/SKILL.md
+++ b/plugins/design/skills/material-design/SKILL.md
@@ -7,16 +7,6 @@ description: Guide for implementing Material Design 3 (Material You). Use when d
 
 Apply Google's Material Design 3 principles when designing and developing user interfaces with emphasis on personalization, accessibility, and cross-platform consistency.
 
-## When to Activate
-
-Use this skill when:
-- Designing or implementing Android applications
-- Building web applications following Material Design
-- Working with Flutter or Jetpack Compose
-- Implementing dynamic theming and color systems
-- Creating Material components
-- Reviewing designs for Material Design compliance
-
 ## Anti-fabrication
 
 This skill follows `core:anti-fabrication`. The claim area is the tonal-palette, type-

--- a/plugins/languages/elixir/.claude-plugin/plugin.json
+++ b/plugins/languages/elixir/.claude-plugin/plugin.json
@@ -1,13 +1,22 @@
 {
   "name": "elixir",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Elixir development skills: Phoenix, OTP, Ports, Ecto, Tidewave MCP, testing, configuration, style, and anti-patterns",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["elixir", "phoenix", "otp", "ports", "ecto", "style", "beam", "erlang"],
+  "keywords": [
+    "elixir",
+    "phoenix",
+    "otp",
+    "ports",
+    "ecto",
+    "style",
+    "beam",
+    "erlang"
+  ],
   "agents": [
     "./agents/tidewave.md"
   ],

--- a/plugins/languages/elixir/skills/config/SKILL.md
+++ b/plugins/languages/elixir/skills/config/SKILL.md
@@ -8,17 +8,6 @@ license: MIT
 
 Guide for proper application configuration in Elixir, with emphasis on understanding and correctly using runtime vs compile-time configuration.
 
-## When to Activate
-
-Use this skill when:
-- Setting up or modifying application configuration
-- Choosing between `config.exs` and `runtime.exs`
-- Deciding between `Application.compile_env` and `Application.get_env`
-- Debugging configuration-related issues
-- Working with releases or deployment configuration
-- Migrating from `use Mix.Config` to `import Config`
-- Writing libraries that need configuration
-
 ## Critical Principle
 
 > **Runtime configuration is the preferred approach.** Only use compile-time configuration when values must affect compilation itself.

--- a/plugins/languages/elixir/skills/otp/SKILL.md
+++ b/plugins/languages/elixir/skills/otp/SKILL.md
@@ -7,16 +7,6 @@ description: Guide for OTP and Elixir concurrency. Use when implementing GenServ
 
 This skill activates when working with OTP behaviors, building concurrent systems, managing processes, or implementing fault-tolerant architectures in Elixir.
 
-## When to Use This Skill
-
-Activate when:
-- Implementing GenServer, GenStage, Supervisor, or other OTP behaviors
-- Designing supervision trees and fault-tolerance strategies
-- Working with Tasks, Agents, or process management
-- Building concurrent or distributed systems
-- Managing application state
-- Troubleshooting process-related issues
-
 ## OTP Behaviors
 
 Full catalogs for GenServer, Supervisor, Task, and Agent — client/server structure, dynamic supervision, restart configuration — live in `references/behaviors.md`. Two decisions from that catalog are worth keeping here:

--- a/plugins/languages/elixir/skills/phoenix/SKILL.md
+++ b/plugins/languages/elixir/skills/phoenix/SKILL.md
@@ -9,16 +9,6 @@ This skill activates when working with Phoenix web applications, including setup
 
 **Current versions**: Phoenix 1.8.x (current: 1.8.5), Phoenix LiveView 1.1.x (current: 1.1.27). Requires Elixir 1.14+, Erlang/OTP 25+.
 
-## When to Use This Skill
-
-Activate this skill when:
-- Creating or modifying Phoenix applications
-- Implementing LiveView components or pages
-- Working with Phoenix contexts and business logic
-- Building real-time features with channels or LiveView
-- Configuring Phoenix routers, plugs, or endpoints
-- Troubleshooting Phoenix-specific issues
-
 ## Phoenix Project Structure
 
 Follow Phoenix conventions:

--- a/plugins/languages/elixir/skills/ports/SKILL.md
+++ b/plugins/languages/elixir/skills/ports/SKILL.md
@@ -8,16 +8,6 @@ license: MIT
 
 Ports are Elixir's mechanism for communicating with external OS programs via stdin/stdout. A Port is not a network port — it is a process-like entity that manages an external OS program, forwarding messages as bytes and delivering responses back to the owning Elixir process.
 
-## When to Use This Skill
-
-Activate when:
-- Spawning and communicating with external programs or scripts
-- Implementing binary protocols over stdin/stdout
-- Wrapping a port in a GenServer for lifecycle management
-- Deciding between Port, NIF, C Node, or `System.cmd`
-- Handling port crashes, exit status, or monitoring ports
-- Working with long-running external processes
-
 ## Port Fundamentals
 
 Open a port with `Port.open/2`. The most common name forms are `{:spawn, command}` and `{:spawn_executable, path}`.

--- a/plugins/languages/elixir/skills/style/SKILL.md
+++ b/plugins/languages/elixir/skills/style/SKILL.md
@@ -6,18 +6,6 @@ license: MIT
 
 # Elixir Style and Conventions
 
-## When to Activate
-
-Activate when:
-- Writing or reviewing Elixir code for idiomatic style
-- Deciding between bang (`!`) and non-bang function variants
-- Handling errors from external APIs, user input, or DB operations
-- Designing Ecto schemas and changesets for validation
-- Building Phoenix forms connected to changeset validation
-- Chaining multi-step operations with `with` or `case`
-- Choosing between `map.key` and `map[:key]` access patterns
-- Implementing non-DB data structures (search forms, filter params)
-
 This skill complements `elixir:anti-patterns` — that skill covers what to avoid; this one covers what to do instead.
 
 ## Tagged Tuples and Return Conventions

--- a/plugins/languages/elixir/skills/testing/SKILL.md
+++ b/plugins/languages/elixir/skills/testing/SKILL.md
@@ -7,17 +7,6 @@ description: Guide for Elixir testing with ExUnit. Use when writing unit tests, 
 
 This skill activates when writing, organizing, or improving tests for Elixir applications using ExUnit and related testing tools.
 
-## When to Use This Skill
-
-Activate when:
-- Writing unit, integration, or property-based tests
-- Organizing test suites and test files
-- Setting up test fixtures and factories
-- Mocking external dependencies
-- Testing concurrent or asynchronous code
-- Improving test coverage or quality
-- Troubleshooting failing tests
-
 ## ExUnit Basics
 
 ### Test Module Structure

--- a/plugins/languages/rust/.claude-plugin/plugin.json
+++ b/plugins/languages/rust/.claude-plugin/plugin.json
@@ -1,13 +1,19 @@
 {
   "name": "rust",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Rust programming skills: ownership, borrowing, lifetimes, async, best practices, anti-patterns, CLI apps, and adversarial-TDD worker agents",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["rust", "systems-programming", "memory-safety", "agents", "tdd"],
+  "keywords": [
+    "rust",
+    "systems-programming",
+    "memory-safety",
+    "agents",
+    "tdd"
+  ],
   "skills": [
     "./skills/rust",
     "./skills/ownership",

--- a/plugins/languages/rust/skills/anti-patterns/SKILL.md
+++ b/plugins/languages/rust/skills/anti-patterns/SKILL.md
@@ -8,13 +8,6 @@ license: MIT
 
 Catalog of Rust anti-patterns and clippy anti-idioms for reviewers and implementers actively hunting code to fix or remove. Complements `/rust:troubleshooting` (which teaches the idiomatic GOOD patterns) by naming the BAD patterns explicitly, with detection hints.
 
-## When to Use This Skill
-
-Activate when:
-- Reviewing a Rust diff or module for anti-patterns
-- Refactoring code flagged by clippy or code review
-- Deciding whether a `.clone()`, `&Vec<T>` parameter, `unwrap()`, or sentinel return value is a bug to fix
-
 ## Sources
 
 Rust Design Patterns book ([anti-patterns](https://rust-unofficial.github.io/patterns/anti_patterns/), [idioms](https://rust-unofficial.github.io/patterns/idioms/)) and the [Clippy lint index](https://rust-lang.github.io/rust-clippy/master/index.html) — full attribution per entry in `references/anti-patterns.md`, dated URLs in `sources.md`.

--- a/plugins/languages/rust/skills/async/SKILL.md
+++ b/plugins/languages/rust/skills/async/SKILL.md
@@ -7,16 +7,6 @@ description: Guide for async and concurrent Rust programming. Use when writing a
 
 Async functions, tokio runtime, streams, threads, channels, and shared state.
 
-## When to Use This Skill
-
-Activate when:
-- Writing async functions with tokio
-- Running concurrent async operations with join! or spawn
-- Processing async streams
-- Spawning OS threads
-- Using channels (mpsc) for message passing
-- Sharing state with Arc and Mutex
-
 For async patterns, concurrency primitives, and shared state examples, see `references/async.md`.
 
 ## Anti-fabrication

--- a/plugins/languages/rust/skills/cli/SKILL.md
+++ b/plugins/languages/rust/skills/cli/SKILL.md
@@ -7,16 +7,6 @@ description: Guide for building Rust command-line applications. Use when parsing
 
 Argument parsing, user-facing output, exit codes, signal handling, and subprocess testing for command-line tools.
 
-## When to Use This Skill
-
-Activate when:
-- Parsing arguments and subcommands with clap's derive API
-- Adding an `anyhow::Context` to an error chain for a readable top-level failure message
-- Printing progress bars, verbosity-gated logs, or machine-readable output (JSON/TSV) for piped consumers
-- Handling Ctrl+C or other signals for graceful shutdown
-- Choosing a process exit code on success or failure
-- Testing a compiled binary as a subprocess with assert_cmd
-
 For argument parsing, error context, output, signals, exit codes, and testing patterns, see `references/cli.md`.
 
 ## Example

--- a/plugins/languages/rust/skills/error-handling/SKILL.md
+++ b/plugins/languages/rust/skills/error-handling/SKILL.md
@@ -7,15 +7,6 @@ description: Guide for Rust error handling. Use when working with Result, Option
 
 Result, Option, error propagation, and custom error types.
 
-## When to Use This Skill
-
-Activate when:
-- Returning and handling Result types
-- Working with Option for optional values
-- Using the ? operator for error propagation
-- Implementing custom error types with Display and From
-- Composing error enums with thiserror or adding caller context with anyhow
-
 For Result, Option, ? operator, custom error type patterns, and the thiserror/anyhow ecosystem crates, see `references/error-handling.md`.
 
 ## Anti-fabrication

--- a/plugins/languages/rust/skills/ownership/SKILL.md
+++ b/plugins/languages/rust/skills/ownership/SKILL.md
@@ -7,15 +7,6 @@ description: Guide for Rust ownership, borrowing, and lifetimes. Use when workin
 
 Ownership rules, borrowing, slices, and lifetimes.
 
-## When to Use This Skill
-
-Activate when:
-- Understanding ownership and move semantics
-- Working with references and borrowing rules
-- Using string or array slices
-- Annotating or debugging lifetimes
-- Fixing borrow checker errors
-
 For ownership rules, borrowing patterns, slices, and lifetime annotations, see `references/ownership.md`.
 
 ## Anti-fabrication

--- a/plugins/languages/rust/skills/rust/SKILL.md
+++ b/plugins/languages/rust/skills/rust/SKILL.md
@@ -7,13 +7,6 @@ description: Guide for Rust programming language. Use when writing Rust code, se
 
 Entry point for Rust development. Provides an overview and routes to focused skills.
 
-## When to Use This Skill
-
-Activate when:
-- Starting a new Rust project
-- Needing a general overview of Rust capabilities
-- Unsure which specific Rust skill to load
-
 ## Available Skills
 
 This plugin provides focused skills for specific Rust topics:

--- a/plugins/languages/rust/skills/testing/SKILL.md
+++ b/plugins/languages/rust/skills/testing/SKILL.md
@@ -7,15 +7,6 @@ description: Guide for Rust testing and Cargo usage. Use when writing unit or in
 
 Unit tests, integration tests, Cargo.toml configuration, and common commands.
 
-## When to Use This Skill
-
-Activate when:
-- Writing unit tests with #[test] and #[cfg(test)]
-- Setting up integration tests in tests/ directory
-- Configuring Cargo.toml dependencies and profiles
-- Running cargo test, build, clippy, or fmt
-- Using #[should_panic] or Result-returning tests
-
 For test patterns, Cargo.toml configuration, and command reference, see `references/testing.md`.
 
 ## Anti-fabrication

--- a/plugins/languages/rust/skills/troubleshooting/SKILL.md
+++ b/plugins/languages/rust/skills/troubleshooting/SKILL.md
@@ -7,14 +7,6 @@ description: Guide for Rust best practices, common patterns, and idiomatic code.
 
 Best practices, common patterns, and idiomatic Rust.
 
-## When to Use This Skill
-
-Activate when:
-- Following Rust best practices (borrowing, error propagation, iterators)
-- Applying design patterns (builder, newtype)
-- Choosing between &str and &String
-- Writing idiomatic Rust code
-
 For best practices, common patterns, and idiomatic guidelines, see `references/troubleshooting.md`.
 
 ## Anti-fabrication

--- a/plugins/languages/typescript/.claude-plugin/plugin.json
+++ b/plugins/languages/typescript/.claude-plugin/plugin.json
@@ -1,13 +1,21 @@
 {
   "name": "typescript",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TypeScript development skills: language and type system, Vitest/Jest/Playwright testing, ESLint/typescript-eslint/Biome linting, and the Node.js runtime",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["typescript", "javascript", "node", "vitest", "eslint", "testing", "linting"],
+  "keywords": [
+    "typescript",
+    "javascript",
+    "node",
+    "vitest",
+    "eslint",
+    "testing",
+    "linting"
+  ],
   "skills": [
     "./skills/language",
     "./skills/testing",

--- a/plugins/languages/typescript/skills/language/SKILL.md
+++ b/plugins/languages/typescript/skills/language/SKILL.md
@@ -8,17 +8,6 @@ license: MIT
 
 Core TypeScript: strict mode, the type system, utility types, declaration files, and discriminated unions.
 
-## When to Use This Skill
-
-Activate when:
-- Configuring `tsconfig.json`, especially `strict` and its component flags
-- Designing generic functions, classes, or constraints
-- Writing conditional types, mapped types, or template literal types
-- Choosing between the built-in utility types (`Partial`, `Pick`, `Omit`, `Record`, ...)
-- Writing or consuming `.d.ts` declaration files
-- Modeling variant data with discriminated unions and exhaustiveness checks
-- Deciding between `interface` and `type`, or between `enum` and a union of literals
-
 ## Strict Mode
 
 `strict: true` in `tsconfig.json` is the floor for new TypeScript code in this workspace, not an opt-in extra. It is a single flag that enables a family of component flags — turn it on first, then reach for a component flag only when you need something `strict` doesn't cover.

--- a/plugins/languages/typescript/skills/linting/SKILL.md
+++ b/plugins/languages/typescript/skills/linting/SKILL.md
@@ -8,15 +8,6 @@ license: MIT
 
 ESLint + typescript-eslint for type-aware linting, Biome as a fast all-in-one alternative, Prettier for formatting, and CI wiring.
 
-## When to Use This Skill
-
-Activate when:
-- Setting up `eslint.config.js` (flat config) for a TypeScript project
-- Choosing between typescript-eslint's `recommended`, `strict`, and `stylistic` presets
-- Deciding between the ESLint+Prettier stack and Biome
-- Configuring pre-commit hooks (`husky` + `lint-staged`) for lint/format
-- Adding lint and format checks to `mise run ci` or a CI workflow
-
 ## ESLint with typescript-eslint
 
 ### Setup

--- a/plugins/languages/typescript/skills/node/SKILL.md
+++ b/plugins/languages/typescript/skills/node/SKILL.md
@@ -8,16 +8,6 @@ license: MIT
 
 Async patterns, streams, module systems, package managers, and mise/CI integration for Node.js TypeScript projects.
 
-## When to Use This Skill
-
-Activate when:
-- Writing async/await code, chaining Promises, or using `EventEmitter`
-- Reading, writing, or piping Node streams (`Readable`/`Writable`/`Duplex`/`Transform`)
-- Deciding between ESM (`"type": "module"`) and CommonJS for a package
-- Writing a `package.json` `exports` field, including dual ESM/CJS conditional exports
-- Choosing between npm, pnpm, and Bun for a project
-- Pinning a Node version with mise or wiring Node into CI
-
 ## Async Patterns
 
 ### async/await over raw Promise chains

--- a/plugins/languages/typescript/skills/testing/SKILL.md
+++ b/plugins/languages/typescript/skills/testing/SKILL.md
@@ -8,16 +8,6 @@ license: MIT
 
 Vitest and Jest for unit/integration tests, Playwright for end-to-end, type-level testing, coverage, and CI wiring.
 
-## When to Use This Skill
-
-Activate when:
-- Choosing or configuring a unit test runner (Vitest or Jest) for a TypeScript project
-- Mocking modules, timers, or globals in a test
-- Asserting that a type is exactly what's expected, at compile time rather than runtime
-- Writing or running Playwright end-to-end browser tests
-- Setting coverage thresholds or wiring `test`/`coverage` into `mise run ci`
-- Debugging a flaky or slow TypeScript test suite
-
 ## Choosing Vitest vs Jest
 
 Both are viable; the deciding factor is the rest of the toolchain, not raw feature count.

--- a/plugins/languages/zig/.claude-plugin/plugin.json
+++ b/plugins/languages/zig/.claude-plugin/plugin.json
@@ -1,13 +1,18 @@
 {
   "name": "zig",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Zig programming skills: build system, comptime, allocators, error handling, C interop, testing, and troubleshooting",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["zig", "systems-programming", "comptime", "allocators"],
+  "keywords": [
+    "zig",
+    "systems-programming",
+    "comptime",
+    "allocators"
+  ],
   "skills": [
     "./skills/zig",
     "./skills/language",

--- a/plugins/languages/zig/skills/allocators/SKILL.md
+++ b/plugins/languages/zig/skills/allocators/SKILL.md
@@ -7,14 +7,6 @@ description: Guide for Zig memory management and allocators. Use when choosing a
 
 Memory management patterns, allocator types, and allocation lifecycle.
 
-## When to Use This Skill
-
-Activate when:
-- Choosing an allocator for a specific use case
-- Managing memory allocation and deallocation
-- Debugging memory leaks or use-after-free
-- Writing allocator-aware library code
-
 For allocator types, patterns, and examples, see `references/allocators.md`.
 
 ## Anti-fabrication

--- a/plugins/languages/zig/skills/build/SKILL.md
+++ b/plugins/languages/zig/skills/build/SKILL.md
@@ -7,15 +7,6 @@ description: Guide for the Zig build system and CI integration. Use when configu
 
 Build configuration, cross-compilation, dependency management, and CI patterns.
 
-## When to Use This Skill
-
-Activate when:
-- Creating or editing build.zig files
-- Adding build steps, options, or dependencies
-- Cross-compiling for different targets
-- Setting up CI pipelines for Zig projects
-- Managing build.zig.zon dependencies
-
 For detailed build.zig patterns, API methods, and examples, see `references/build.md`.
 
 ## Anti-fabrication

--- a/plugins/languages/zig/skills/c-interop/SKILL.md
+++ b/plugins/languages/zig/skills/c-interop/SKILL.md
@@ -7,15 +7,6 @@ description: Guide for Zig and C interoperability. Use when importing C headers 
 
 Importing C libraries, exporting Zig to C, type mappings, and translate-c.
 
-## When to Use This Skill
-
-Activate when:
-- Importing C headers with @cImport/@cInclude
-- Exporting Zig functions for C consumption
-- Mapping between Zig and C types
-- Using the translate-c tool
-- Linking C libraries in build.zig
-
 For type mappings, linking patterns, and string interop examples, see `references/c-interop.md`.
 
 ## Anti-fabrication

--- a/plugins/languages/zig/skills/language/SKILL.md
+++ b/plugins/languages/zig/skills/language/SKILL.md
@@ -7,15 +7,6 @@ description: Guide for Zig core language features. Use when writing Zig code wit
 
 Core language features, data types, and idioms for writing Zig code.
 
-## When to Use This Skill
-
-Activate when:
-- Writing Zig code with structs, enums, unions, optionals
-- Using comptime for compile-time execution and generics
-- Handling errors with error unions, try, catch, errdefer
-- Working with slices, arrays, pointers, and strings
-- Using defer/errdefer for resource cleanup
-
 ## Anti-fabrication
 
 This skill follows `core:anti-fabrication`. Verified against zig 0.16.0 (locally

--- a/plugins/languages/zig/skills/testing/SKILL.md
+++ b/plugins/languages/zig/skills/testing/SKILL.md
@@ -7,15 +7,6 @@ description: Guide for Zig built-in testing framework. Use when writing tests, u
 
 Built-in test framework, leak detection, and CI integration.
 
-## When to Use This Skill
-
-Activate when:
-- Writing unit tests in Zig
-- Using the test allocator for memory leak detection
-- Configuring test steps in build.zig
-- Filtering and running specific tests
-- Skipping platform-specific tests
-
 For assertion functions, test allocator patterns, and build integration, see `references/testing.md`.
 
 ## Anti-fabrication

--- a/plugins/languages/zig/skills/troubleshooting/SKILL.md
+++ b/plugins/languages/zig/skills/troubleshooting/SKILL.md
@@ -7,15 +7,6 @@ description: Guide for debugging and troubleshooting Zig programs. Use when diag
 
 Common errors, debugging techniques, and solutions for Zig development issues.
 
-## When to Use This Skill
-
-Activate when:
-- Diagnosing Zig compiler errors
-- Debugging runtime panics or safety checks
-- Investigating memory leaks or use-after-free
-- Fixing build.zig configuration issues
-- Understanding error return traces
-
 For error catalogs, debugging patterns, and common pitfalls, see `references/troubleshooting.md`.
 
 ## Anti-fabrication

--- a/plugins/languages/zig/skills/zig/SKILL.md
+++ b/plugins/languages/zig/skills/zig/SKILL.md
@@ -7,14 +7,6 @@ description: Guide for Zig programming language. Use when writing Zig code, sett
 
 Entry point for Zig development. Provides an overview, version awareness, and routes to focused skills.
 
-## When to Use This Skill
-
-Activate when:
-- Starting a new Zig project
-- Needing a general overview of Zig capabilities
-- Migrating a project between Zig versions
-- Unsure which specific Zig skill to load
-
 ## Anti-fabrication
 
 This skill follows `core:anti-fabrication`. Zig is pre-1.0 with every minor release

--- a/plugins/pm/.claude-plugin/plugin.json
+++ b/plugins/pm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pm",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Product management toolkit: harvest implementation-agnostic feature specs from prototypes with SDLC guardrails and author PRDs as implementation contracts",
   "author": {
     "name": "vinnie357"

--- a/plugins/pm/skills/prd/SKILL.md
+++ b/plugins/pm/skills/prd/SKILL.md
@@ -8,14 +8,6 @@ license: MIT
 
 Author a Product Requirements Document that serves as the handoff contract between product intent and an implementing team — human or AI agent. The PRD states WHAT the feature does and WHY it exists; it never prescribes HOW to build it.
 
-## When to Use
-
-Activate when:
-- The `/pm:prd` command is invoked.
-- Turning one feature-area entry from a `/pm:spec-harvest` feature inventory into a standalone PRD.
-- Defining scope boundaries, acceptance criteria, or success metrics before an engineering handoff.
-- Reviewing an existing PRD for implementation leakage (tech names, schemas, API shapes) or missing non-goals.
-
 ## PRD as Contract
 
 A PRD is complete when the implementing team needs no follow-up questions to start work. Treat every unanswerable question as a defect in the document, not a gap the implementer fills in.

--- a/plugins/pm/skills/spec-harvest/SKILL.md
+++ b/plugins/pm/skills/spec-harvest/SKILL.md
@@ -8,15 +8,6 @@ description: "Extracts implementation-agnostic feature specs from working protot
 
 Extracts a customer-value feature inventory, an SDLC risk assessment, and per-feature PRDs from a working prototype — without carrying the prototype's implementation choices into the spec. `/pm:harvest` runs all four phases end-to-end via an agent team; `/pm:assess` runs phase 3 alone against an existing inventory.
 
-## When to Use
-
-Activate when:
-- Handing a prototype to an engineering team that will rebuild it for production.
-- Reverse-engineering prototype code into user stories and acceptance criteria.
-- Assessing licensing, security, or supportability risk before a production build.
-- Reading bees epics alongside prototype code to produce a coding spec.
-- Separating customer-value behavior from prototype shortcuts before scoping work.
-
 ## Four Phases
 
 1. **Discovery** — pure inventory, no judgment. Record what is observed: routes/pages, data models, external integrations, dependencies, technology stack and framework choices. Every entry carries a confidence tag (see Anti-Fabrication below).

--- a/plugins/tools/agent-sandboxing/.claude-plugin/plugin.json
+++ b/plugins/tools/agent-sandboxing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sandboxing",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "Agent sandboxing for AI coding agents: microVM and kernel-isolated execution environments. Index skill (sandbox) routes to substrate-specific paths. Currently covers the kubernetes-sigs/agent-sandbox path on kind, GKE, and kina (Kubernetes-in-Apple-Containers), with Kata, gVisor, and Apple Container microVM substrates. Ships 7 skills + 6 slash commands + nushell scripts. Designed to expand to non-k8s sandboxing paths.",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/agent-sandboxing/skills/agent-substrate-overview/SKILL.md
+++ b/plugins/tools/agent-sandboxing/skills/agent-substrate-overview/SKILL.md
@@ -8,12 +8,6 @@ license: MIT
 
 Agent Substrate is an Apache-2.0 Kubernetes runtime for agent-like workloads that multiplexes many stateful actors onto fewer worker pods, preserving in-memory + disk state via gVisor checkpoint/restore. It is **explicitly alpha** (v0.0.0, README quote: "VERY early development… APIs are almost guaranteed to change"). This skill is a short reference so you can evaluate it against `k8s-agent-sandbox`, not an operational guide.
 
-## When to use this skill
-
-- Comparing Substrate's control plane to `kubernetes-sigs/agent-sandbox` before choosing one.
-- Reading a Substrate `ActorTemplate` / `WorkerPool` YAML and wanting to know the field semantics.
-- Looking at the `demos/claude-code-multiplex/` example to understand Substrate's Claude Code integration shape.
-
 If the operational decision is already "use Substrate," read the upstream README directly — this skill is intentionally not a step-by-step install guide because Substrate is at v0.0.0 with API churn between commits, so pinning a recipe here would go stale.
 
 ## What Substrate is

--- a/plugins/tools/agent-sandboxing/skills/claude-code-on-sandbox/SKILL.md
+++ b/plugins/tools/agent-sandboxing/skills/claude-code-on-sandbox/SKILL.md
@@ -8,13 +8,6 @@ license: MIT
 
 Claude Code does not ship an officially maintained standalone OCI image. The supported path is the `@anthropic-ai/claude-code` npm CLI plus the Anthropic-published Dev Container Feature (`ghcr.io/anthropics/devcontainer-features/claude-code:1.0`). For sandboxed Kubernetes deployment, the pattern is: build a Dockerfile that installs Claude Code via mise (using the registry short name), wire it into a `SandboxTemplate` that pins a `runtimeClassName`, and let agent-sandbox provision per-session pods from that template.
 
-## When to use
-
-- Building a Dockerfile that packages Claude Code for in-cluster execution.
-- Deploying Claude Code as a `SandboxTemplate` workload on a kind/Kata, GKE/Kata, or kina cluster.
-- Persisting `~/.claude` (auth, settings, sessions) across SandboxClaims via a PVC.
-- Locking down outbound traffic to Anthropic's API only.
-
 ## Mise-based Dockerfile
 
 The plugin ships `templates/Dockerfile.claude-code` and `templates/mise.toml.claude-code`. Use them verbatim or adapt.

--- a/plugins/tools/agent-sandboxing/skills/k8s-agent-sandbox/SKILL.md
+++ b/plugins/tools/agent-sandboxing/skills/k8s-agent-sandbox/SKILL.md
@@ -8,15 +8,6 @@ license: MIT
 
 The upstream open-source project `kubernetes-sigs/agent-sandbox` ships four CRDs that model "give me a per-session, isolated pod for an AI agent and reap it when the session ends." This skill covers the controller, the CRD model, and the lifecycle. Pair with `kata-on-kind` / `kata-on-gke` / `kina-microvm` for the RuntimeClass install and with `claude-code-on-sandbox` for the workload-side packaging.
 
-## When to use
-
-- Standing up the agent-sandbox controller on a new cluster.
-- Authoring a `SandboxTemplate` for an agent workload.
-- Provisioning per-session sandboxes via `SandboxClaim` from a shell, CI job, or the Python SDK.
-- Configuring `SandboxWarmPool` to get sub-second cold-starts.
-- Locking down agent egress with `networkPolicyManagement: Managed`.
-- Deciding between managed GKE Agent Sandbox (gVisor only) and self-installed upstream (Kata + gVisor + anything else).
-
 ## What it is
 
 `kubernetes-sigs/agent-sandbox` is Apache-2.0 (verified at https://github.com/kubernetes-sigs/agent-sandbox). Latest release v0.4.6 (2026-05-14). API group `agents.x-k8s.io` (core `Sandbox`) and `extensions.agents.x-k8s.io` (templates, claims, warm pools). The upstream README example uses `v1alpha1`; `docs/api.md` documents `v1beta1`. Verify the installed CRD version before authoring manifests:

--- a/plugins/tools/agent-sandboxing/skills/kata-on-gke/SKILL.md
+++ b/plugins/tools/agent-sandboxing/skills/kata-on-gke/SKILL.md
@@ -8,12 +8,6 @@ license: MIT
 
 GKE ships a managed "Agent Sandbox" add-on, but it pins `runtimeClassName: gvisor`. There is no managed Kata path. For microVM isolation on GKE, follow the upstream `examples/kata-gke-sandbox/` recipe: a standard (non-Autopilot) GKE cluster, an Ubuntu N2 node pool with nested virtualization, and a `setup.sh` that installs Kata onto those nodes.
 
-## When to use
-
-- Running agent workloads on GKE with hardware-level isolation, not userspace-kernel (gVisor) isolation.
-- Reproducing a `kata-on-kind` dev setup in a real GKE cluster.
-- Pairing GKE with `kubernetes-sigs/agent-sandbox` upstream (not the managed addon) so SandboxTemplates can pin `runtimeClassName: kata-qemu`.
-
 ## Prerequisites
 
 - GCP project with billing enabled.

--- a/plugins/tools/agent-sandboxing/skills/kata-on-kind/SKILL.md
+++ b/plugins/tools/agent-sandboxing/skills/kata-on-kind/SKILL.md
@@ -8,12 +8,6 @@ license: MIT
 
 `kind` runs Kubernetes nodes as Docker containers. `kata-deploy` is a DaemonSet that installs the Kata Containers runtime + VM artifacts onto every node it lands on and reconfigures containerd to register the `kata-qemu`, `kata-clh`, and `kata-fc` RuntimeClasses. Combining the two on a Linux host gives microVM-isolated pods for local development.
 
-## When to use
-
-- Setting up a local microVM dev loop for `kubernetes-sigs/agent-sandbox` workloads.
-- Verifying that `/dev/kvm` is exposed and nested virtualization works.
-- Reproducing a GKE Standard + Kata production setup on a laptop before pushing to GKE.
-
 ## Host prerequisites — Linux only
 
 Kata-on-kind requires the host to expose `/dev/kvm` to the kind node container. macOS hosts (Apple Silicon or Intel) cannot do this — Hypervisor.framework does not expose nested KVM to a guest Linux VM. For macOS, use `kina-microvm` (Apple Container nodes) instead.

--- a/plugins/tools/agent-sandboxing/skills/kina-microvm/SKILL.md
+++ b/plugins/tools/agent-sandboxing/skills/kina-microvm/SKILL.md
@@ -10,12 +10,6 @@ license: MIT
 
 The structural difference matters: with kata-on-kind, isolation lives at the **pod** level via `runtimeClassName: kata-qemu` on a Linux container node. With kina, isolation lives at the **node** level — every node IS already an Apple Container microVM, so every pod on the cluster is already inside a microVM. There is no per-pod `runtimeClassName` swap.
 
-## When to use
-
-- Developing `kubernetes-sigs/agent-sandbox` workloads on a Mac (Apple Silicon or Intel).
-- Wanting microVM isolation locally without requiring a Linux host.
-- Needing parity between local dev and a future Linux+Kata or GKE deployment.
-
 ## Why not kata-on-kind on macOS
 
 Apple Silicon's Hypervisor.framework does not expose nested KVM to guest Linux VMs. Docker Desktop and Colima both run a Linux VM under the hood; that VM cannot itself host KVM-accelerated Kata microVMs. Symptom if you try: `qemu-system-x86_64: failed to access /dev/kvm`.

--- a/plugins/tools/allium/.claude-plugin/plugin.json
+++ b/plugins/tools/allium/.claude-plugin/plugin.json
@@ -1,12 +1,20 @@
 {
   "name": "allium",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Opinionated Allium integration for /core:agent-loop: attach behavioral specs to epics, propagate TDD tests, weed-check semantic divergence post-CI.",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["allium", "agent-loop", "tdd", "behavioral-spec", "epic"],
-  "skills": ["./skills/allium"]
+  "keywords": [
+    "allium",
+    "agent-loop",
+    "tdd",
+    "behavioral-spec",
+    "epic"
+  ],
+  "skills": [
+    "./skills/allium"
+  ]
 }

--- a/plugins/tools/allium/skills/allium/SKILL.md
+++ b/plugins/tools/allium/skills/allium/SKILL.md
@@ -8,13 +8,6 @@ license: MIT
 
 Opinionated integration between [juxt/allium](https://github.com/juxt/allium) and the `/core:agent-loop` workflow. Allium captures observable behavior in `.allium` files using `entity`, `rule`, and `config` blocks — implementation-agnostic, co-located with code.
 
-## When to Use
-
-- Epic author is attaching a formal behavioral spec to a new epic
-- Worker needs to seed failing TDD tests from a spec before implementing
-- Validator has passed CI and needs to confirm the code matches the spec semantically
-- Refactor epic requires a behavioral baseline before decomposition
-
 ## Prerequisites
 
 Upstream Allium Claude plugin must be installed separately:

--- a/plugins/tools/altana/.claude-plugin/plugin.json
+++ b/plugins/tools/altana/.claude-plugin/plugin.json
@@ -1,17 +1,28 @@
 {
   "name": "altana",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "altana CLI wrapper: delegate prompts to sandboxed AI harnesses, run council fan-outs for diverse perspectives, and distribute tasks across harness presets",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["altana", "ai-agents", "harness", "delegate", "council", "sandbox", "awman", "local-llm"],
+  "keywords": [
+    "altana",
+    "ai-agents",
+    "harness",
+    "delegate",
+    "council",
+    "sandbox",
+    "awman",
+    "local-llm"
+  ],
   "commands": [
     "./commands/delegate.md",
     "./commands/council.md",
     "./commands/harness.md"
   ],
-  "skills": ["./skills/altana"]
+  "skills": [
+    "./skills/altana"
+  ]
 }

--- a/plugins/tools/altana/skills/altana/SKILL.md
+++ b/plugins/tools/altana/skills/altana/SKILL.md
@@ -8,16 +8,6 @@ license: MIT
 
 Procedural knowledge for working with the altana CLI — a tool that delegates prompts to named AI harness presets, collects structured JSON results, and fans out tasks across multiple harnesses for diverse-perspective synthesis.
 
-## When to Use
-
-Activate when:
-- Running `/altana:delegate`, `/altana:council`, or `/altana:harness` commands.
-- Debugging non-`done` status values or unexpected JSON output.
-- Configuring `altana.toml` harness presets or prompt templates.
-- Choosing between foreground vs background invocation for long tasks.
-- Synthesizing council results across multiple harness responses.
-- Using the model picker or `altana models` to enumerate available models.
-
 ## Config Discovery
 
 altana resolves its config in this order:

--- a/plugins/tools/awman/.claude-plugin/plugin.json
+++ b/plugins/tools/awman/.claude-plugin/plugin.json
@@ -1,10 +1,21 @@
 {
   "name": "awman",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "awman: parallel AI code agent sessions with container isolation, worktrees, and a REST API",
-  "author": { "name": "vinnie357" },
+  "author": {
+    "name": "vinnie357"
+  },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["awman", "agents", "workflows", "tmux", "claude-code", "container"],
-  "skills": ["./skills/awman"]
+  "keywords": [
+    "awman",
+    "agents",
+    "workflows",
+    "tmux",
+    "claude-code",
+    "container"
+  ],
+  "skills": [
+    "./skills/awman"
+  ]
 }

--- a/plugins/tools/awman/skills/awman/SKILL.md
+++ b/plugins/tools/awman/skills/awman/SKILL.md
@@ -15,17 +15,6 @@ awman was previously named **amux**. See "Migrating from amux" below.
 Source: https://github.com/prettysmartdev/awman (accessed 2026-07-13)
 License: Apache-2.0 | Latest at research time: v0.11.0 (2026-07-13)
 
-## When to Use This Skill
-
-Activate when:
-- Setting up a project for parallel agent sessions (`awman init`, `awman ready`)
-- Running a chat session or one-off prompt via the awman CLI
-- Authoring or executing multi-step workflows (`awman new workflow`, `awman exec workflow`)
-- Driving the REST API server (`awman api`) from an automation script
-- Migrating an existing amux setup to awman
-- Troubleshooting container isolation, worktrees, or config resolution
-- Configuring agent selection, container runtimes, or environment passthrough
-
 ## Prerequisites
 
 A container runtime, set via the global-only `runtime` config key (`awman config set --global runtime <value>`, then `awman ready`):

--- a/plugins/tools/beads/.claude-plugin/plugin.json
+++ b/plugins/tools/beads/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "beads",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Beads (bd) distributed git-backed graph issue tracker: task management, dependency tracking, AI agent workflows",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/beads/skills/beads/SKILL.md
+++ b/plugins/tools/beads/skills/beads/SKILL.md
@@ -8,16 +8,6 @@ license: MIT
 
 This skill activates when working with Beads (`bd`) for task management, dependency tracking, and AI agent workflows.
 
-## When to Use This Skill
-
-Activate when:
-- Managing tasks with dependencies in a git repository
-- Working with AI agents that need task queue access
-- Running multi-branch parallel development workflows
-- Needing collision-resistant task IDs across distributed teams
-- Tracking task hierarchies and dependency graphs
-- Integrating issue tracking directly into version control
-
 ## What is Beads?
 
 Beads is a distributed graph issue tracker designed for AI agents and modern development workflows. As of v1.1.x it is powered by [Dolt](https://github.com/dolthub/dolt) — a version-controlled SQL database — not plain JSONL+SQLite (confirmed against `gastownhall/beads` README, tag `v1.1.2`; the legacy SQLite backend has been removed):

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.78",
+  "version": "0.2.79",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/commands/research-skill.md
+++ b/plugins/tools/claude-code/commands/research-skill.md
@@ -38,14 +38,13 @@ Research a topic and create a properly structured Agent Skill following the Agen
 ```markdown
 ---
 name: skill-name
-description: When Claude should use this skill (concise, activation-focused)
+description: What the skill does and when to use it — this is the ONLY text
+  Claude sees during discovery, so every activation trigger belongs here, not
+  in a body section.
 license: MIT
 ---
 
 # Skill Name
-
-## When to Use This Skill
-[Activation criteria]
 
 ## Core Concepts
 [Essential knowledge]

--- a/plugins/tools/claude-code/skills/claude-agents/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-agents/SKILL.md
@@ -15,15 +15,6 @@ Invoke `/core:anti-fabrication` always — every claim about a tool, file, or te
 
 Glob patterns like `/core:*` do not expand in Agent prompts. List skill names explicitly.
 
-## When to Use This Skill
-
-Activate this skill when:
-- Creating custom agent types for specific workflows
-- Defining agent behaviors and tool permissions
-- Configuring agent capabilities
-- Understanding agent vs skill differences
-- Implementing domain-specific agents
-
 ## What Are Agents?
 
 Agents are specialized Claude instances with:

--- a/plugins/tools/claude-code/skills/claude-hooks/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-hooks/SKILL.md
@@ -8,14 +8,6 @@ license: MIT
 
 Hooks are shell commands or prompts that Claude Code executes in response to events. They are the only mechanism that can compel behavior — Claude reads memory and skills as guidance, but the harness runs hooks, not Claude.
 
-## When to Use
-
-- Inject binding context at session start (SessionStart)
-- Validate or block tool calls before execution (PreToolUse)
-- Format, lint, or log after tool calls (PostToolUse)
-- Enforce completion standards before the agent stops (Stop / SubagentStop)
-- Augment user prompts with project context (UserPromptSubmit)
-
 ## Hook Configuration Locations
 
 | Scope | Path | Use case |

--- a/plugins/tools/claude-code/skills/claude-output-styles/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-output-styles/SKILL.md
@@ -8,17 +8,6 @@ license: MIT
 
 Guide for the native Claude Code output style feature and for applying the same response-contract pattern to agents, slash commands, teams, and skills.
 
-## When to Use This Skill
-
-Activate this skill when:
-
-- Creating a custom output style for a session or plugin
-- Shipping output styles from a plugin via the `output-styles/` directory
-- Deciding whether a need is best served by an output style, a skill, CLAUDE.md, or `--append-system-prompt`
-- Standardizing the response shape a worker agent must return so a team lead can filter and parse it
-- Writing reusable response-format contracts that multiple agents, commands, or skills reference
-- Debugging why a subagent is not honoring the session's output style
-
 ## Two Things This Skill Covers
 
 1. **The Claude Code feature**: a session-level system prompt modification selected via `/config`, shipped as Markdown files, optionally bundled in plugins.

--- a/plugins/tools/claude-code/skills/claude-skills-benchmark/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-skills-benchmark/SKILL.md
@@ -7,15 +7,6 @@ description: Evaluate and benchmark Agent Skills quality using static analysis a
 
 Evaluate Agent Skills through static analysis and evaluation-driven methodology. Source: Anthropic's skill evaluation guidance.
 
-## When to Use
-
-Activate when:
-- Assessing skill quality across a plugin or marketplace
-- Measuring skill activation accuracy (false positives/negatives)
-- Comparing skill versions or skill-vs-no-skill performance
-- Running the `/benchmark-skills` command
-- Reviewing skill descriptions for optimization
-
 ## Static Analysis Checks
 
 The check list, pass criteria, and failure keys are defined in `test/validate-skills-quality.nu` — that script is the single source of truth; do not restate its checks here. Run `mise run test:skills-quality` to produce the current scorecard.

--- a/plugins/tools/claude-code/skills/claude-skills/references/examples.md
+++ b/plugins/tools/claude-code/skills/claude-skills/references/examples.md
@@ -21,14 +21,6 @@ license: MIT
 
 # Git Operations
 
-## When to Use
-
-Activate when:
-- Creating commit messages
-- Managing branches
-- Resolving conflicts
-- Rebasing or merging
-
 ## Conventional Commits
 
 Follow the format: `type(scope): description`
@@ -68,14 +60,6 @@ license: MIT
 ---
 
 # Phoenix Framework
-
-## When to Use
-
-Activate for:
-- Phoenix application development
-- LiveView implementations
-- Context design
-- Channel setup
 
 ## Project Structure
 
@@ -134,37 +118,32 @@ Loading entire API references into SKILL.md wastes context window space for ever
 - Move detailed reference material to `references/`
 - Keep SKILL.md under 500 lines (Anthropic recommendation)
 
-### Missing Activation Criteria
+### Missing Activation Triggers
 
-Without a "When to Use" section and description triggers, Claude cannot determine when to activate the skill.
+The description is the ONLY text visible during discovery (Level 1) — Claude never reads the SKILL.md body until AFTER it has already activated the skill. Putting activation triggers in a body "When to Use" section instead of (or in addition to) the description means they never influence discovery; a body-only trigger list is invisible exactly when it would matter.
 
-```markdown
-# Bad — no activation guidance
-# My Skill
-
-This skill helps with stuff.
+```yaml
+# Bad — no triggers anywhere; Claude cannot determine when to activate
+description: Helps with Git operations
 ```
 
 ```markdown
-# Good — clear activation criteria
-# My Skill
+# Bad — triggers exist, but only in the body, where discovery never sees them
+---
+description: Guide for Git operations including commits, branches, rebasing, and conflict resolution
+---
+
+# Git Operations
 
 ## When to Use
 
 Activate when:
-- Specific scenario 1
-- Specific scenario 2
-- Specific scenario 3
+- Creating commit messages
+- Managing branches
+- Resolving conflicts
 ```
 
-### Missing "Use when" in Description
-
-The description is the ONLY text visible during discovery (Level 1). Body content loads only after activation.
-
 ```yaml
-# Bad — missing triggers
-description: Guide for Git operations including commits, branches, rebasing, and conflict resolution
-
-# Good — includes triggers
+# Good — triggers live in description, where discovery reads them
 description: Guide for Git operations including commits, branches, rebasing, and conflict resolution. Use when working with version control or the user mentions git, commits, or branches.
 ```

--- a/plugins/tools/claude-code/skills/claude-statusline/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-statusline/SKILL.md
@@ -10,15 +10,6 @@ Guide for designing, configuring, and debugging the Claude Code status line — 
 
 Per `core:anti-fabrication`: test status-line scripts against the real stdin payload (see Testing Locally) before claiming a field renders — never assert output you have not observed.
 
-## When to Use This Skill
-
-Activate this skill when:
-- Creating or editing a status-line script
-- Configuring the `statusLine` block in `settings.json`
-- Surfacing token usage, model, cost, git, or project context at a glance
-- Debugging blank or stale status-line output
-- Customizing the subagent panel via `subagentStatusLine`
-
 ## What Is the Status Line?
 
 The status line is a shell command that Claude Code executes locally on each session update. Claude Code pipes a JSON payload (model, workspace, context-window, cost, etc.) to the script's stdin and renders the script's stdout verbatim as the bar at the bottom of the UI. It runs on the user's machine, consumes no API tokens, and is temporarily hidden during autocomplete, help menus, and permission prompts.

--- a/plugins/tools/claude-code/skills/claude-teams/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-teams/SKILL.md
@@ -18,15 +18,6 @@ Require each teammate to quote one sentence from each loaded skill in its first 
 
 Glob patterns like `/core:*` do not expand in Agent prompts. List skill names explicitly.
 
-## When to Use
-
-Activate when:
-- Setting up or configuring Agent Teams (experimental)
-- Creating custom subagents for task delegation
-- Building multi-agent workflows with the Claude Agent SDK
-- Designing coordination patterns for parallel agent work
-- Troubleshooting agent communication or task assignment
-
 ## Approaches
 
 Three approaches exist for multi-agent coordination, each with different trade-offs:

--- a/plugins/tools/dagu/.claude-plugin/plugin.json
+++ b/plugins/tools/dagu/.claude-plugin/plugin.json
@@ -1,13 +1,18 @@
 {
   "name": "dagu",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Dagu workflow orchestration: workflow authoring, web UI, and REST API",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["dagu", "workflow", "orchestration", "automation"],
+  "keywords": [
+    "dagu",
+    "workflow",
+    "orchestration",
+    "automation"
+  ],
   "skills": [
     "./skills/workflows",
     "./skills/webui",

--- a/plugins/tools/dagu/skills/rest-api/SKILL.md
+++ b/plugins/tools/dagu/skills/rest-api/SKILL.md
@@ -7,17 +7,6 @@ description: Guide for using the Dagu REST API. Use when programmatically managi
 
 Use this skill when integrating Dagu with external systems, automating workflow operations, or programmatically managing workflows through the API.
 
-## When to Use This Skill
-
-Activate when:
-- Triggering workflows programmatically
-- Querying workflow status from applications
-- Building automation around Dagu
-- Integrating Dagu with CI/CD pipelines
-- Creating custom dashboards or monitoring tools
-- Scheduling workflows dynamically
-- Fetching execution logs programmatically
-
 ## Core API Capabilities
 
 The Dagu REST API provides endpoints for:

--- a/plugins/tools/dagu/skills/webui/SKILL.md
+++ b/plugins/tools/dagu/skills/webui/SKILL.md
@@ -7,17 +7,6 @@ description: Guide for using the Dagu Web UI. Use when monitoring workflow execu
 
 Use this skill when working with Dagu's web interface to manage workflows, view execution history, monitor running workflows, or configure the UI.
 
-## When to Use This Skill
-
-Activate when:
-- Navigating the Dagu web interface
-- Starting, stopping, or retrying workflows via UI
-- Viewing workflow execution logs and status
-- Monitoring running workflows
-- Managing workflow history
-- Configuring workflow schedules through the UI
-- Troubleshooting workflow issues using the UI
-
 ## Core Capabilities
 
 The Dagu Web UI provides:

--- a/plugins/tools/dagu/skills/workflows/SKILL.md
+++ b/plugins/tools/dagu/skills/workflows/SKILL.md
@@ -7,17 +7,6 @@ description: Guide for authoring Dagu workflows with YAML syntax. Use when creat
 
 This skill activates when creating or modifying Dagu workflow definitions, configuring workflow steps, scheduling, or composing complex workflows.
 
-## When to Use This Skill
-
-Activate when:
-- Writing Dagu workflow YAML files
-- Configuring workflow steps and executors
-- Setting up workflow scheduling with cron
-- Defining step dependencies and data flow
-- Implementing error handling and retries
-- Composing hierarchical workflows
-- Using environment variables and parameters
-
 ## Basic Workflow Structure
 
 ### Minimal Workflow

--- a/plugins/tools/github/.claude-plugin/plugin.json
+++ b/plugins/tools/github/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "GitHub Actions, Workflows, act local testing, community health files, Dependabot consolidation, and PR review",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/github/skills/act/SKILL.md
+++ b/plugins/tools/github/skills/act/SKILL.md
@@ -7,17 +7,6 @@ description: Test GitHub Actions locally using act. Use when debugging workflows
 
 Activate when testing GitHub Actions workflows locally, debugging workflow issues, or developing actions without committing to remote repositories. This skill covers act installation, configuration, and usage patterns.
 
-## When to Use This Skill
-
-Activate when:
-- Testing workflow changes before committing
-- Debugging workflow failures locally
-- Developing new workflows iteratively
-- Validating workflow syntax and logic
-- Testing actions with different events
-- Running workflows without GitHub runners
-- Troubleshooting act-specific issues
-
 ## Installation
 
 Install via mise: `mise install act` (pinned in the github plugin's mise.toml), then verify with `act --version`. Homebrew, Linux script, source, and Chocolatey methods: see `references/setup-and-config.md`.

--- a/plugins/tools/github/skills/actions/SKILL.md
+++ b/plugins/tools/github/skills/actions/SKILL.md
@@ -7,17 +7,6 @@ description: Create and configure GitHub Actions. Use when building custom actio
 
 Activate when creating, modifying, troubleshooting, or optimizing GitHub Actions components. This skill covers action development, marketplace integration, and best practices.
 
-## When to Use This Skill
-
-Activate when:
-- Creating custom GitHub Actions (JavaScript, Docker, or composite)
-- Publishing actions to GitHub Marketplace
-- Configuring action metadata and inputs/outputs
-- Implementing action security and permissions
-- Troubleshooting action execution
-- Selecting or evaluating marketplace actions
-- Optimizing action performance and reliability
-
 ## Action Types
 
 ### JavaScript Actions

--- a/plugins/tools/github/skills/community-health/SKILL.md
+++ b/plugins/tools/github/skills/community-health/SKILL.md
@@ -7,16 +7,6 @@ description: Guide for setting up GitHub community health files for open source 
 
 Activate when setting up or auditing community health files for GitHub repositories. This skill covers the files GitHub checks in its Community Standards profile, plus related repo configuration.
 
-## When to Use This Skill
-
-Activate when:
-- Preparing a repository for public/open-source release
-- Adding or updating community standards files (CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, etc.)
-- Setting up issue or pull request templates
-- Configuring CODEOWNERS or FUNDING.yml
-- Auditing a repo against GitHub's community profile checklist
-- Setting repo-level configuration (merge strategy, branch protection, topics)
-
 ## Community Profile Checklist
 
 GitHub checks these 6 items on the `/community` tab:

--- a/plugins/tools/github/skills/dependabot-consolidator/SKILL.md
+++ b/plugins/tools/github/skills/dependabot-consolidator/SKILL.md
@@ -8,13 +8,6 @@ license: MIT
 
 Codifies the recipe proven on kina PR #36: collect open Dependabot PRs, consolidate into one tested branch and PR, verify with baseline-diff gates, and close out on operator approval. Single-repo, operator-supervised scope.
 
-## When to Use This Skill
-
-- A repo accumulates multiple open Dependabot PRs and you want to batch them
-- You want a single reviewable dependency-update PR instead of N separate reviews
-- You need to verify dependency bumps without confusing pre-existing CI failures with regressions
-- You are preparing a consolidated PR for operator review and approval before merging
-
 ## Scope: Dependabot only
 
 List open Dependabot PRs with:

--- a/plugins/tools/github/skills/pr-review/SKILL.md
+++ b/plugins/tools/github/skills/pr-review/SKILL.md
@@ -11,13 +11,6 @@ Reviews open, human-authored pull requests with the care of the Forge operating 
 runs per PR, each branch is built and tested locally under baseline-diff discipline, and the
 operator owns every merge. Repo-agnostic — stack and gates are discovered, never hardcoded.
 
-## When to Use This Skill
-
-- A repo accumulates open contributor or collaborator PRs that need review before merge
-- External PRs need a local build/test pass (the project's CI does not run the full suite)
-- You triage the open PR queue and want one reviewable verdict per PR
-- You verify a PR without confusing pre-existing failures with regressions it introduced
-
 ## Scope: human-authored PRs only
 
 List open PRs and exclude bots:

--- a/plugins/tools/github/skills/workflows/SKILL.md
+++ b/plugins/tools/github/skills/workflows/SKILL.md
@@ -7,18 +7,6 @@ description: Write and optimize GitHub Actions workflows. Use when creating CI/C
 
 Activate when creating, modifying, debugging, or optimizing GitHub Actions workflow files. This skill covers workflow structure, best practices, and common CI/CD patterns; full YAML syntax detail lives in `references/`.
 
-## When to Use This Skill
-
-Activate when:
-- Writing .github/workflows/*.yml files
-- Configuring workflow triggers and events
-- Defining jobs, steps, and dependencies
-- Using expressions and contexts
-- Managing secrets and environment variables
-- Implementing CI/CD pipelines
-- Optimizing workflow performance
-- Debugging workflow failures
-
 ## Workflow File Structure
 
 File anatomy (`name:`, `on:`, `env:`, `jobs:`) and the `.github/workflows/` location requirement: see `references/workflow-syntax.md`.

--- a/plugins/tools/graphify/.claude-plugin/plugin.json
+++ b/plugins/tools/graphify/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "graphify",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Graphify knowledge-graph tool: build a queryable graph of a codebase and query it instead of reading raw files",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/graphify/skills/graphify-agents/SKILL.md
+++ b/plugins/tools/graphify/skills/graphify-agents/SKILL.md
@@ -12,15 +12,6 @@ The project's published benchmark reports "**71.5x** fewer tokens per query vs r
 
 For installing graphify and the full CLI surface, load the `graphify` skill.
 
-## When to Use This Skill
-
-Activate when:
-- Giving a research or Explore subagent codebase context without reading every file
-- Adding a graph-build + graph-query step to a `/core:agent-loop` Phase 1 pre-flight
-- Doing impact analysis ("what breaks if I change X") before decomposing an epic
-- Exposing the graph to an agent through the graphify MCP server
-- Deciding between a graph query and grep+read for a given question
-
 ## The Core Pattern: Query, Don't Read
 
 | Question shape | Without graphify | With graphify |

--- a/plugins/tools/graphify/skills/graphify/SKILL.md
+++ b/plugins/tools/graphify/skills/graphify/SKILL.md
@@ -10,16 +10,6 @@ Graphify converts a folder of code, docs, PDFs, images, and videos into a querya
 
 PyPI package: **`graphifyy`** (double-y). CLI command: **`graphify`**. License: MIT. Requires Python >= 3.10.
 
-## When to Use This Skill
-
-Activate when:
-- Installing graphify in a project via mise
-- Building or refreshing a knowledge graph of a repository or document corpus
-- Exporting a graph to GraphML, SVG, Neo4j/Cypher, an Obsidian vault, or call-flow HTML
-- Querying a codebase with `query`, `path`, `explain`, or `affected`
-- Setting up `graphify hook install` to rebuild the graph on git commits
-- Wiring graphify into an AI assistant via `graphify install` / `graphify claude install`
-
 For using graphify to reduce agent token usage during research and decomposition, load `graphify-agents`.
 
 ## Installation

--- a/plugins/tools/linear/.claude-plugin/plugin.json
+++ b/plugins/tools/linear/.claude-plugin/plugin.json
@@ -1,13 +1,20 @@
 {
   "name": "linear",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Linear project management: MCP/GraphQL API, VantageEx epic authoring, auditing, and grooming",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["linear", "project-management", "epics", "graphql", "vantageex", "mcp"],
+  "keywords": [
+    "linear",
+    "project-management",
+    "epics",
+    "graphql",
+    "vantageex",
+    "mcp"
+  ],
   "skills": [
     "./skills/linear"
   ],

--- a/plugins/tools/linear/skills/linear/SKILL.md
+++ b/plugins/tools/linear/skills/linear/SKILL.md
@@ -8,17 +8,6 @@ license: MIT
 
 Manage Linear issues, author VantageEx-compatible epics, and interact with the Linear API via MCP or direct GraphQL.
 
-## When to Use
-
-Activate when:
-- Querying, creating, or updating Linear issues
-- Authoring epics for VantageEx agent consumption
-- Auditing existing epics for VantageEx compatibility
-- Grooming epics to fix audit findings
-- Transitioning issue workflow states
-- Attaching GitHub PRs to Linear issues
-- Working with Linear comments or description sections
-
 ## MCP Setup (Preferred)
 
 The Linear MCP server provides tool-based access to Linear. Set up once:

--- a/plugins/tools/playwright/.claude-plugin/plugin.json
+++ b/plugins/tools/playwright/.claude-plugin/plugin.json
@@ -1,13 +1,19 @@
 {
   "name": "playwright",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Playwright MCP browser automation for Claude Code",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["playwright", "mcp", "browser", "automation", "screenshots"],
+  "keywords": [
+    "playwright",
+    "mcp",
+    "browser",
+    "automation",
+    "screenshots"
+  ],
   "skills": [
     "./skills/playwright"
   ]

--- a/plugins/tools/playwright/skills/playwright/SKILL.md
+++ b/plugins/tools/playwright/skills/playwright/SKILL.md
@@ -8,17 +8,6 @@ license: MIT
 
 The Playwright MCP server gives Claude Code agents direct browser control through 50+ tools that operate on the accessibility tree rather than screenshots. This enables fast, structured web interaction — navigating pages, clicking elements, filling forms, extracting content, and taking screenshots — without requiring vision models.
 
-## When to Use
-
-Activate when:
-- Installing or configuring the Playwright MCP server for Claude Code
-- Browsing websites that reject non-browser HTTP clients (curl/wget blocked)
-- Taking screenshots of web applications or local dev servers
-- Automating browser interactions (clicking, typing, form submission)
-- Running local web UI tests through browser automation
-- Inspecting or extracting content from rendered web pages
-- Managing browser tabs, dialogs, or file uploads in automation workflows
-
 ## Installation
 
 ### Claude Code (recommended)

--- a/plugins/tools/qa/.claude-plugin/plugin.json
+++ b/plugins/tools/qa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "QA team that validates a running application against Gherkin user stories using Playwright and Tidewave",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/qa/skills/qa/SKILL.md
+++ b/plugins/tools/qa/skills/qa/SKILL.md
@@ -8,16 +8,6 @@ license: MIT
 
 A team-driven validation loop that exercises a running application against a Gherkin user story, treats every `Then` clause as a TDD assertion, and files behavior deltas as bees issues via the existing `bees-manager` agent.
 
-## When to Use
-
-Activate when:
-- The `/qa <path>` slash command is invoked.
-- The `/qa:new-story <name>` slash command is invoked.
-- Reasoning about how to validate a documented golden path end-to-end.
-- Decomposing a Gherkin user story into parallel work items.
-- Mapping Given/When/Then to RED/GREEN states for `/core:tdd`.
-- Authoring a new Gherkin file in `docs/user-stories/`.
-
 ## Inputs
 
 The `/qa` command expects:

--- a/plugins/tools/runex/.claude-plugin/plugin.json
+++ b/plugins/tools/runex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "runex",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Runex workflow engine: API, bundles, step logs, and debugging",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/runex/skills/runex/SKILL.md
+++ b/plugins/tools/runex/skills/runex/SKILL.md
@@ -38,17 +38,6 @@ upstream bug, not a doc error (filed separately, claude-skills-239). Re-verify a
 the live `lib/runex/driver.ex` and `mix.exs @version` before asserting a driver name or
 version this skill doesn't cover — this is the fastest-moving source in the repo.
 
-## When to Use This Skill
-
-Activate when:
-- Submitting workflows via the Runex REST API
-- Authoring or modifying TOML/YAML workflow files
-- Creating or updating workflow bundles
-- Inspecting run status or step logs for debugging
-- Configuring workflow path resolution (`RUNEX_WORKFLOW_PATH`, `RUNEX_WORKFLOWS_DIR`) or bundle search (`RUNEX_BUNDLE_DIRS`)
-- Calling the step heartbeat endpoint from long-running steps
-- Working with federation endpoints (multi-node Postgres deployments)
-
 ## Install
 
 Mise is the recommended install path. It manages the version, pins reproducibly, and uses the GitHub releases backend.

--- a/plugins/tools/slidev/.claude-plugin/plugin.json
+++ b/plugins/tools/slidev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slidev",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Slidev presentation skills: strategy, branding, interactive demos, markdown slides, syntax, code blocks, export, and troubleshooting",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/slidev/skills/code/SKILL.md
+++ b/plugins/tools/slidev/skills/code/SKILL.md
@@ -7,17 +7,6 @@ description: Guide for Slidev code block features. Use when configuring syntax h
 
 Code presentation features including highlighting, editor integration, and animated transitions.
 
-## When to Use This Skill
-
-Activate when:
-- Configuring Shiki syntax highlighting
-- Highlighting specific lines in code blocks
-- Using Monaco editor for interactive code
-- Creating Magic Move animated code transitions
-- Adding TwoSlash type annotations
-- Grouping code blocks with tabs
-- Importing code snippets from external files
-
 For code block syntax, highlighting options, and editor configuration, see `references/code.md`.
 
 ## Anti-fabrication

--- a/plugins/tools/slidev/skills/export/SKILL.md
+++ b/plugins/tools/slidev/skills/export/SKILL.md
@@ -7,15 +7,6 @@ description: Guide for exporting Slidev presentations. Use when exporting to PDF
 
 Export presentations to PDF, PPTX, PNG, and build static SPA sites.
 
-## When to Use This Skill
-
-Activate when:
-- Exporting slides to PDF or PPTX
-- Generating PNG images of individual slides
-- Building a static SPA for web hosting
-- Configuring export options and CLI flags
-- Troubleshooting Playwright dependencies for export
-
 For export commands, format options, CLI flags, and build configuration, see `references/export.md`.
 
 ## Anti-fabrication

--- a/plugins/tools/slidev/skills/presentations/SKILL.md
+++ b/plugins/tools/slidev/skills/presentations/SKILL.md
@@ -7,16 +7,6 @@ description: Guide for presentation strategy and best practices. Use when planni
 
 Structured frameworks for planning, structuring, and designing effective presentations for any audience.
 
-## When to Use This Skill
-
-Activate when:
-- Planning the structure or narrative of a slide deck
-- Choosing how to frame a problem or recommendation
-- Adapting a presentation for developers, executives, or mixed audiences
-- Designing a one-pager (executive summary or single-slide overview)
-- Applying presentation design principles (rule of threes, assertion-evidence, cognitive load)
-- Reviewing or critiquing a slide deck's structure or messaging
-
 ## Core Frameworks
 
 ### Problem-First Framing (Pyramid Principle)

--- a/plugins/tools/slidev/skills/slidev/SKILL.md
+++ b/plugins/tools/slidev/skills/slidev/SKILL.md
@@ -7,13 +7,6 @@ description: Guide for Slidev markdown-based presentation framework. Use when cr
 
 Entry point for Slidev development. Provides an overview and routes to focused skills.
 
-## When to Use This Skill
-
-Activate when:
-- Starting a new Slidev presentation project
-- Needing a general overview of Slidev capabilities
-- Unsure which specific Slidev skill to load
-
 ## Available Skills
 
 This plugin provides focused skills for specific Slidev topics:

--- a/plugins/tools/slidev/skills/styles/SKILL.md
+++ b/plugins/tools/slidev/skills/styles/SKILL.md
@@ -7,16 +7,6 @@ description: Guide for brand discovery, theme generation, and style validation f
 
 Brand discovery, theme generation, and style validation for Slidev presentations.
 
-## When to Use This Skill
-
-Activate when:
-- Extracting brand tokens (colors, fonts, spacing) from a website using Playwright MCP
-- Creating a Slidev theme from brand guidelines or a style guide URL
-- Validating slides for brand compliance or WCAG contrast requirements
-- Configuring UnoCSS theme shortcuts and CSS variables for a presentation
-- Applying a logo, custom font, or color palette to existing slides
-- Working from a manual brand brief when no website is available
-
 ## Brand Discovery Pipeline Overview
 
 The full brand discovery workflow has four stages:

--- a/plugins/tools/slidev/skills/syntax/SKILL.md
+++ b/plugins/tools/slidev/skills/syntax/SKILL.md
@@ -7,13 +7,4 @@ description: Guide for Slidev slide syntax and structure. Use when working with 
 
 Slide structure, frontmatter configuration, layouts, and presentation features.
 
-## When to Use This Skill
-
-Activate when:
-- Structuring slides with separators and frontmatter
-- Choosing and configuring slide layouts
-- Adding presenter notes or click animations
-- Configuring slide transitions
-- Using MDC (Markdown Components) syntax
-
 For syntax reference, frontmatter properties, layout catalog, and animation patterns, see `references/syntax.md`.

--- a/plugins/tools/slidev/skills/troubleshooting/SKILL.md
+++ b/plugins/tools/slidev/skills/troubleshooting/SKILL.md
@@ -7,13 +7,4 @@ description: Guide for debugging and troubleshooting Slidev presentations. Use w
 
 Common errors, debugging techniques, and solutions for Slidev development issues.
 
-## When to Use This Skill
-
-Activate when:
-- Diagnosing PDF/PPTX/PNG export failures
-- Debugging missing or broken slide content
-- Fixing font loading or rendering issues
-- Resolving build or deployment errors
-- Troubleshooting theme or component problems
-
 For error catalogs, debugging patterns, and common solutions, see `references/troubleshooting.md`.

--- a/plugins/tools/tweag/.claude-plugin/plugin.json
+++ b/plugins/tools/tweag/.claude-plugin/plugin.json
@@ -1,13 +1,20 @@
 {
   "name": "tweag",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Tweag tools: Topiary universal code formatter and Nickel configuration language",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["tweag", "topiary", "nickel", "formatter", "configuration", "tree-sitter"],
+  "keywords": [
+    "tweag",
+    "topiary",
+    "nickel",
+    "formatter",
+    "configuration",
+    "tree-sitter"
+  ],
   "skills": [
     "./skills/topiary",
     "./skills/nickel"

--- a/plugins/tools/tweag/skills/nickel/SKILL.md
+++ b/plugins/tools/tweag/skills/nickel/SKILL.md
@@ -8,17 +8,6 @@ license: MIT
 
 Nickel is a configuration language designed to automate generation of static configuration files (JSON, YAML, TOML, XML). It combines gradual typing with runtime contracts to provide both static checking for complex logic and flexible validation for configuration data.
 
-## When to Use This Skill
-
-Activate this skill when:
-- Defining typed configuration schemas with validation contracts
-- Validating YAML/JSON/TOML files against Nickel contract definitions
-- Merging multiple configuration files using Nickel's merge semantics
-- Converting between configuration formats (JSON ↔ YAML ↔ TOML)
-- Generating type-safe configurations from a single Nickel source
-- Creating reusable configuration templates with metadata
-- Building configuration pipelines with validation and transformation
-
 ## Key Concepts
 
 ### Gradual Typing

--- a/plugins/tools/tweag/skills/topiary/SKILL.md
+++ b/plugins/tools/tweag/skills/topiary/SKILL.md
@@ -8,15 +8,6 @@ license: MIT
 
 Topiary is a universal code formatter that uses Tree-sitter grammars and queries to define formatting rules. Rather than implementing language-specific formatting logic, Topiary uses declarative Tree-sitter query files (.scm) to specify how code should be formatted.
 
-## When to Use This Skill
-
-Activate this skill when:
-- Formatting code in languages without dedicated formatters (JSON, TOML, Bash, Nickel, OCaml, OCamllex, CSS, OpenSCAD, SDML, WIT, or custom languages)
-- Writing or debugging Tree-sitter query files (.scm)
-- Configuring Topiary via languages.ncl for custom languages or indentation settings
-- Setting up Topiary as part of a development workflow or CI/CD pipeline
-- Learning Tree-sitter query syntax for code analysis
-
 ## Key Concepts
 
 ### Tree-Sitter Queries

--- a/plugins/tools/whamm/.claude-plugin/plugin.json
+++ b/plugins/tools/whamm/.claude-plugin/plugin.json
@@ -1,13 +1,22 @@
 {
   "name": "whamm",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "whamm! WebAssembly bytecode instrumentation: install via mise, the instr/info CLI, injection strategies, and the DTrace-inspired .mm monitor DSL",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["whamm", "webassembly", "wasm", "instrumentation", "bytecode", "dtrace", "profiling", "wasmtime"],
+  "keywords": [
+    "whamm",
+    "webassembly",
+    "wasm",
+    "instrumentation",
+    "bytecode",
+    "dtrace",
+    "profiling",
+    "wasmtime"
+  ],
   "skills": [
     "./skills/whamm",
     "./skills/whamm-dsl"

--- a/plugins/tools/whamm/skills/whamm-dsl/SKILL.md
+++ b/plugins/tools/whamm/skills/whamm-dsl/SKILL.md
@@ -10,17 +10,6 @@ A `.mm` script is the instrumentation program whamm! injects into a WebAssembly 
 
 For installing whamm! and running instrumented modules, load the companion **whamm** skill in this plugin.
 
-## When to Use This Skill
-
-Activate when:
-- Writing `.mm` monitor scripts to instrument WebAssembly binaries
-- Reading or debugging existing `.mm` files
-- Choosing the right match rule, mode, or predicate for a probe
-- Selecting between `var`, `unshared var`, `report var`, and `frame var`
-- Understanding which bound variables are available at a given probe site
-- Using libraries (`use whamm_core;`) or the `@static`/`@init` call modifiers
-- Looking up type syntax (tuples, maps, strings, type bounds)
-
 ## Script structure
 
 A `.mm` file contains, in order:

--- a/plugins/tools/whamm/skills/whamm/SKILL.md
+++ b/plugins/tools/whamm/skills/whamm/SKILL.md
@@ -10,15 +10,6 @@ Entry point for installing, configuring, and running whamm! (v0.1.0). whamm! ins
 
 For the `.mm` language itself — probe syntax, events, libraries, and examples — load the companion **whamm-dsl** skill in this plugin.
 
-## When to Use This Skill
-
-Activate when:
-- Instrumenting or profiling a `.wasm` binary without modifying source
-- Counting opcodes, tracking function calls, or measuring memory access patterns in a WebAssembly module
-- Installing whamm via `mise` or building from source
-- Choosing between bytecode-rewriting and wei (engine-support) injection strategies
-- Running an instrumented module with `wasmtime` (rewriting path) or Wizard engine (wei path)
-
 ## Install (mise github backend)
 
 Copy the stanzas from `templates/mise.toml` into your project's `mise.toml`. Full explanation of asset patterns, Rosetta caveat, and build-from-source steps lives in `references/installation.md`.

--- a/plugins/ui/.claude-plugin/plugin.json
+++ b/plugins/ui/.claude-plugin/plugin.json
@@ -1,13 +1,19 @@
 {
   "name": "ui",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "UI framework skills: daisyUI components, theming, and responsive design",
   "author": {
     "name": "vinnie357"
   },
   "repository": "https://github.com/vinnie357/claude-skills",
   "license": "MIT",
-  "keywords": ["ui", "daisyui", "tailwind", "components", "design"],
+  "keywords": [
+    "ui",
+    "daisyui",
+    "tailwind",
+    "components",
+    "design"
+  ],
   "skills": [
     "./skills/daisyui"
   ]

--- a/plugins/ui/skills/daisyui/SKILL.md
+++ b/plugins/ui/skills/daisyui/SKILL.md
@@ -7,16 +7,6 @@ description: Guide for daisyUI component library with Tailwind CSS. Use when bui
 
 Use this skill when building user interfaces with daisyUI and Tailwind CSS, implementing UI components, or configuring themes.
 
-## When to Use This Skill
-
-Activate when:
-- Building UI components with daisyUI
-- Choosing appropriate daisyUI components for design needs
-- Implementing responsive layouts with daisyUI
-- Configuring or customizing themes
-- Converting designs to daisyUI components
-- Troubleshooting daisyUI component styling
-
 ## What is daisyUI?
 
 daisyUI is a Tailwind CSS component library providing:

--- a/plugins/wasm/.claude-plugin/plugin.json
+++ b/plugins/wasm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "WebAssembly skills: wasmtime runtime, component model, guest compilation, and host embedding",
   "author": {
     "name": "vinnie357"

--- a/plugins/wasm/skills/wasmtime/SKILL.md
+++ b/plugins/wasm/skills/wasmtime/SKILL.md
@@ -8,16 +8,6 @@ license: MIT
 
 Wasmtime is a standalone, fast, secure WebAssembly runtime from the Bytecode Alliance. It implements the WebAssembly standard and extensions including WASI (WebAssembly System Interface) and the Component Model.
 
-## When to Use This Skill
-
-Activate when:
-- Compiling Rust or Zig code to WebAssembly targets
-- Embedding a WebAssembly runtime in Rust or Elixir applications
-- Working with WASI for system interface access
-- Using the Component Model and WIT interfaces
-- Building plugin systems with WebAssembly sandboxing
-- Optimizing wasm module size or runtime performance
-
 ## Anti-fabrication
 
 This skill follows `core:anti-fabrication`. Wasmtime ships major-version bumps roughly

--- a/plugins/wasm/skills/wit/SKILL.md
+++ b/plugins/wasm/skills/wit/SKILL.md
@@ -10,17 +10,6 @@ WIT is the Interface Definition Language (IDL) for the WebAssembly Component Mod
 
 See also: [wasmtime skill](../wasmtime/SKILL.md) for runtime embedding and compilation details.
 
-## When to Use This Skill
-
-Activate when:
-- Writing `.wit` files to define component interfaces
-- Designing worlds for WebAssembly components
-- Understanding the Component Model type system
-- Using `cargo-component`, `wit-bindgen`, or `wasm-tools`
-- Mapping WIT types to host language types (Rust, Go, Python, JavaScript)
-- Structuring packages and namespaces for wasm components
-- Composing components via shared interfaces
-
 ## Anti-fabrication
 
 This skill follows `core:anti-fabrication`. The claim area is the WIT type system and

--- a/test/validate-skills-quality.nu
+++ b/test/validate-skills-quality.nu
@@ -508,6 +508,200 @@ def has-braced-claude-var [body: string]: nothing -> bool {
     ($body | parse --regex '\$\{CLAUDE_[A-Z_]+[^}]*\}' | is-not-empty)
 }
 
+# Redundant "When to Use" check (claude-skills-296). Per the Claude Code
+# Skills docs, the frontmatter `description` is the ONLY text Claude sees
+# during discovery (Level 1) — a body "## When to Use" / "## When to
+# Activate" section that is JUST a restated trigger-bullet list duplicates
+# work the description must already carry and never reaches discovery. H2
+# only ("^##\s+" requires whitespace immediately after the second `#`, so an
+# H3 "### When to Use" — real decision content in references/, agents/,
+# commands/ — never matches). Structural, no thresholds: flags a heading
+# whose section has at least one bullet line and NOTHING else structural (no
+# H3 subheading, no fenced code block, no table). Trailing prose (a scope
+# note, a references/*.md pointer) does NOT exempt a section — only
+# structural content does.
+#
+# Fence-AWARE, not fence-STRIPPED. Unlike has-anti-fab-evidence and the
+# invocation check, this does not run strip-fences over the body first:
+# strip-fences deletes an entire fenced block (markers and content) with no
+# trace, which would erase the "this section has a code fence" signal the
+# self-test's fenced-block case depends on to exempt it. Fence state is
+# tracked inline instead, for exactly one purpose: a "## When to
+# (Use|Activate)" heading found while still inside an open fence is a
+# documentation EXAMPLE of the anti-pattern (illustrating what not to write),
+# not a real structural heading, and must not be matched.
+def has-redundant-when-to-use-section [content: string]: nothing -> bool {
+    let body = (strip-frontmatter $content)
+    let all_lines = ($body | lines)
+
+    # Pass 1: fence-aware scan for the first REAL (non-fenced) heading line.
+    # -1 is the not-found sentinel (rather than null) so the arithmetic below
+    # stays on a single int type throughout.
+    mut open_len = 0
+    mut heading_idx = -1
+    for pair in ($all_lines | enumerate) {
+        let trimmed = ($pair.item | str trim)
+        let fence = ($trimmed | parse --regex '^(?P<ticks>`{3,})')
+        let tick_len = if ($fence | is-not-empty) { $fence | first | get ticks | str length } else { 0 }
+        if $open_len == 0 {
+            if $tick_len > 0 {
+                $open_len = $tick_len
+            } else if $heading_idx == -1 {
+                let is_heading = ($trimmed | str downcase | parse --regex '^##\s+when to (use|activate)\b')
+                if ($is_heading | is-not-empty) {
+                    $heading_idx = $pair.index
+                }
+            }
+        } else if $tick_len >= $open_len {
+            $open_len = 0
+        }
+    }
+    if $heading_idx == -1 {
+        return false
+    }
+
+    # Pass 2: section = lines after the heading up to the next "## " line
+    # (fence-aware, so a "## "-shaped line inside a fence never ends the
+    # section early) or EOF.
+    let after = ($all_lines | skip ($heading_idx + 1))
+    mut section_lines = []
+    mut open_len2 = 0
+    mut ended = false
+    for line in $after {
+        if $ended { continue }
+        let trimmed = ($line | str trim)
+        let fence = ($trimmed | parse --regex '^(?P<ticks>`{3,})')
+        let tick_len = if ($fence | is-not-empty) { $fence | first | get ticks | str length } else { 0 }
+        if $open_len2 == 0 {
+            if $tick_len > 0 {
+                $open_len2 = $tick_len
+                $section_lines = ($section_lines | append $line)
+            } else if ($trimmed | str starts-with "## ") {
+                $ended = true
+            } else {
+                $section_lines = ($section_lines | append $line)
+            }
+        } else {
+            $section_lines = ($section_lines | append $line)
+            if $tick_len >= $open_len2 {
+                $open_len2 = 0
+            }
+        }
+    }
+
+    let content_lines = ($section_lines | where {|l| ($l | str trim | str length) > 0 })
+    if ($content_lines | is-empty) {
+        return false
+    }
+
+    let has_bullet = ($content_lines | any {|l| let t = ($l | str trim); ($t | str starts-with "- ") or ($t | str starts-with "* ") })
+    let has_subheading = ($content_lines | any {|l| ($l | str trim | str starts-with "#") })
+    let has_fence = ($content_lines | any {|l| ($l | str trim | str starts-with "```") })
+    let has_table = ($content_lines | any {|l| ($l | str trim | str starts-with "|") })
+
+    $has_bullet and (not $has_subheading) and (not $has_fence) and (not $has_table)
+}
+
+# Embedded self-test for has-redundant-when-to-use-section (claude-skills-296).
+# 13 cases: three heading-spelling variants that flag, four structural
+# exemptions (H3 subheading, fenced code, table, zero bullets), a
+# non-matching heading, fence-awareness in both directions (a whole flagged
+# section wrapped in a fence must NOT match; a real heading followed by a
+# real fenced block inside its section must still see the fence and pass),
+# H2-only, a trailing-prose line that does not exempt, EOF-terminated
+# sections, and the "* " bullet alternation.
+def run-redundant-when-to-use-self-test [] {
+    mut failed = false
+
+    # Case 1: heading + "Activate when:" + 3 bullets -> FLAG
+    if not (has-redundant-when-to-use-section "## When to Use\n\nActivate when:\n- doing X\n- doing Y\n- doing Z\n") {
+        print $"(ansi red_bold)❌ redundant-when-to-use self-test: case 1 (basic bullets) not flagged(ansi reset)"
+        $failed = true
+    }
+
+    # Case 2: heading "When to Activate" -> FLAG
+    if not (has-redundant-when-to-use-section "## When to Activate\n\nActivate when:\n- doing X\n- doing Y\n- doing Z\n") {
+        print $"(ansi red_bold)❌ redundant-when-to-use self-test: case 2 ('When to Activate') not flagged(ansi reset)"
+        $failed = true
+    }
+
+    # Case 3: heading "When to use" (lowercase) -> FLAG
+    if not (has-redundant-when-to-use-section "## When to use\n\nActivate when:\n- doing X\n- doing Y\n- doing Z\n") {
+        print $"(ansi red_bold)❌ redundant-when-to-use self-test: case 3 (lowercase 'use') not flagged(ansi reset)"
+        $failed = true
+    }
+
+    # Case 4: same bullets + one "### Sub" line -> pass
+    if (has-redundant-when-to-use-section "## When to Use\n\nActivate when:\n- doing X\n- doing Y\n- doing Z\n\n### Sub\n\nMore decision content.\n") {
+        print $"(ansi red_bold)❌ redundant-when-to-use self-test: case 4 (H3 subheading) wrongly flagged(ansi reset)"
+        $failed = true
+    }
+
+    # Case 5: same bullets + one fenced code block -> pass
+    if (has-redundant-when-to-use-section "## When to Use\n\nActivate when:\n- doing X\n- doing Y\n- doing Z\n\n```bash\nexample command\n```\n") {
+        print $"(ansi red_bold)❌ redundant-when-to-use self-test: case 5 (fenced code block) wrongly flagged(ansi reset)"
+        $failed = true
+    }
+
+    # Case 6: same bullets + one "|" table line -> pass
+    if (has-redundant-when-to-use-section "## When to Use\n\nActivate when:\n- doing X\n- doing Y\n- doing Z\n\n| A | B |\n|---|---|\n| 1 | 2 |\n") {
+        print $"(ansi red_bold)❌ redundant-when-to-use self-test: case 6 (table) wrongly flagged(ansi reset)"
+        $failed = true
+    }
+
+    # Case 7: heading present, prose only, zero bullets -> pass
+    if (has-redundant-when-to-use-section "## When to Use\n\nThis activates when the user asks about X or Y, described only in prose.\n") {
+        print $"(ansi red_bold)❌ redundant-when-to-use self-test: case 7 (zero bullets) wrongly flagged(ansi reset)"
+        $failed = true
+    }
+
+    # Case 8: non-matching heading -> pass
+    if (has-redundant-when-to-use-section "## When Nushell over bash\n\n- bash one-liners\n- structured pipelines\n") {
+        print $"(ansi red_bold)❌ redundant-when-to-use self-test: case 8 (non-matching heading) wrongly flagged(ansi reset)"
+        $failed = true
+    }
+
+    # Case 9: whole flagged section wrapped in a markdown fence -> pass
+    # (proves fence-awareness: a heading found while inside an open fence is
+    # an example, not real document structure).
+    if (has-redundant-when-to-use-section "```markdown\n## When to Use\n\nActivate when:\n- doing X\n- doing Y\n- doing Z\n```\n") {
+        print $"(ansi red_bold)❌ redundant-when-to-use self-test: case 9 (whole section fenced) wrongly flagged(ansi reset)"
+        $failed = true
+    }
+
+    # Case 10: H3 "### When to Use" + bullets, NO H2 -> pass (proves H2-only)
+    if (has-redundant-when-to-use-section "### When to Use\n\nActivate when:\n- doing X\n- doing Y\n- doing Z\n") {
+        print $"(ansi red_bold)❌ redundant-when-to-use self-test: case 10 (H3-only heading) wrongly flagged(ansi reset)"
+        $failed = true
+    }
+
+    # Case 11: intro+bullets+trailing "See references/x.md" line -> FLAG
+    # (trailing prose does not exempt).
+    if not (has-redundant-when-to-use-section "## When to Use\n\nActivate when:\n- doing X\n- doing Y\n- doing Z\nSee references/x.md for details.\n") {
+        print $"(ansi red_bold)❌ redundant-when-to-use self-test: case 11 (trailing pointer prose) not flagged(ansi reset)"
+        $failed = true
+    }
+
+    # Case 12: section is the LAST thing in the file (EOF-terminated, no
+    # trailing "## ") with bullets ending at EOF -> FLAG.
+    if not (has-redundant-when-to-use-section "## When to Use\n\nActivate when:\n- doing X\n- doing Y\n- doing Z") {
+        print $"(ansi red_bold)❌ redundant-when-to-use self-test: case 12 (EOF-terminated section) not flagged(ansi reset)"
+        $failed = true
+    }
+
+    # Case 13: same as case 1 but using "* " bullets instead of "- " -> FLAG
+    # (proves the bullet-marker alternation).
+    if not (has-redundant-when-to-use-section "## When to Use\n\nActivate when:\n* doing X\n* doing Y\n* doing Z\n") {
+        print $"(ansi red_bold)❌ redundant-when-to-use self-test: case 13 (star bullets) not flagged(ansi reset)"
+        $failed = true
+    }
+
+    if not $failed {
+        print $"(ansi green_bold)✅ redundant-when-to-use self-test passed \(13 cases\)(ansi reset)"
+    }
+    $failed
+}
+
 # Embedded self-test for the skills: frontmatter checks (claude-skills-119):
 # every bad case must be flagged, every good case must pass clean. Exercises
 # check-agent-skills directly — the same implementation the Pass-2 agent
@@ -2845,7 +3039,8 @@ def main [--update-baseline, --self-test] {
         let pass2_eval_failed = (run-pass2-eval-self-test)
         let anti_fab_failed = (run-anti-fab-self-test)
         let braced_claude_failed = (run-braced-claude-self-test)
-        if $skills_failed or $baseline_failed or $checks_failed or $duplicate_failed or $vocab_failed or $pass2_links_failed or $orphans_failed or $safe_read_ref_failed or $fm_schema_failed or $accumulator_failed or $pass2_eval_failed or $anti_fab_failed or $braced_claude_failed { exit 1 }
+        let redundant_when_to_use_failed = (run-redundant-when-to-use-self-test)
+        if $skills_failed or $baseline_failed or $checks_failed or $duplicate_failed or $vocab_failed or $pass2_links_failed or $orphans_failed or $safe_read_ref_failed or $fm_schema_failed or $accumulator_failed or $pass2_eval_failed or $anti_fab_failed or $braced_claude_failed or $redundant_when_to_use_failed { exit 1 }
         exit 0
     }
 
@@ -3052,6 +3247,16 @@ def main [--update-baseline, --self-test] {
             let unsafe_refs = ($ref_reads | where {|r| $r.unsafe})
             if ($unsafe_refs | length) > 0 { $failed = ($failed | append "ref_unsafe") }
 
+            # 20. Redundant "When to Use" section (claude-skills-296): a body
+            # "## When to Use"/"## When to Activate" H2 section that is only
+            # a restated trigger-bullet list duplicates the description,
+            # which is the sole text Claude sees at discovery time. Not a
+            # DETAIL_CHECK — a ratchet on "how many redundant sections" buys
+            # nothing per skill; this is a single boolean per file.
+            if (has-redundant-when-to-use-section $content) {
+                $failed = ($failed | append "redundant_when_to_use")
+            }
+
             # 8. Has examples: code fence / example header in SKILL.md, or a
             # code fence in a reference file SKILL.md mentions (see has-examples)
             if not (has-examples $content $refs) { $failed = ($failed | append "examples") }
@@ -3186,7 +3391,7 @@ def main [--update-baseline, --self-test] {
                 {check: "ref_unsafe", count: ($unsafe_refs | length)}
             ])
 
-            let check_count = 19
+            let check_count = 20
             let score = $check_count - ($failed | length)
 
             $results = ($results | append {


### PR DESCRIPTION
- Add `redundant_when_to_use` check (#20) to `test/validate-skills-quality.nu`: flags a body H2 \"## When to Use\"/\"## When to Activate\" section that is only a restated trigger-bullet list, since the description is the only text Claude sees at discovery time. Fence-aware (a heading inside an example fence is not matched), H2-only (H3 decision content in references/agents/commands is exempt), structural (a subheading, code fence, or table exempts a section; trailing prose does not). 13 in-memory self-test cases.
- Strip the redundant section from 83 skills across 25 plugins (798 lines removed): 65 skills where the section was pure intro+bullets, 18 skills where a trailing pointer line (a sibling-skill note or a `references/*.md` pointer) was preserved verbatim in place.
- Fix `plugins/tools/claude-code/commands/research-skill.md`'s SKILL.md template to stop prescribing a body When-to-Use section; its `description:` template line now states triggers belong there.
- Fix `plugins/tools/claude-code/skills/claude-skills/references/examples.md`: both worked example skills (git, phoenix) dropped their own redundant When-to-Use sections, and the "Missing Activation Criteria" / "Missing \"Use when\" in Description" pitfalls — previously contradictory, since the first's \"Good\" example was exactly the anti-pattern the second one warns against — are folded into one "Missing Activation Triggers" pitfall.
- Bump patch version for the 25 touched plugins plus the `all-skills` meta-plugin (`mise update-all-skills`); marketplace `metadata.version` left unchanged (skill count unchanged at 106).
- `test/quality-baseline.json` untouched — every finding fixed in this PR, none baselined.
- Follow-up (not filed): a later issue could enrich SKILL.md descriptions with any activation nuance that was stranded in a deleted section, where the description didn't already capture it.