### PR TITLE
feat(github,pm,wasm): add core:restraint skill to review-type agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -349,7 +349,7 @@
       "source": "./plugins/tools/qa",
       "strict": true,
       "description": "QA team that validates a running application against Gherkin user stories using Playwright and Tidewave",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "category": "tools",
       "keywords": [
         "qa",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.151",
+      "version": "0.4.152",
       "category": "meta",
       "keywords": [
         "skills",
@@ -215,7 +215,7 @@
       "source": "./plugins/tools/github",
       "strict": true,
       "description": "GitHub Actions, Workflows, act local testing, community health files, Dependabot consolidation, and PR review",
-      "version": "0.3.12",
+      "version": "0.3.13",
       "category": "tools",
       "keywords": [
         "github",
@@ -311,7 +311,7 @@
       "source": "./plugins/pm",
       "strict": true,
       "description": "Product management toolkit: harvest implementation-agnostic feature specs from prototypes with SDLC guardrails and author PRDs as implementation contracts",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "category": "tools",
       "keywords": [
         "pm",
@@ -501,7 +501,7 @@
       "source": "./plugins/wasm",
       "strict": true,
       "description": "WebAssembly skills: wasmtime runtime, component model, guest compilation, and host embedding",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "category": "language",
       "keywords": [
         "wasm",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.151",
+  "version": "0.4.152",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/pm/.claude-plugin/plugin.json
+++ b/plugins/pm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pm",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Product management toolkit: harvest implementation-agnostic feature specs from prototypes with SDLC guardrails and author PRDs as implementation contracts",
   "author": {
     "name": "vinnie357"

--- a/plugins/pm/agents/pm-sdlc-assessor.md
+++ b/plugins/pm/agents/pm-sdlc-assessor.md
@@ -6,6 +6,7 @@ skills:
   - pm:spec-harvest
   - core:anti-fabrication
   - core:security
+  - core:restraint
 model: sonnet
 ---
 

--- a/plugins/tools/github/.claude-plugin/plugin.json
+++ b/plugins/tools/github/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "GitHub Actions, Workflows, act local testing, community health files, Dependabot consolidation, and PR review",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/github/skills/dependabot-consolidator/agents/dependabot-collector.md
+++ b/plugins/tools/github/skills/dependabot-consolidator/agents/dependabot-collector.md
@@ -7,6 +7,13 @@ tools: Bash, Read, Grep
 
 You are the dependabot-collector. Your role is to list and classify all open Dependabot PRs in a repository and emit a structured report. You make no git mutations.
 
+## Load skills
+
+Invoke each with the Skill tool and quote one sentence from each as proof:
+
+- /core:anti-fabrication
+- /core:restraint
+
 ## Workflow
 
 1. **List open Dependabot PRs**:

--- a/plugins/tools/github/skills/dependabot-consolidator/agents/dependabot-consolidator-worker.md
+++ b/plugins/tools/github/skills/dependabot-consolidator/agents/dependabot-consolidator-worker.md
@@ -7,6 +7,13 @@ tools: Bash, Read, Edit, Grep
 
 You are the dependabot-consolidator-worker. Your role is to create the consolidated branch, cherry-pick each Dependabot PR in order, resolve conflicts with keep-both logic, run baseline-diff gates, push, and draft the PR body. You never merge.
 
+## Load skills
+
+Invoke each with the Skill tool and quote one sentence from each as proof:
+
+- /core:anti-fabrication
+- /core:restraint
+
 ## Inputs expected from the caller
 
 - Ordered list of PR head SHAs (from the collector report)

--- a/plugins/tools/github/skills/pr-review/agents/pr-collector.md
+++ b/plugins/tools/github/skills/pr-review/agents/pr-collector.md
@@ -15,6 +15,7 @@ Invoke each with the Skill tool and quote one sentence from each as proof:
 
 - /core:mise
 - /core:anti-fabrication
+- /core:restraint
 
 ## Workflow
 

--- a/plugins/tools/github/skills/pr-review/agents/pr-review-worker.md
+++ b/plugins/tools/github/skills/pr-review/agents/pr-review-worker.md
@@ -17,6 +17,7 @@ Invoke each with the Skill tool and quote one sentence from each as proof. Alway
 - /core:mise
 - /core:security
 - /core:anti-fabrication
+- /core:restraint
 
 Plus the stack-specific skills named in your dispatch (for example `/rust:rust`,
 `/rust:testing`, `/rust:error-handling`; `/core:documentation`; `/github:workflows`,

--- a/plugins/tools/qa/.claude-plugin/plugin.json
+++ b/plugins/tools/qa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "QA team that validates a running application against Gherkin user stories using Playwright and Tidewave",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/qa/agents/qa-backend.md
+++ b/plugins/tools/qa/agents/qa-backend.md
@@ -13,6 +13,7 @@ You validate the backend-shaped assertions of a Gherkin scenario against an appl
 
 - `/qa:qa`
 - `/core:anti-fabrication`
+- `/core:restraint`
 - `/core:tdd`
 - `/core:nushell`
 

--- a/plugins/tools/qa/agents/qa-lead.md
+++ b/plugins/tools/qa/agents/qa-lead.md
@@ -17,6 +17,7 @@ Load each by exact name. Do not use glob patterns. Quote one sentence from each 
 - `/core:agent-loop`
 - `/core:tdd`
 - `/core:anti-fabrication`
+- `/core:restraint`
 - `/core:bees`
 - `/core:nushell`
 - `/claude-code:claude-teams`

--- a/plugins/tools/qa/agents/qa-playwright.md
+++ b/plugins/tools/qa/agents/qa-playwright.md
@@ -13,6 +13,7 @@ You drive a single Gherkin scenario through a running web application using Play
 
 - `/qa:qa`
 - `/core:anti-fabrication`
+- `/core:restraint`
 - `/core:tdd`
 - `/playwright:playwright` (requires the playwright plugin from this marketplace; the agent still runs, uninformed, without it)
 

--- a/plugins/tools/qa/agents/qa-tidewave.md
+++ b/plugins/tools/qa/agents/qa-tidewave.md
@@ -13,6 +13,7 @@ You validate the backend-shaped assertions of a Gherkin scenario against a runni
 
 - `/qa:qa`
 - `/core:anti-fabrication`
+- `/core:restraint`
 - `/core:tdd`
 - `/elixir:tidewave` (requires the elixir plugin from this marketplace; the agent still runs, uninformed, without it)
 - `/elixir:phoenix` (requires the elixir plugin from this marketplace; the agent still runs, uninformed, without it)

--- a/plugins/wasm/.claude-plugin/plugin.json
+++ b/plugins/wasm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "WebAssembly skills: wasmtime runtime, component model, guest compilation, and host embedding",
   "author": {
     "name": "vinnie357"

--- a/plugins/wasm/agents/wasm-inspector.md
+++ b/plugins/wasm/agents/wasm-inspector.md
@@ -12,6 +12,7 @@ You are a WebAssembly binary inspector. Your role is to analyze `.wasm` files us
 - `/wasm:wasmtime`
 - `/wasm:wit`
 - `/core:anti-fabrication`
+- `/core:restraint`
 
 ## Workflow
 


### PR DESCRIPTION
- Add core:restraint skill to pr-review-worker
- Add core:restraint skill to pr-collector
- Add core:restraint skill to dependabot-collector
- Add core:restraint skill to dependabot-consolidator-worker
- Add core:restraint skill to qa-lead
- Add core:restraint skill to qa-playwright
- Add core:restraint skill to qa-tidewave
- Add core:restraint skill to qa-backend
- Add core:restraint skill to pm-sdlc-assessor (frontmatter)
- Add core:restraint skill to wasm-inspector
- Bump version: github 0.3.12 → 0.3.13
- Bump version: pm 0.1.4 → 0.1.5
- Bump version: wasm 0.1.9 → 0.1.10
- Bump version: qa 0.1.5 → 0.1.6
- Bump version: all-skills 0.4.151 → 0.4.152