### PR TITLE
feat(agent-loop,restraint,output-styles): wire terse-output contract cross-references

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.154",
+      "version": "0.4.155",
       "category": "meta",
       "keywords": [
         "skills",
@@ -143,7 +143,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
-      "version": "0.2.65",
+      "version": "0.2.66",
       "category": "development",
       "keywords": [
         "git",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.154",
+  "version": "0.4.155",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.65",
+  "version": "0.2.66",
   "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/agent-loop/references/agent-worker.md
+++ b/plugins/core/skills/agent-loop/references/agent-worker.md
@@ -34,6 +34,8 @@ Implementation owes the restraint ladder too — see `/core:restraint`'s agent-l
 
 ## Phase 4: Reporting
 
+Use the worker-report contract in `/claude-code:claude-output-styles`'s `assets/worker-report-format.md` for structured output.
+
 1. On completion: report to sub-lead with summary of what was done
 2. On failure: report what was attempted, what failed, error context
 3. On missing skill: report which skill is needed and why

--- a/plugins/core/skills/agent-loop/references/fix-agent.md
+++ b/plugins/core/skills/agent-loop/references/fix-agent.md
@@ -34,6 +34,8 @@ You receive CI failure context from the Validator and fix the code. You do NOT c
 
 ## Phase 4: Report
 
+Use the worker-report contract in `/claude-code:claude-output-styles`'s `assets/worker-report-format.md` for structured output.
+
 1. Report to sub-team leader:
    - Which failures were fixed and how
    - Any failures that could not be resolved (with explanation)

--- a/plugins/core/skills/agent-loop/references/validator.md
+++ b/plugins/core/skills/agent-loop/references/validator.md
@@ -73,6 +73,8 @@ Collect any divergences reported by `weed`. Treat each divergence as a validatio
 
 ## Phase 3: Report Failures
 
+Use the worker-report contract in `/claude-code:claude-output-styles`'s `assets/worker-report-format.md` for structured output.
+
 1. Collect ALL failures from the full suite run (CI failures and, if applicable, spec divergences)
 2. Report failures in structured format:
    - file, line, error type, error message

--- a/plugins/core/skills/restraint/SKILL.md
+++ b/plugins/core/skills/restraint/SKILL.md
@@ -72,7 +72,7 @@ A report names a symptom. Before editing, grep every caller of the function you 
 
 ## Anti-prose
 
-If the explanation is longer than the code, delete the explanation. Every paragraph defending a simplification is complexity smuggled back in as prose. Boring over clever — clever is what someone decodes at 3am.
+If the explanation is longer than the code, delete the explanation. Every paragraph defending a simplification is complexity smuggled back in as prose. Boring over clever — clever is what someone decodes at 3am. See `/claude-code:claude-output-styles`'s `assets/worker-report-format.md` for a reusable contract that enforces terseness in agent output.
 
 ## In the agent loop
 


### PR DESCRIPTION
- Add one-line cross-reference from agent-worker.md Phase 4 to worker-report-format.md contract
- Add one-line cross-reference from validator.md Phase 3 to worker-report-format.md contract
- Add one-line cross-reference from fix-agent.md Phase 4 to worker-report-format.md contract
- Add one-line cross-reference from restraint SKILL.md Anti-prose section to worker-report-format.md contract
- Bump core plugin version 0.2.65 → 0.2.66 (plugin.json + marketplace.json)
- Bump all-skills meta-plugin version 0.4.154 → 0.4.155 (plugin.json + marketplace.json)
- mise run ci green, no gitleaks findings