### PR TITLE
docs(core): extend git skill attribution scope to PR/MR comments and add GitLab MR equivalents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.152",
+      "version": "0.4.153",
       "category": "meta",
       "keywords": [
         "skills",
@@ -143,7 +143,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
-      "version": "0.2.63",
+      "version": "0.2.64",
       "category": "development",
       "keywords": [
         "git",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.152",
+  "version": "0.4.153",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.63",
+  "version": "0.2.64",
   "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/git/SKILL.md
+++ b/plugins/core/skills/git/SKILL.md
@@ -26,9 +26,17 @@ does, and its two claims are verified two different ways:
   rejected ("Refusing to allow an OAuth App to create or update workflow ... without
   `workflow` scope"); the identical push over SSH succeeds.
 
-Don't assert `git`/`gh` CLI or GitHub API behavior this skill doesn't already cover
-without checking the current docs, or testing it directly when the docs don't say —
-CLI flags and API responses do change across versions.
+Don't assert `git`/`gh`/`glab` CLI or GitHub/GitLab API behavior this skill doesn't
+already cover without checking the current docs, or testing it directly when the docs
+don't say — CLI flags and API responses do change across versions.
+
+- **`glab` command/flag names** throughout this skill and `references/gitlab-mr.md`
+  come from the official docs at `https://docs.gitlab.com/cli/` (per-command pages
+  cited in `sources.md`), NOT from local execution — `glab` was not installed on the
+  machine where this content was authored, and no command here was tested by running
+  it. No `glab` version is pinned deliberately: pinning a version never actually run
+  against would overstate the evidence. Re-check with `glab <cmd> --help` before
+  relying on a flag.
 
 ## Commit Format
 
@@ -54,7 +62,7 @@ optional footer
 
 **Footer** (optional): Reference issues (`Closes #123`), note breaking changes (`BREAKING CHANGE: ...`).
 
-**NEVER include attribution** — no `Co-Authored-By`, `Signed-off-by`, or similar footers. This rule has no exceptions.
+**NEVER include attribution** — no `Co-Authored-By`, `Signed-off-by`, or similar footers. This rule has no exceptions, and it is not limited to commits: it covers everything posted through `gh`/`glab` under the authenticated identity — PR/MR titles and descriptions, PR/MR comments and review bodies (`gh pr comment --body`, `gh pr review --body`, `glab mr note create --message`), issue comments, release notes, and annotated-tag messages. Unlike gitleaks (which has the `check-secrets-before-commit.sh` PreToolUse hook as a backstop), this rule has **no enforcement hook at all** — a known gap, not an oversight to assume away. A commit message is amendable while the PR is open; a posted comment is public immediately, and edits leave a visible history.
 
 **Examples:**
 
@@ -75,7 +83,7 @@ BREAKING CHANGE: API now requires PostgreSQL 12+
 Closes #789
 ```
 
-## PR Format
+## PR / MR Format
 
 Title matches commit format. Body is a bullet list of changes only.
 
@@ -83,23 +91,29 @@ Title matches commit format. Body is a bullet list of changes only.
 gh pr create --title "feat(auth): add JWT authentication" --body "- Add JWT generation and validation
 - Implement refresh token rotation
 - Add authentication middleware"
+
+glab mr create --title "feat(auth): add JWT authentication" --description "- Add JWT generation and validation
+- Implement refresh token rotation
+- Add authentication middleware"
 ```
+
+Note `glab`'s flag is `--description`, not `--body` — the flag name differs from `gh`'s.
 
 **Rules:**
 - No attribution (no "Generated with Claude Code" or similar)
-- No PR templates or boilerplate sections
+- No PR / MR templates or boilerplate sections
 - No "Summary", "Test Plan", or other headers
 - Just the changes as bullet points
 - Keep it minimal and scannable
 
-## PR Workflow
+## PR / MR Workflow
 
 1. **Gate 1 — Local CI**: `mise run ci` — fix until 0 failures
 2. **Commit**: Conventional commit, no attribution
 3. **Gitleaks**: Scan committed changes for secrets — `$(mise which gitleaks) git . --staged`, never a bare `gitleaks` (`/core:security`). The `check-secrets-before-commit.sh` PreToolUse hook backstops this on `git commit`, but only while `/core:security` is loaded (hooks are scoped to their own skill's lifecycle) and it fails open — allows the commit — when no scanner is available. Run the scan yourself; don't treat the hook as a substitute for it.
 4. **Push**: `git push -u origin <branch>`
-5. **Create PR**: `gh pr create` with minimal format (title + bullets)
-6. **Gate 2 — Watch remote CI**: `gh pr checks --watch` (wait for CI to complete)
+5. **Create PR**: `gh pr create` (GitHub) or `glab mr create` (GitLab) with minimal format (title + bullets)
+6. **Gate 2 — Watch remote CI**: `gh pr checks --watch` (GitHub) or `glab ci status --live` (GitLab) (wait for CI to complete)
 7. **After CI passes** (if using bees):
    - `bees close <task-id>`
    - `git add .bees/ && git commit -m "chore(bees): close <task-id>"`
@@ -119,7 +133,7 @@ Three gates protect main. None is optional, and none substitutes for another.
 **Gate 2 — Remote (before every squash merge).** Squash-merge a PR only when **both** conditions hold:
 
 1. Local `mise run ci` is green on the branch HEAD being merged, **and**
-2. `gh pr checks` reports every remote check passing.
+2. `gh pr checks` (GitHub) or `glab ci status` (GitLab) reports every remote check passing.
 
 **Gate 3 — Adversarial review (before every squash merge).** Every PR gets a review from a separate agent on the strongest thinking model the harness offers — the same tier as `/core:agent-loop`'s reviewer default, and overridable by its model-overrides convention. Name a capability, never a model literal. No exemption: not for one-line fixes, not for documentation, not for version bumps.
 
@@ -139,6 +153,7 @@ Gate 3 requirements:
 - **Read-only, with a scratchpad clone for destructive tests.** See `/core:agent-loop`'s `references/dispatch-discipline.md`, "Read-only agents never touch the shared working tree".
 - **Findings are addressed or answered, not waved through.** Applying a fix, disputing it with evidence, and filing it as a tracked follow-up all count. Silence does not.
 - **Verify the reviewer's claims independently** before acting on them. A review is evidence, not a verdict.
+- **Grep for attribution before posting a comment or declaring gates green** — both the branch's commits and the comment text about to be posted: `git log origin/main..HEAD --format='%B' | grep -niE 'co-authored-by|signed-off-by|assisted-by|generated with'`, same pattern against the comment body. The pattern deliberately excludes bare model/vendor names — in this repo (`claude-skills`, scopes like `feat(claude-code):`) a bare `grep -i claude` would be a constant false positive. Eyeball the trailer block to catch what the pattern misses.
 - **The verdict and each finding's disposition land as a durable record on the PR** — a PR comment, or a bees comment the PR links. Gates 1 and 2 have observables (`mise run ci` output, `gh pr checks`); Gate 3 needs one too, or "review done" is an unverifiable assertion of exactly the kind this gate exists to catch. Check it with `gh pr view <n> --comments`.
 
 No `gh pr merge --squash` while any gate is red. The user approves the merge; agents never merge.
@@ -158,13 +173,17 @@ Gates 1 and 2 prove the suite passes, not that the change is correct. A green bu
 Squash merge only, and only after all three gates are green:
 
 ```bash
-mise run ci                    # Gate 1: local, already green before the last commit
-gh pr checks <number>          # Gate 2: remote
+mise run ci                              # Gate 1: local, already green before the last commit
+gh pr checks <number>                    # Gate 2: remote (GitHub)
+glab ci status --branch <branch>         # Gate 2: remote (GitLab)
 # Gate 3: adversarial review reported, findings addressed or answered
-gh pr merge <number> --squash
+gh pr merge <number> --squash            # GitHub
+glab mr merge <number> --squash --yes    # GitLab
 ```
 
-Never use regular merge or rebase merge for PRs. Squash merge keeps main history clean with one commit per PR.
+Never use regular merge or rebase merge for PRs or MRs. Squash merge keeps main history clean with one commit per PR.
+
+**`--auto-merge` hazard on `glab mr merge`.** The flag defaults to true — left unset, it can queue an automatic merge that fires later once the pipeline succeeds, a merge the user never explicitly approved at that moment. This conflicts directly with "agents never merge." Always pass `--auto-merge=false` explicitly, or do not run `glab mr merge` at all without explicit user go-ahead.
 
 ## Branch Naming
 
@@ -175,15 +194,18 @@ Never use regular merge or rebase merge for PRs. Squash merge keeps main history
 
 **Examples:** `feature/user-authentication`, `fix/456-null-pointer-error`, `chore/update-dependencies`
 
+Branch naming is platform-agnostic — identical on GitHub and GitLab. So are the Three-Gate Merge Policy and Key Rules; only the CLI verbs change.
+
 ## Remote and Authentication Conventions
 
 ### SSH-form remote URLs for operations
 
-Use SSH-form remote URLs (`git@github.com:<owner>/<repo>.git`), not HTTPS, for any worker that performs `git push`, `git fetch`, or other operations. SSH key-based auth bypasses OAuth scope checks that HTTPS push enforces, so it works reliably across container hosts and CI runners that do not carry GitHub-aware credential helpers.
+Use SSH-form remote URLs (`git@github.com:<owner>/<repo>.git`, or `git@gitlab.com:<group>/<project>.git` on GitLab), not HTTPS, for any worker that performs `git push`, `git fetch`, or other operations. SSH key-based auth bypasses OAuth scope checks that HTTPS push enforces, so it works reliably across container hosts and CI runners that do not carry GitHub-aware credential helpers.
 
 ```bash
 # Convert an https remote to ssh form
 git remote set-url origin git@github.com:<owner>/<repo>.git
+git remote set-url origin git@gitlab.com:<group>/<project>.git
 ```
 
 ### No git worktrees for agent isolation
@@ -208,6 +230,8 @@ Prefer the layered auth chain over a single static `GITHUB_TOKEN` env var:
 
 A single `GITHUB_TOKEN` env var blanket-deployed across hosts loses scope granularity and rotation independence. Use `gh auth refresh -h github.com -s workflow` to add the `workflow` scope when CI scripts need it.
 
+GitLab's entry point is `glab auth login` (`--hostname` for self-managed instances, `--stdin` for CI token input, `--job-token` in CI) — the same layering principle applies: keyring first, scoped token for unattended hosts.
+
 ### Prefer git-backed substrate
 
 Default to git-backed designs (local, private, or GitHub) for any system that needs an audit trail, replicability, or merge semantics. Git provides commit-level history, signature verification, hooks, and a uniform protocol across local files, private servers, and public hosts. Build atop git before introducing a new storage layer.
@@ -223,6 +247,26 @@ gh pr checkout 123                      # Checkout PR locally
 gh pr merge 123 --squash                # Squash merge PR
 ```
 
+## GitLab MR Commands
+
+Same workflow, different verbs. `glab` mirrors `gh`'s shape, including the `-R, --repo` global flag. Flag detail, auth, and the surfaces this skill deliberately does not model are in [gitlab-mr.md](references/gitlab-mr.md).
+
+| Action | GitHub | GitLab |
+|--------|--------|--------|
+| Create | `gh pr create --title "..." --body "..."` | `glab mr create --title "..." --description "..."` |
+| Draft | `gh pr create --draft` | `glab mr create --draft` |
+| List | `gh pr list` | `glab mr list` |
+| View | `gh pr view 123` | `glab mr view 123` |
+| View with comments | `gh pr view 123 --comments` | `glab mr view 123 --comments` |
+| Checkout | `gh pr checkout 123` | `glab mr checkout 123` |
+| Comment (Gate 3 record) | `gh pr comment 123 --body "..."` | `glab mr note create 123 -m "..."` |
+| CI status (Gate 2) | `gh pr checks 123` | `glab ci status --branch <branch>` |
+| Watch CI | `gh pr checks --watch` | `glab ci status --live` |
+| Squash-merge | `gh pr merge 123 --squash` | `glab mr merge 123 --squash --yes --auto-merge=false` |
+| Authenticate | `gh auth login` | `glab auth login` |
+
+`gh pr checks` is scoped to the PR; `glab ci status` is scoped to a branch (current branch by default). They are not interchangeable at Gate 2 — on GitLab, confirm the branch being checked is the MR's actual source branch before trusting the result.
+
 ## Key Rules
 
 - **No attribution**: Never add `Co-Authored-By`, `Signed-off-by`, or similar to commits. No "Generated with Claude Code" or similar in PRs
@@ -237,6 +281,7 @@ gh pr merge 123 --squash                # Squash merge PR
 For detailed command references and advanced topics, see:
 
 - **[commands.md](references/commands.md)** — Branch management, staging, committing, viewing changes, stashing, remote operations, tags, aliases
+- **[gitlab-mr.md](references/gitlab-mr.md)** — GitLab MR equivalents in full: `glab` flag detail for create/view/note/merge, `glab ci status` vs `gh pr checks` scoping, `glab auth login`, and the GitLab-only surfaces this skill deliberately does not model
 - **[advanced.md](references/advanced.md)** — Rebasing, merge strategies, conflict resolution, interactive rebase, history management, cherry-picking, bisect, submodules
 - **[troubleshooting.md](references/troubleshooting.md)** — Common issues (wrong branch, sensitive data, recover deleted branch, bad merge) and best practices
 - **[shallow-clone-remotes.md](references/shallow-clone-remotes.md)** — When `origin` is a file-based local clone: add `github` remote, push there, verify with `gh api`

--- a/plugins/core/skills/git/references/gitlab-mr.md
+++ b/plugins/core/skills/git/references/gitlab-mr.md
@@ -1,0 +1,127 @@
+# GitLab MR Commands
+
+Scope: policy is unchanged from the main skill — commit format, no attribution,
+branch naming, the Three-Gate Merge Policy, and squash-only merging apply
+identically on GitLab. Only the CLI verbs differ, from `gh` to `glab`. This file
+covers `glab` flag detail; the main skill body carries the policy.
+
+## Provenance
+
+Sourced from the official docs at `https://docs.gitlab.com/cli/` (per-command
+pages cited in `sources.md`), not from local execution. `glab` was not installed
+on the machine where this content was authored, and no command here was tested by
+running it. No `glab` version is pinned — pinning a version never actually run
+against would overstate the evidence. Re-check with `glab <cmd> --help` before
+relying on a flag.
+
+## Authentication — `glab auth login [flags]`
+
+| Flag | Purpose |
+|------|---------|
+| `--hostname string` | GitLab instance — required for self-managed/Dedicated, omit for gitlab.com |
+| `--stdin` | Read the token from stdin (scripting, CI) |
+| `-t, --token string` | Pass the access token directly |
+| `-j, --job-token` | Use a CI job token |
+| `--device` | OAuth 2.0 device flow for headless environments (GitLab 17.9+) |
+| `-g, --git-protocol string` | `ssh`, `https`, or `http` |
+
+## Create — `glab mr create [flags]`
+
+| Flag | Purpose |
+|------|---------|
+| `-t, --title` / `-d, --description string` | MR title / description — **`--description`, not `--body`**; `glab`'s flag name differs from `gh`'s |
+| `--description-file string` | Read description from a file (`-` for stdin) — the `gh --body-file` equivalent |
+| `--draft` | Mark as draft |
+| `-b, --target-branch` / `-s, --source-branch` | Base / source branch |
+| `-f, --fill` | Auto-fill title/description from commits, push branch |
+| `--push`, `-y, --yes`, `-w, --web` | Push after creation; skip confirmation; finish in browser |
+| `-l, --label`, `-a, --assignee`, `--reviewer` | Attach labels, assignees, reviewers |
+
+## List / view / checkout
+
+`glab mr list [flags]` (alias `ls`): `-A, --all`; `-c, --closed`; `-M, --merged`;
+`-d, --draft`; `-s/-t, --source-branch/--target-branch string`; `-F, --output
+text|json`.
+
+`glab mr view [<id|branch>] [flags]`:
+
+| Flag | Purpose |
+|------|---------|
+| `-c, --comments` | Comments and activities — the Gate-3 durable-record read, equivalent to `gh pr view --comments` |
+| `--resolved` / `--unresolved` | Only resolved / unresolved discussions (implies `--comments`) |
+| `-s, --system-logs` | System activity/logs |
+| `-F, --output`, `-w, --web` | `text`/`json`; open in browser |
+
+`glab mr checkout [<id>|<branch>|<url>] [flags]`: `-b, --branch string` (local
+branch name); `-f, --force` (reset to remote on divergence); `-u,
+--set-upstream-to string`.
+
+## Comment — `glab mr note create`
+
+The `gh pr comment` equivalent — posts under the authenticated identity.
+
+`glab mr note create [<id>|<branch>] [flags]`
+
+| Flag | Purpose |
+|------|---------|
+| `-m, --message string` | The comment content — the key flag |
+| `--file string` / `--line string` / `--old-line int` | Diff comment: file, line (single or range), old-version line for removed lines |
+| `--reply string` | Reply to an existing discussion |
+| `--resolvable` | Resolvable discussion thread (default true) |
+| `--unique` | Skip posting if identical content already exists |
+
+Docs example: `glab mr note create 123 -m "Looks good to me!"`
+
+**Attribution rule applies here too.** This posts under the authenticated identity
+exactly like a commit — no `Co-Authored-By`, no "Generated with Claude Code" or
+model/vendor mentions. Unlike a commit, a posted comment is public immediately and
+cannot be quietly amended; edits leave a visible history.
+
+## Merge — `glab mr merge [<id|branch>] [flags]`
+
+| Flag | Purpose |
+|------|---------|
+| `-s, --squash` / `-r, --rebase` | Squash or rebase merge |
+| `-d, --remove-source-branch` | Delete source branch after merge |
+| `-m, --message` / `--squash-message` | Merge / squash commit message |
+| `--sha string` | Require a specific SHA to merge |
+| `-y, --yes` | Skip confirmation |
+| `--auto-merge` | Queue automatic merge once checks pass — **defaults to true** |
+
+**Hazard.** `--auto-merge` defaults to true. Left unset, `glab mr merge` can queue
+a merge that fires later when the pipeline succeeds — a merge the user never
+explicitly approved at that moment. Conflicts directly with "agents never merge."
+Always pass `--auto-merge=false`, or do not run `glab mr merge` at all without
+explicit user go-ahead.
+
+## CI status — `glab ci status [flags]`
+
+The Gate 2 command.
+
+| Flag | Purpose |
+|------|---------|
+| `-b, --branch string` | Branch to check — **defaults to the current branch** |
+| `-l, --live` | Live-updating view, roughly `gh`'s `--watch` |
+| `-w, --wait` | Wait for the pipeline to finish (scripts) |
+| `-F, --output`, `--jq` | `text`/`json`; jq filter for programmatic parsing |
+
+**Scoping asymmetry.** `glab ci status` is branch-scoped (current branch by
+default); `gh pr checks` is PR-scoped. Not interchangeable at Gate 2 — on GitLab,
+confirm the branch being checked is the MR's actual source branch.
+
+## Explicitly out of scope
+
+- **MR approvals** (`glab mr approve`/`approvers`/`revoke`). GitLab's approval
+  system is a project/instance policy engine (required approvers, approval rules,
+  code-owner approvals) with no GitHub-side counterpart this skill models. Gate 3
+  here is an agent adversarial review recorded as a comment — not a platform
+  approval. Never satisfy Gate 3 with `glab mr approve`.
+- `glab mr todo`, `subscribe`/`unsubscribe`, `rebase`, `diff`, `glab issue` — no
+  corresponding GitHub-side content in this skill.
+- Self-managed GitLab instance configuration beyond `--hostname` — a deployment
+  concern, not a git-workflow one.
+
+## Global flag
+
+`-R, --repo string` — select another repository (`OWNER/REPO` or
+`GROUP/NAMESPACE/REPO`), same shape as `gh -R`.

--- a/plugins/core/skills/sources.md
+++ b/plugins/core/skills/sources.md
@@ -2,7 +2,7 @@
 
 This file documents the sources used to create the core plugin skills.
 
-Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `git-scm-docs`, `conventional-commits`, `github-rest-troubleshooting`, `github-oauth-scopes` (Git Skill); `mise` (Mise Skill); `nushell` (Nushell Skill); `google-tech-writing` (Documentation Skill); `google-eng-practices-review` (Code Review Skill); `anti-fabrication-internal` (Anti-Fabrication Skill); `twelve-factor-net` (Twelve-Factor App Skill); `gitleaks` (Security Skill); `bees` (Bees Skill); `apple-container` (Container Skill); `ponytail` (Restraint Skill); `tdd-by-example`, `growing-object-oriented-software`, `three-laws-of-tdd`, `software-craftsmanship-manifesto`, `canon-tdd`, `tdd-fowler-bliki` (TDD Skill); `allium`, `workflow-execution-substrate`, `forge-operating-model` (Agent Loop Skill).
+Structured tracking: [sources.toml](sources.toml) — versions, check methods, and skill coverage live there. Entries: `git-scm-docs`, `conventional-commits`, `github-rest-troubleshooting`, `github-oauth-scopes`, `gitlab-cli-docs` (Git Skill); `mise` (Mise Skill); `nushell` (Nushell Skill); `google-tech-writing` (Documentation Skill); `google-eng-practices-review` (Code Review Skill); `anti-fabrication-internal` (Anti-Fabrication Skill); `twelve-factor-net` (Twelve-Factor App Skill); `gitleaks` (Security Skill); `bees` (Bees Skill); `apple-container` (Container Skill); `ponytail` (Restraint Skill); `tdd-by-example`, `growing-object-oriented-software`, `three-laws-of-tdd`, `software-craftsmanship-manifesto`, `canon-tdd`, `tdd-fowler-bliki` (TDD Skill); `allium`, `workflow-execution-substrate`, `forge-operating-model` (Agent Loop Skill).
 
 ## Git Skill
 
@@ -28,6 +28,12 @@ Structured tracking: [sources.toml](sources.toml) — versions, check methods, a
 - **Purpose**: Documents the `workflow` scope OAuth apps/PATs need to push GitHub Actions workflow files over HTTPS — the documented half of the SSH-bypasses-scope claim; the SSH-side exemption itself is not documented on this or any GitHub page found, and is described in the skill as empirically observed, not cited, for that reason
 - **Date Accessed**: 2026-08-01
 - **Key Topics**: OAuth app scopes, `workflow` scope, PAT scope requirements
+
+### GitLab CLI (glab) Documentation
+- **URL**: https://docs.gitlab.com/cli/
+- **Purpose**: Per-command reference for `glab` — source for the GitLab MR content added to the skill body's GitLab MR Commands table and to `references/gitlab-mr.md` (create, list, view, checkout, note, note create, merge, ci status, auth login)
+- **Date Accessed**: 2026-08-21
+- **Key Topics**: `glab mr create`/`list`/`view`/`checkout`/`note create`/`merge` flags, `glab ci status` branch-vs-PR scoping, `glab auth login`, `--auto-merge` default-true behavior
 
 ## Mise Skill
 

--- a/plugins/core/skills/sources.toml
+++ b/plugins/core/skills/sources.toml
@@ -70,6 +70,22 @@ breaking_changes_likely = false
 notes = "Docs-based reference, no version pinned. Confirms the `workflow` scope entry (\"Grants the ability to add and update GitHub Actions workflow files\") — covers only the HTTPS/OAuth-token side of the skill's SSH-vs-HTTPS claim. No GitHub docs page found stating the SSH-side exemption as a general principle; that half is described in the skill as observed behavior (a workflow-file push rejected over HTTPS without the scope, identical push succeeding over SSH), not as a citable claim."
 
 # ----------------------------------------------------------------------------
+# GitLab CLI (glab) Documentation — per-command reference for the GitLab MR
+# equivalents added to the skill body and references/gitlab-mr.md.
+# ----------------------------------------------------------------------------
+[[sources]]
+skills = ["git"]
+name = "gitlab-cli-docs"
+url = "https://docs.gitlab.com/cli/"
+check_method = "manual"
+current_version = "unknown"
+version_constraint = "rolling"
+last_checked = "2026-08-21"
+update_priority = "medium"
+breaking_changes_likely = false
+notes = "Per-command reference for glab; source for the GitLab MR content in the skill body and references/gitlab-mr.md. Pages used: /cli/mr/create/, /cli/mr/list/, /cli/mr/view/, /cli/mr/checkout/, /cli/mr/note/, /cli/mr/note/create/, /cli/mr/merge/, /cli/ci/status/, /cli/auth/login/. Docs-based only -- glab was not installed on the authoring machine and no command was executed, so current_version is 'unknown' rather than a guessed release; the skill body pins no glab version either, which keeps the version_pin check inapplicable."
+
+# ----------------------------------------------------------------------------
 # mise — tool version manager and task runner. CalVer releases via GitHub.
 # current_version is the version the skill content was verified against per
 # sources.md ("Version v2026.3.15", accessed 2026-03-25), not


### PR DESCRIPTION
- Extend the attribution rule beyond commits to everything posted through `gh`/`glab` under the authenticated identity: PR/MR titles/descriptions, comments, review bodies, issue comments, release notes, tag messages — and state explicitly this has no enforcement hook, unlike gitleaks
- Add a Gate 3 requirement to grep both the branch's commits and the comment about to be posted for attribution trailers before declaring gates green
- Rename PR Format / PR Workflow to PR / MR Format / PR / MR Workflow, add `glab mr create` alongside `gh pr create` (note `--description`, not `--body`)
- Add `glab ci status`/`glab mr merge` to Gate 2 and Merge Strategy, with an explicit `--auto-merge=false` instruction (the flag defaults to true, which can queue an unapproved merge)
- Add a GitLab MR Commands mapping table (create/list/view/checkout/comment/CI-status/merge/auth) and state the `gh pr checks` (PR-scoped) vs `glab ci status` (branch-scoped) asymmetry
- Confirm branch naming and the Three-Gate Merge Policy are platform-agnostic — only the CLI verbs change
- Add `references/gitlab-mr.md` (127 lines) with full `glab` flag detail, auth, and an explicit GitLab-only out-of-scope section (MR approvals, todo/subscribe/rebase/diff, issue tracking, self-managed instance config)
- Extend the Anti-fabrication section's CLI-behavior disclaimer to cover `glab`, and add a provenance bullet: `glab` command/flag names are docs-sourced, not locally executed or version-pinned
- Add `gitlab-cli-docs` to sources.toml and sources.md (Git Skill)
- Bump core plugin (0.2.63 -> 0.2.64) and all-skills meta-plugin (0.4.151 -> 0.4.152)

Inline-vs-reference placement note: git/SKILL.md had 255 lines of headroom under the enforced 500-line hard cap before this change (245 lines). The reference-file split for `glab` flag detail was chosen for progressive disclosure — matching this skill's existing shape of 5 references — not because inline placement would have failed CI. Platform-agnostic policy (attribution scope, Gate 3 grep, the GitHub->GitLab mapping table, and the two gate-execution gotchas) stays inline because the PR/MR Workflow and Merge Strategy sections name a CLI verb an agent must execute at read time; deferring that to a reference would leave those instructions unexecutable on a GitLab repo. Final line counts: SKILL.md 290 lines (target ~311, well under the 335 soft ceiling), gitlab-mr.md 127 lines (target 100-130).