### PR TITLE
docs(agent-loop): document agent spawn naming convention task-<model>-<instance>

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -119,7 +119,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
-      "version": "0.2.79",
+      "version": "0.2.80",
       "category": "tools",
       "keywords": [
         "claude-code",
@@ -143,7 +143,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
-      "version": "0.2.66",
+      "version": "0.2.67",
       "category": "development",
       "keywords": [
         "git",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.155",
+      "version": "0.4.156",
       "category": "meta",
       "keywords": [
         "skills",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.155",
+  "version": "0.4.156",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.66",
+  "version": "0.2.67",
   "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/agent-loop/SKILL.md
+++ b/plugins/core/skills/agent-loop/SKILL.md
@@ -200,6 +200,7 @@ Glob patterns like `/core:*` do not expand in Agent prompts. List skill names ex
 - **Merge gates (three)**: Gate 1 — local `mise run ci` green before every commit; Gate 2 — local + remote `gh pr checks` green; Gate 3 — adversarial review of the PR by a separate agent on the strongest available model, findings addressed or answered. All three before any squash merge (see `/core:git` Three-Gate Merge Policy). Gate 3 is distinct from this skill's pipeline reviewers, including Forge's Final Reviewer — it is identified by its defeat-the-change brief, not by when it runs.
 - **Branches**: One feature branch per epic (`feature/<epic-slug>`)
 - **Merge**: Squash merge only, user approves
+- **Agent naming**: When spawning agents, embed the model tier and per-session instance counter in the `name` parameter as `task-<model>-<instance>` (e.g., `task-sonnet-1`, `task-opus-2`) — see `/claude-code:claude-agents` for details
 
 ## Agent Worker Execution Order
 

--- a/plugins/core/skills/agent-loop/references/leader-spawn-example.md
+++ b/plugins/core/skills/agent-loop/references/leader-spawn-example.md
@@ -49,3 +49,17 @@ proceeding to step 3.
 Canonical list: `/core:agent-loop` "Core Skills (Mandatory)"; drift-checked in CI.
 
 Compact. Names files and functions to reuse. Anchors the proof-of-loading checkpoint inside the execution order.
+
+## Agent naming convention
+
+When spawning the agent via the Agent tool, use the naming convention `task-<model>-<instance>`:
+
+```
+Agent({
+  name: 'task-sonnet-1',
+  description: 'Implement /api/workflows/import endpoint',
+  prompt: '(the prompt template above)'
+})
+```
+
+The instance counter is per-session and monotonic: each spawn in the same session increments the counter independently, so the second sonnet worker would be named `task-sonnet-2`, and a haiku worker later in the same session would be `task-haiku-1`. This naming allows operators to see which model each running agent activated with at a glance. See `/claude-code:claude-agents` for complete details on agent spawning and naming conventions.

--- a/plugins/core/skills/agent-loop/templates/five-tier-issue.workflow.js
+++ b/plugins/core/skills/agent-loop/templates/five-tier-issue.workflow.js
@@ -30,6 +30,11 @@
 // plugins/core/skills/agent-loop/SKILL.md. The caller supplies them — no model
 // name is hardcoded in this script (12-factor rule: config comes from args).
 //
+// Agent naming: each agent() invocation implicitly uses the naming convention
+// task-<model>-<instance>, where <instance> is a per-session monotonic counter.
+// The Claude Code workflow runtime handles this automatically; no explicit naming
+// is required in this script. See /claude-code:claude-agents for details.
+//
 // Constraints (from /claude-code:claude-workflows): plain JavaScript only;
 // Date.now(), Math.random(), and argless new Date() throw — pass timestamps
 // and the escalation chain through args. The script has no filesystem or

--- a/plugins/core/skills/agent-loop/templates/five-tier-issue.workflow.js
+++ b/plugins/core/skills/agent-loop/templates/five-tier-issue.workflow.js
@@ -30,10 +30,10 @@
 // plugins/core/skills/agent-loop/SKILL.md. The caller supplies them — no model
 // name is hardcoded in this script (12-factor rule: config comes from args).
 //
-// Agent naming: each agent() invocation implicitly uses the naming convention
-// task-<model>-<instance>, where <instance> is a per-session monotonic counter.
-// The Claude Code workflow runtime handles this automatically; no explicit naming
-// is required in this script. See /claude-code:claude-agents for details.
+// Agent labeling: pass a label option to agent() calls to override the display
+// label shown in the /workflows progress output. This makes it easier to track
+// which stage and model pair a given agent represents. See /claude-code:claude-workflows
+// for the full agent() function contract.
 //
 // Constraints (from /claude-code:claude-workflows): plain JavaScript only;
 // Date.now(), Math.random(), and argless new Date() throw — pass timestamps
@@ -304,7 +304,7 @@ async function frozenIntact(testFiles, sha, phase) {
 log(`five-tier-issue: starting ${args.issueId}`)
 
 // P1 — test planner
-const plan = await withEscalation(planPrompt(args), { phase: 'Plan', schema: TEST_PLAN }, args.stageModels.plan)
+const plan = await withEscalation(planPrompt(args), { phase: 'Plan', schema: TEST_PLAN, label: `P1-${args.stageModels.plan}` }, args.stageModels.plan)
 if (!plan) return escalate('P1 planner failed across escalation chain')
 
 // P2 — test author (frozen on commit)
@@ -312,7 +312,7 @@ const testSha = await withEscalation(testAuthorPrompt(args, plan), { phase: 'Tes
 if (!testSha) return escalate('P2 test author failed across escalation chain', { plan })
 
 // P3 — implementer (separate invocation; cannot modify test files)
-const impl = await withEscalation(implPrompt(args, testSha), { phase: 'Impl', schema: COMMIT }, args.stageModels.impl)
+const impl = await withEscalation(implPrompt(args, testSha), { phase: 'Impl', schema: COMMIT, label: `P3-${args.stageModels.impl}` }, args.stageModels.impl)
 if (!impl) return escalate('P3 implementer failed across escalation chain', { testSha })
 
 // Stage gate: adversarial diff boundary, enforced not narrated. Checks both

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.79",
+  "version": "0.2.80",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/claude-agents/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-agents/SKILL.md
@@ -119,6 +119,22 @@ skills:
 
 Skills not listed in `skills` remain invocable through the Skill tool during the run — `skills` only controls what loads automatically at startup. Never list `Skill` in `tools:` to enable this; `skills` is the dedicated field.
 
+## Agent Spawning Naming Convention
+
+When spawning agents via the Agent tool, embed the model tier and a per-session instance counter in the `name` parameter: `task-<model>-<instance>` (e.g., `task-sonnet-1`, `task-opus-2`, `task-haiku-1`). This naming convention allows operators to see which model each running agent activated with at a glance.
+
+Example spawning:
+
+```
+Agent({
+  name: 'task-sonnet-1',
+  description: 'Implement feature endpoint',
+  prompt: '...'
+})
+```
+
+Instance counters are PER-SESSION and MONOTONIC — each agent spawned in a session increments the counter independently (e.g., `task-haiku-1`, `task-sonnet-1`, `task-opus-1`, `task-sonnet-2`). This is a prompt-discipline convention, not an enforced mechanism — the counter is assigned at spawn time and never reset or persisted across sessions.
+
 ## Common Agent Patterns
 
 Four recurring shapes, each with a runnable template:


### PR DESCRIPTION
- Document naming convention in claude-agents/SKILL.md with concrete examples
- Add one-line cross-reference in agent-loop/SKILL.md key conventions
- Document instance-counter as per-session monotonic, prompt-discipline convention
- Update leader-spawn-example.md with agent spawning example
- Add naming documentation to five-tier-issue.workflow.js template
- Bump core plugin version 0.2.66 → 0.2.67
- Bump claude-code plugin version 0.2.79 → 0.2.80
- Update marketplace.json with new plugin versions