### PR TITLE
feat(core,github): add comment-reviewer agent and wire into Forge review

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.156",
+      "version": "0.4.157",
       "category": "meta",
       "keywords": [
         "skills",
@@ -143,7 +143,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
-      "version": "0.2.67",
+      "version": "0.2.68",
       "category": "development",
       "keywords": [
         "git",
@@ -215,7 +215,7 @@
       "source": "./plugins/tools/github",
       "strict": true,
       "description": "GitHub Actions, Workflows, act local testing, community health files, Dependabot consolidation, and PR review",
-      "version": "0.3.13",
+      "version": "0.3.14",
       "category": "tools",
       "keywords": [
         "github",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.156",
+  "version": "0.4.157",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/mise.toml
+++ b/mise.toml
@@ -33,7 +33,7 @@ depends = ["test"]
 # "check-version-bumps" CI job (targets origin/<base_ref> on the actual PR).
 # Run it directly with `mise run test:version-bumps <base>` when needed locally.
 description = "Run all validation tests (Claude native + custom)"
-depends = ["test:claude", "test:marketplace", "test:plugins", "test:skills-quality", "test:core-list", "test:disclosure", "test:sources", "test:fenced-literals", "test:security-hook", "test:gitleaks-invocation", "test:no-symlinks"]
+depends = ["test:claude", "test:marketplace", "test:plugins", "test:skills-quality", "test:core-list", "test:disclosure", "test:sources", "test:fenced-literals", "test:security-hook", "test:gitleaks-invocation", "test:no-symlinks", "test:comment-fixtures"]
 
 [tasks."test:claude"]
 description = "Run Claude's native plugin validation"
@@ -348,6 +348,16 @@ run = """
 let repo_root = (git rev-parse --show-toplevel | str trim)
 nu ($repo_root | path join "test" "validate-no-plugin-symlinks.nu") --self-test
 nu ($repo_root | path join "test" "validate-no-plugin-symlinks.nu")
+"""
+
+[tasks."test:comment-fixtures"]
+description = "Validate comment-reviewer eval fixture set / manifest consistency (claude-skills-291)"
+run = """
+#!/usr/bin/env nu
+
+let repo_root = (git rev-parse --show-toplevel | str trim)
+nu ($repo_root | path join "test" "validate-comment-reviewer-fixtures.nu") --self-test
+nu ($repo_root | path join "test" "validate-comment-reviewer-fixtures.nu")
 """
 
 [tasks."test:plugin"]

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.67",
+  "version": "0.2.68",
   "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
   "author": {
     "name": "vinnie357"
@@ -41,6 +41,7 @@
     "./skills/bees/agents/bees-worker.md",
     "./skills/bees/agents/bees-manager.md",
     "./agents/setup.md",
-    "./agents/gcms.md"
+    "./agents/gcms.md",
+    "./agents/comment-reviewer.md"
   ]
 }

--- a/plugins/core/agents/comment-reviewer.md
+++ b/plugins/core/agents/comment-reviewer.md
@@ -1,0 +1,64 @@
+---
+name: comment-reviewer
+description: Reviews code comments for terseness — flags restated, over-explained, missing-purpose, missing-inputs, or contradicting comments, and proposes terser replacements.
+tools: Read, Grep, Edit
+model: fable
+skills:
+  - core:restraint
+  - core:anti-fabrication
+---
+
+# Comment Reviewer
+
+You review comment **quality**, not comment **presence**. A well-named function with no
+comment at all is never a finding — that is a different concern this agent does not own.
+Only judge comments that already exist.
+
+## Defect categories (closed set)
+
+Every flagged comment gets exactly one of these five categories. `none` is not a category —
+it is the absence of a defect, used only on a NO-FLAG roll-up.
+
+- **restates-code** — the comment says nothing beyond what the code already says.
+- **over-explains** — the comment teaches basic language syntax or keywords the reader
+  already knows, for no project-specific reason.
+- **missing-purpose** — a comment exists but never states what the function does or why.
+- **missing-inputs** — purpose may be stated, but a parameter that needs explaining (a
+  non-obvious unit, a base vs. full URL, a sentinel value) isn't described.
+- **contradicts-code** — the comment describes behavior the code does not actually have.
+  This is the highest-severity category: a wrong comment actively misleads, which is worse
+  than no comment at all.
+
+Do not invent a sixth category. If a comment is fine, it produces no finding.
+
+## Anti-fabrication on replacements
+
+When proposing a terser replacement, only claim what the snippet actually supports. Do not
+add a constraint or behavior the code doesn't have — e.g. don't write "must be validated
+first" unless something in the code validates it.
+
+## Output contract
+
+End your report with a `## VERDICTS` block, one line per entry:
+
+```
+## VERDICTS
+<target> | <FLAG|NO-FLAG> | <category> | <replacement or ->
+```
+
+- One **roll-up** line per file reviewed: `<target>` is the bare file path you were given.
+- Zero or more **detail** lines per file: `<target>` is `file:line` for one specific comment.
+- Roll-up rule: FLAG if any comment in the file is flagged, NO-FLAG otherwise. When multiple
+  categories are flagged in one file, the roll-up category is the single most severe by this
+  order: `contradicts-code > missing-purpose > missing-inputs > over-explains > restates-code`.
+- `<category>` is always one of the five defects, or `none` for a NO-FLAG roll-up.
+- A file with no comments at all produces exactly one line: `NO-FLAG | none | -`.
+
+## Model fallback
+
+This agent is defined at `model: fable`. If a spawn fails because fable is unavailable in
+the environment, the SPAWNER should retry the identical task at `model: opus`.
+
+This is a **capability fallback** — degrade to what's available — not the `haiku -> sonnet
+-> opus` escalation-on-failure ladder from `/core:agent-loop`. Don't conflate the two: this
+agent never escalates on a bad review, it only substitutes models when fable can't run.

--- a/plugins/core/agents/comment-reviewer.md
+++ b/plugins/core/agents/comment-reviewer.md
@@ -52,7 +52,7 @@ End your report with a `## VERDICTS` block, one line per entry:
   categories are flagged in one file, the roll-up category is the single most severe by this
   order: `contradicts-code > missing-purpose > missing-inputs > over-explains > restates-code`.
 - `<category>` is always one of the five defects, or `none` for a NO-FLAG roll-up.
-- A file with no comments at all produces exactly one line: `NO-FLAG | none | -`.
+- A file with no comments at all produces exactly one line: `<target> | NO-FLAG | none | -`.
 
 ## Model fallback
 

--- a/plugins/core/skills/agent-loop/references/forge.md
+++ b/plugins/core/skills/agent-loop/references/forge.md
@@ -22,7 +22,7 @@ are the current defaults, not fixed values.
 | Plan | Test Planner (opus) | Research hands (smallest) | 1 |
 | Author tests | Test Author (sonnet) | Test Reviewer (opus) + its own hands (smallest) | 1 |
 | Implement | Implementor (sonnet) | Test Runner (haiku) | × N slices, parallel by dep wave |
-| Review | Reviewer (opus) | Research hands (smallest) | 1 |
+| Review | Reviewer (opus) | Research hands (smallest) + Comment Reviewer (fable) | 1 |
 | Final review | Final Reviewer (opus) | Research hands (smallest) | 1 |
 | Remediate | Implementor (sonnet) | Test Runner (haiku) | per review-finding batch |
 
@@ -37,6 +37,14 @@ The **Test Reviewer** has a specific charter: using haiku hands to surface *only
 new tests, verify the tests follow the Test Planner's plan and carry no redundancy. Catching
 plan-drift and duplicate tests *before* the implementor starts raises the implementor's chance of
 first-pass success — a cheap gate that prevents an expensive failed implementation loop.
+
+The **Comment Reviewer** (`core:comment-reviewer`) has an equally narrow charter: comment
+*quality* only, never comment *presence* — a well-named uncommented function is not a finding.
+It runs as an optional dimension of the Review pair, checking new and touched comments in the
+diff for restated, over-explained, missing-purpose, missing-inputs, or contradicting content,
+and reports through the `## VERDICTS` contract. It defaults to `model: fable`, falling back to
+`opus` when fable is unavailable — a capability substitution, not the escalation-on-failure
+ladder.
 
 ## Startup index per principal
 

--- a/plugins/core/skills/code-review/SKILL.md
+++ b/plugins/core/skills/code-review/SKILL.md
@@ -75,7 +75,7 @@ Worked BAD/GOOD examples (N+1 queries, loading full datasets, list vs set lookup
 - Clear, descriptive variable and function names
 - Functions are small and focused (single responsibility)
 - No code duplication (DRY principle)
-- Comments explain "why", not "what"
+- Comments explain "why", not "what" — watch for restated, over-explained, missing-purpose, missing-inputs, or contradicting comments. See `comment-reviewer` for a dedicated pass.
 - Code follows project conventions and style guide
 - Magic numbers are replaced with named constants
 - Complexity is minimized

--- a/plugins/tools/github/.claude-plugin/plugin.json
+++ b/plugins/tools/github/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "GitHub Actions, Workflows, act local testing, community health files, Dependabot consolidation, and PR review",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/github/skills/pr-review/agents/pr-review-worker.md
+++ b/plugins/tools/github/skills/pr-review/agents/pr-review-worker.md
@@ -77,7 +77,10 @@ Run the same gate set as step 1.
 Read `git diff main...<headRefName>` against `../references/review-rubric.md`: correctness,
 security, test coverage, no leaked secrets, match to the PR's stated intent. Verify claims
 against the real source with Read/Grep — do not assume. For Actions/digest PRs, confirm pins
-are full commit SHAs and digests are correct.
+are full commit SHAs and digests are correct. Apply the rubric's optional comment-quality
+dimension inline yourself (you have no Task tool, so you never spawn a dedicated reviewer for
+it) — dispatching a separate `comment-reviewer` agent, if the orchestrator chooses to, is the
+orchestrator's job per `SKILL.md`'s "Dispatch one `pr-review-worker` per PR" line.
 
 ### 6. Return to main
 

--- a/plugins/tools/github/skills/pr-review/references/review-rubric.md
+++ b/plugins/tools/github/skills/pr-review/references/review-rubric.md
@@ -23,6 +23,12 @@ Check each dimension against the diff and the surrounding code:
   changes smuggled in; docs claims match the code they describe.
 - **Scope and size** — the change is reviewable; unexpectedly large or cross-cutting diffs
   get called out for the operator.
+- **Comment quality** (optional; requires the `core` plugin) — comments state purpose and
+  inputs in the minimum viable language. Flag comments that restate the code, over-explain,
+  omit purpose or inputs, or describe behavior the code no longer has. When `core@vinnie357`
+  is installed, the orchestrator may dispatch its `comment-reviewer` agent for this
+  dimension. When it is not installed, skip the dimension — its absence is never itself a
+  finding.
 
 ## Findings
 

--- a/test/fixtures/comment-reviewer/expected.json
+++ b/test/fixtures/comment-reviewer/expected.json
@@ -27,7 +27,7 @@
       "file": "f04.rs",
       "verdict": "NO-FLAG",
       "category": "none",
-      "why": "States purpose, and the second line carries a load-bearing caveat (offsetless RFC 3339 timestamps silently misread as local time) that is not obvious from the signature alone.",
+      "why": "States purpose, and the caveat (release-build i64 addition wraps via two's complement on overflow instead of panicking, so an out-of-range `delta` silently corrupts `balance_cents`) is real and not recoverable from the `+` expression alone — it's a compiler/build-profile fact, per the Rust Book's Integer Overflow section, not something the code reveals.",
       "example_replacement": "n/a — already a good comment, no change"
     },
     {

--- a/test/fixtures/comment-reviewer/expected.json
+++ b/test/fixtures/comment-reviewer/expected.json
@@ -1,0 +1,69 @@
+{
+  "contract_version": 1,
+  "categories": ["restates-code", "over-explains", "missing-purpose", "missing-inputs", "contradicts-code", "none"],
+  "fixtures": [
+    {
+      "file": "f01.py",
+      "verdict": "FLAG",
+      "category": "restates-code",
+      "why": "Four inline comments each restate the line below; the docstring already carries purpose.",
+      "example_replacement": "delete all four inline comments; keep the docstring"
+    },
+    {
+      "file": "f02.js",
+      "verdict": "FLAG",
+      "category": "over-explains",
+      "why": "The docblock spends nine lines explaining what `+` and `return` do — language basics, not project-specific knowledge — while burying the one caveat worth keeping.",
+      "example_replacement": "/** Sum of `a` and `b`. Non-numeric args coerce per JS rules. */"
+    },
+    {
+      "file": "f03.ex",
+      "verdict": "FLAG",
+      "category": "missing-purpose",
+      "why": "Three lines of provenance (date, ticket, reviewer, ownership) and zero lines explaining what normalize_rate does, why precision/currency order matters, or what minor_unit conversion means.",
+      "example_replacement": "# Rounds `rate` to `precision` decimal places, then scales it to `currency`'s minor unit (e.g. dollars -> cents)."
+    },
+    {
+      "file": "f04.rs",
+      "verdict": "NO-FLAG",
+      "category": "none",
+      "why": "States purpose, and the second line carries a load-bearing caveat (offsetless RFC 3339 timestamps silently misread as local time) that is not obvious from the signature alone.",
+      "example_replacement": "n/a — already a good comment, no change"
+    },
+    {
+      "file": "f05.py",
+      "verdict": "NO-FLAG",
+      "category": "none",
+      "why": "Over-correction guard: three lines for one line of code looks verbose by line-count alone, but the comment documents a genuinely non-obvious race (edge cache serving a stale 503 for ~200ms post-restart) that justifies the sleep. Do not flag on length alone.",
+      "example_replacement": "n/a — already a good comment, no change"
+    },
+    {
+      "file": "f06.go",
+      "verdict": "NO-FLAG",
+      "category": "none",
+      "why": "Scope boundary: no comments exist at all, and this agent reviews comment quality, not comment presence. An uncommented obvious function is never a finding.",
+      "example_replacement": "n/a — no comment to review"
+    },
+    {
+      "file": "f07.ts",
+      "verdict": "FLAG",
+      "category": "contradicts-code",
+      "why": "The docblock claims retry-with-backoff behavior (up to 3 attempts, throws only after the third) that the function body does not implement — it makes exactly one fetch call. A wrong comment is worse than no comment.",
+      "example_replacement": "/** Fetches `url` with a 5s timeout. No retry — throws on the first failure. */"
+    },
+    {
+      "file": "f08.nu",
+      "verdict": "FLAG",
+      "category": "missing-inputs",
+      "why": "Purpose is stated (\"Publishes the bundle\") but none of the three parameters is described, and `dest` is easy to misread as an endpoint when it is actually a base URL the function appends a path to.",
+      "example_replacement": "# Publishes the bundle. `dest` is the base URL of the target Runex instance; the /api/bundles/import path is appended."
+    },
+    {
+      "file": "f09.py",
+      "verdict": "NO-FLAG",
+      "category": "none",
+      "why": "Keyword-matcher trap: the two-word lead-in \"Reverse order:\" looks terse enough to flag as under-explained, but the sentence that follows it fully justifies the non-obvious reverse-iteration choice (forward deletion skips the following entry). Freeze this wording — lengthening the lead-in into a full restating sentence would make the fixture genuinely ambiguous and void its NO-FLAG verdict.",
+      "example_replacement": "n/a — already a good comment, no change"
+    }
+  ]
+}

--- a/test/fixtures/comment-reviewer/snippets/f01.py
+++ b/test/fixtures/comment-reviewer/snippets/f01.py
@@ -1,0 +1,10 @@
+def collect_ids(users):
+    """Ids of `users`, in source order."""
+    # Create an empty list called ids.
+    ids = []
+    # Loop over each user in users.
+    for user in users:
+        # Append the user's id to the ids list.
+        ids.append(user.id)
+    # Return the ids list.
+    return ids

--- a/test/fixtures/comment-reviewer/snippets/f02.js
+++ b/test/fixtures/comment-reviewer/snippets/f02.js
@@ -1,0 +1,14 @@
+/**
+ * This function takes two parameters. The first parameter is called `a` and
+ * the second parameter is called `b`. Both parameters are expected to be
+ * numbers. The function then uses the JavaScript addition operator, which is
+ * the `+` symbol, to add the value of `a` to the value of `b`. The addition
+ * operator is a binary operator, meaning it operates on exactly two operands,
+ * one on its left and one on its right. Once the addition has been performed,
+ * the resulting value is handed back to whatever called this function by
+ * means of the `return` statement. Note that if either argument is not a
+ * number, JavaScript's type coercion rules will apply.
+ */
+function add(a, b) {
+  return a + b;
+}

--- a/test/fixtures/comment-reviewer/snippets/f03.ex
+++ b/test/fixtures/comment-reviewer/snippets/f03.ex
@@ -1,0 +1,8 @@
+# Added 2026-03-14 by the platform team.
+# Ticket: PLAT-4471. Reviewed in the Q1 audit by J. Okonkwo.
+# Do not remove without checking with the payments guild.
+def normalize_rate(rate, currency, precision) do
+  rate
+  |> Decimal.round(precision)
+  |> Decimal.mult(minor_unit(currency))
+end

--- a/test/fixtures/comment-reviewer/snippets/f04.rs
+++ b/test/fixtures/comment-reviewer/snippets/f04.rs
@@ -1,0 +1,6 @@
+/// Parses `input` as an RFC 3339 timestamp, returned in UTC.
+/// `input` must carry an explicit offset; RFC 3339 allows omitting it, and
+/// reading an offsetless value as local time shifts ledger entries silently.
+pub fn parse_timestamp(input: &str) -> Result<DateTime<Utc>, ParseError> {
+    DateTime::parse_from_rfc3339(input).map(|dt| dt.with_timezone(&Utc))
+}

--- a/test/fixtures/comment-reviewer/snippets/f04.rs
+++ b/test/fixtures/comment-reviewer/snippets/f04.rs
@@ -1,6 +1,7 @@
-/// Parses `input` as an RFC 3339 timestamp, returned in UTC.
-/// `input` must carry an explicit offset; RFC 3339 allows omitting it, and
-/// reading an offsetless value as local time shifts ledger entries silently.
-pub fn parse_timestamp(input: &str) -> Result<DateTime<Utc>, ParseError> {
-    DateTime::parse_from_rfc3339(input).map(|dt| dt.with_timezone(&Utc))
+/// Applies `delta` to `balance_cents` and returns the resulting balance.
+/// In a release build, `i64` addition overflow wraps via two's complement
+/// instead of panicking — an out-of-range `delta` silently corrupts the
+/// balance rather than raising an error.
+pub fn apply_delta(balance_cents: i64, delta: i64) -> i64 {
+    balance_cents + delta
 }

--- a/test/fixtures/comment-reviewer/snippets/f05.py
+++ b/test/fixtures/comment-reviewer/snippets/f05.py
@@ -1,0 +1,6 @@
+def fetch_after_restart(url):
+    # Wait 250ms before the first attempt: the edge cache serves a stale 503
+    # for ~200ms after a backend restart, so an immediate request re-reads
+    # that cached error instead of reaching the new backend.
+    time.sleep(0.25)
+    return requests.get(url, timeout=5)

--- a/test/fixtures/comment-reviewer/snippets/f06.go
+++ b/test/fixtures/comment-reviewer/snippets/f06.go
@@ -1,0 +1,6 @@
+func UserDisplayName(u User) string {
+	if u.Nickname != "" {
+		return u.Nickname
+	}
+	return u.FullName
+}

--- a/test/fixtures/comment-reviewer/snippets/f07.ts
+++ b/test/fixtures/comment-reviewer/snippets/f07.ts
@@ -1,0 +1,7 @@
+/**
+ * Fetches `url`, retrying up to 3 times with exponential backoff.
+ * Throws only after the third attempt fails.
+ */
+export async function fetchWithRetry(url: string): Promise<Response> {
+  return fetch(url, { signal: AbortSignal.timeout(5000) });
+}

--- a/test/fixtures/comment-reviewer/snippets/f08.nu
+++ b/test/fixtures/comment-reviewer/snippets/f08.nu
@@ -1,0 +1,5 @@
+# Publishes the bundle.
+export def publish-bundle [name: string, version: string, dest: string] {
+    let tarball = (build-tarball $name $version)
+    http post $"($dest)/api/bundles/import" $tarball
+}

--- a/test/fixtures/comment-reviewer/snippets/f09.py
+++ b/test/fixtures/comment-reviewer/snippets/f09.py
@@ -1,0 +1,7 @@
+def purge_expired(items):
+    """Removes expired entries from `items` in place."""
+    # Reverse order: deleting an element shifts the index of every element
+    # after it, so a forward loop skips the entry following each deletion.
+    for i in range(len(items) - 1, -1, -1):
+        if items[i].expired:
+            del items[i]

--- a/test/validate-comment-reviewer-fixtures.nu
+++ b/test/validate-comment-reviewer-fixtures.nu
@@ -1,0 +1,290 @@
+#!/usr/bin/env nu
+
+# Gate A validator for the comment-reviewer eval fixture set
+# (test/fixtures/comment-reviewer/, claude-skills-291).
+#
+# This is NOT a live-agent test — it cannot invoke the comment-reviewer
+# agent in CI (no API key), so it does not judge whether the agent's actual
+# verdicts match `expected.json`. It only checks that the fixture set and
+# its manifest are internally consistent: a live-inference eval run
+# (outside CI) is the thing that actually exercises the agent against these
+# nine snippets and diffs its verdicts against `expected.json`.
+#
+# Six checks, each independently reportable so a broken manifest names every
+# problem in one run instead of failing fast on the first:
+#
+#   1. `expected.json` parses as valid JSON and `contract_version` is 1.
+#   2. Bijection: every file in snippets/ has exactly one manifest entry,
+#      and every manifest entry names a file that exists in snippets/.
+#   3. Every `category` is in the declared closed set; every `verdict` is
+#      exactly "FLAG" or "NO-FLAG" (no other casing/spelling).
+#   4. FLAG entries never carry category "none"; NO-FLAG entries always do.
+#      Catches an entry whose verdict and category disagree about whether
+#      there's a finding.
+#   5. At least one FLAG and one NO-FLAG entry exist — catches a degenerate
+#      all-one-verdict manifest that would trivially "pass" any diff.
+#   6. The manifest's own `categories` array matches the fixed six-category
+#      list below exactly (order-independent) — drift check for someone
+#      editing the closed set without updating the fixtures that declare it.
+#
+# `why` and `example_replacement` are advisory prose, not checked here.
+#
+# Usage:
+#   nu test/validate-comment-reviewer-fixtures.nu
+#   nu test/validate-comment-reviewer-fixtures.nu --self-test   # pure-function fixtures, no filesystem
+
+const FIXTURE_DIR = "test/fixtures/comment-reviewer"
+const EXPECTED_CATEGORIES = ["restates-code" "over-explains" "missing-purpose" "missing-inputs" "contradicts-code" "none"]
+const VALID_VERDICTS = ["FLAG" "NO-FLAG"]
+
+# ---- Pure checks (no I/O) ----------------------------------------------
+
+# Check 1 (contract_version half): true only when the manifest declares
+# contract_version == 1.
+def check-contract-version [manifest: record]: nothing -> bool {
+  ($manifest | get -o contract_version) == 1
+}
+
+# Check 2: bijection between snippet filenames on disk and `file` entries in
+# the manifest. Returns { missing_entries: [...], missing_files: [...] } —
+# missing_entries are snippets with no manifest row, missing_files are
+# manifest rows naming a snippet that does not exist.
+def check-bijection [snippet_files: list<string>, fixture_entries: list<string>]: nothing -> record {
+  {
+    missing_entries: ($snippet_files | where { |f| $f not-in $fixture_entries } | sort)
+    missing_files: ($fixture_entries | where { |f| $f not-in $snippet_files } | sort)
+  }
+}
+
+# Check 3: for each fixture, is its category in the closed set and its
+# verdict exactly "FLAG" or "NO-FLAG"? Returns a list of error strings,
+# empty when clean.
+def check-verdict-category-shape [fixtures: list<record>]: nothing -> list<string> {
+  mut errors = []
+  for fx in $fixtures {
+    if ($fx.category not-in $EXPECTED_CATEGORIES) {
+      $errors = ($errors | append $"($fx.file): category '($fx.category)' is not in the closed set \(($EXPECTED_CATEGORIES | str join ', ')\)")
+    }
+    if ($fx.verdict not-in $VALID_VERDICTS) {
+      $errors = ($errors | append $"($fx.file): verdict '($fx.verdict)' must be exactly 'FLAG' or 'NO-FLAG'")
+    }
+  }
+  $errors
+}
+
+# Check 4: FLAG entries must not carry category "none"; NO-FLAG entries must
+# carry category "none" exactly. Returns a list of error strings.
+def check-flag-none-consistency [fixtures: list<record>]: nothing -> list<string> {
+  mut errors = []
+  for fx in $fixtures {
+    if $fx.verdict == "FLAG" and $fx.category == "none" {
+      $errors = ($errors | append $"($fx.file): verdict FLAG but category is 'none' — a flagged entry must name a real category")
+    }
+    if $fx.verdict == "NO-FLAG" and $fx.category != "none" {
+      $errors = ($errors | append $"($fx.file): verdict NO-FLAG but category is '($fx.category)', expected 'none'")
+    }
+  }
+  $errors
+}
+
+# Check 5: at least one FLAG and at least one NO-FLAG entry exist. Returns
+# a list of error strings (0, 1, or 2 depending on which side is missing).
+def check-verdict-diversity [fixtures: list<record>]: nothing -> list<string> {
+  mut errors = []
+  if ($fixtures | where verdict == "FLAG" | is-empty) {
+    $errors = ($errors | append "no FLAG entries in the manifest — degenerate all-NO-FLAG set")
+  }
+  if ($fixtures | where verdict == "NO-FLAG" | is-empty) {
+    $errors = ($errors | append "no NO-FLAG entries in the manifest — degenerate all-FLAG set")
+  }
+  $errors
+}
+
+# Check 6: the manifest's declared `categories` array matches the fixed
+# six-category list, order-independent, both directions.
+def check-categories-closed-set [declared: list<string>]: nothing -> list<string> {
+  let missing = ($EXPECTED_CATEGORIES | where { |c| $c not-in $declared })
+  let extra = ($declared | where { |c| $c not-in $EXPECTED_CATEGORIES })
+  mut errors = []
+  if ($missing | is-not-empty) {
+    $errors = ($errors | append $"categories missing from manifest declaration — ($missing | str join ', ')")
+  }
+  if ($extra | is-not-empty) {
+    $errors = ($errors | append $"categories declared that are not in the fixed set — ($extra | str join ', ')")
+  }
+  $errors
+}
+
+# ---- Orchestration (I/O) ------------------------------------------------
+
+def main [--self-test] {
+  if $self_test {
+    self-test
+    return
+  }
+
+  let repo_root = (git rev-parse --show-toplevel | str trim)
+  cd $repo_root
+
+  let manifest_path = ([$FIXTURE_DIR "expected.json"] | path join)
+  let snippets_dir = ([$FIXTURE_DIR "snippets"] | path join)
+
+  if not ($manifest_path | path exists) {
+    print $"(ansi red_bold)❌ manifest not found: ($manifest_path)(ansi reset)"
+    exit 1
+  }
+
+  if not ($snippets_dir | path exists) {
+    print $"(ansi red_bold)❌ snippets dir not found: ($snippets_dir)(ansi reset)"
+    exit 1
+  }
+
+  let manifest = try {
+    open $manifest_path
+  } catch { |err|
+    print $"(ansi red_bold)❌ ($manifest_path) failed to parse as JSON:(ansi reset)"
+    print $"  ($err.msg)"
+    exit 1
+  }
+
+  mut errors = []
+
+  # Check 1
+  if not (check-contract-version $manifest) {
+    $errors = ($errors | append $"contract_version must be 1, got ($manifest | get -o contract_version)")
+  }
+
+  let fixtures = ($manifest | get -o fixtures | default [])
+  let snippet_files = (ls $snippets_dir | get name | each { |p| $p | path basename } | sort)
+  let fixture_entries = ($fixtures | get -o file | default [] | sort)
+
+  # Check 2
+  let bijection = (check-bijection $snippet_files $fixture_entries)
+  if ($bijection.missing_entries | is-not-empty) {
+    $errors = ($errors | append $"snippet\(s\) with no manifest entry — ($bijection.missing_entries | str join ', ')")
+  }
+  if ($bijection.missing_files | is-not-empty) {
+    $errors = ($errors | append $"manifest entr\(y|ies\) naming a snippet that does not exist — ($bijection.missing_files | str join ', ')")
+  }
+
+  # Check 3
+  $errors = ($errors | append (check-verdict-category-shape $fixtures))
+
+  # Check 4
+  $errors = ($errors | append (check-flag-none-consistency $fixtures))
+
+  # Check 5
+  $errors = ($errors | append (check-verdict-diversity $fixtures))
+
+  # Check 6
+  let declared_categories = ($manifest | get -o categories | default [])
+  $errors = ($errors | append (check-categories-closed-set $declared_categories))
+
+  if ($errors | is-not-empty) {
+    print $"(ansi red_bold)❌ comment-reviewer fixture validation failed \(($errors | length) issue\(s\)\):(ansi reset)\n"
+    for e in $errors {
+      print $"  • ($e)"
+    }
+    exit 1
+  }
+
+  print $"(ansi green_bold)✅ comment-reviewer fixtures consistent \(($fixtures | length) fixtures, ($declared_categories | length) categories\)(ansi reset)"
+  exit 0
+}
+
+# ---- Self-test ------------------------------------------------------------
+
+def self-test [] {
+  mut failures = []
+
+  # check-contract-version
+  if (check-contract-version { contract_version: 1 }) != true {
+    $failures = ($failures | append "check-contract-version: expected true for contract_version=1")
+  }
+  if (check-contract-version { contract_version: 2 }) != false {
+    $failures = ($failures | append "check-contract-version: expected false for contract_version=2")
+  }
+  if (check-contract-version {}) != false {
+    $failures = ($failures | append "check-contract-version: expected false when field is absent")
+  }
+
+  # check-bijection
+  let bij_clean = (check-bijection ["a.py" "b.py"] ["a.py" "b.py"])
+  if ($bij_clean.missing_entries | is-not-empty) or ($bij_clean.missing_files | is-not-empty) {
+    $failures = ($failures | append $"check-bijection: expected clean bijection, got ($bij_clean | to nuon)")
+  }
+  let bij_dirty = (check-bijection ["a.py" "b.py" "c.py"] ["a.py" "d.py"])
+  if $bij_dirty.missing_entries != ["b.py" "c.py"] {
+    $failures = ($failures | append $"check-bijection: expected missing_entries [b.py, c.py], got ($bij_dirty.missing_entries)")
+  }
+  if $bij_dirty.missing_files != ["d.py"] {
+    $failures = ($failures | append $"check-bijection: expected missing_files [d.py], got ($bij_dirty.missing_files)")
+  }
+
+  # check-verdict-category-shape
+  let shape_clean = (check-verdict-category-shape [{file: "f01.py" verdict: "FLAG" category: "restates-code"}])
+  if ($shape_clean | is-not-empty) {
+    $failures = ($failures | append $"check-verdict-category-shape: expected clean, got ($shape_clean)")
+  }
+  let shape_bad_category = (check-verdict-category-shape [{file: "f01.py" verdict: "FLAG" category: "bogus-category"}])
+  if ($shape_bad_category | is-empty) {
+    $failures = ($failures | append "check-verdict-category-shape: expected an error for a category not in the closed set")
+  }
+  let shape_bad_verdict = (check-verdict-category-shape [{file: "f01.py" verdict: "maybe" category: "none"}])
+  if ($shape_bad_verdict | is-empty) {
+    $failures = ($failures | append "check-verdict-category-shape: expected an error for a verdict that is not FLAG/NO-FLAG")
+  }
+
+  # check-flag-none-consistency
+  let consistency_clean = (check-flag-none-consistency [
+    {file: "f01.py" verdict: "FLAG" category: "restates-code"}
+    {file: "f04.rs" verdict: "NO-FLAG" category: "none"}
+  ])
+  if ($consistency_clean | is-not-empty) {
+    $failures = ($failures | append $"check-flag-none-consistency: expected clean, got ($consistency_clean)")
+  }
+  let consistency_flag_none = (check-flag-none-consistency [{file: "f01.py" verdict: "FLAG" category: "none"}])
+  if ($consistency_flag_none | is-empty) {
+    $failures = ($failures | append "check-flag-none-consistency: expected an error for FLAG with category=none")
+  }
+  let consistency_noflag_category = (check-flag-none-consistency [{file: "f04.rs" verdict: "NO-FLAG" category: "restates-code"}])
+  if ($consistency_noflag_category | is-empty) {
+    $failures = ($failures | append "check-flag-none-consistency: expected an error for NO-FLAG with a real category")
+  }
+
+  # check-verdict-diversity
+  let diversity_clean = (check-verdict-diversity [
+    {file: "f01.py" verdict: "FLAG" category: "restates-code"}
+    {file: "f04.rs" verdict: "NO-FLAG" category: "none"}
+  ])
+  if ($diversity_clean | is-not-empty) {
+    $failures = ($failures | append $"check-verdict-diversity: expected clean, got ($diversity_clean)")
+  }
+  let diversity_all_flag = (check-verdict-diversity [{file: "f01.py" verdict: "FLAG" category: "restates-code"}])
+  if ($diversity_all_flag | is-empty) {
+    $failures = ($failures | append "check-verdict-diversity: expected an error for an all-FLAG set")
+  }
+  let diversity_all_noflag = (check-verdict-diversity [{file: "f04.rs" verdict: "NO-FLAG" category: "none"}])
+  if ($diversity_all_noflag | is-empty) {
+    $failures = ($failures | append "check-verdict-diversity: expected an error for an all-NO-FLAG set")
+  }
+
+  # check-categories-closed-set
+  if (check-categories-closed-set $EXPECTED_CATEGORIES) != [] {
+    $failures = ($failures | append "check-categories-closed-set: expected clean for the exact fixed list")
+  }
+  if (check-categories-closed-set ($EXPECTED_CATEGORIES | where $it != "none")) == [] {
+    $failures = ($failures | append "check-categories-closed-set: expected an error when 'none' is missing")
+  }
+  if (check-categories-closed-set ($EXPECTED_CATEGORIES | append "bogus")) == [] {
+    $failures = ($failures | append "check-categories-closed-set: expected an error for an extra undeclared category")
+  }
+
+  if ($failures | is-not-empty) {
+    print $"(ansi red_bold)❌ comment-reviewer fixture validator self-test failed:(ansi reset)"
+    for f in $failures { print $"  • ($f)" }
+    exit 1
+  }
+
+  print $"(ansi green_bold)✅ comment-reviewer fixture validator self-test passed(ansi reset)"
+}

--- a/test/validate-skills-quality.nu
+++ b/test/validate-skills-quality.nu
@@ -3451,7 +3451,7 @@ def main [--update-baseline, --self-test] {
     # own doc comment. What DID change: the per-file wiring is hermetically
     # tested, and a WHOLE deletion of the merge call is caught by the full
     # run via a baseline stale-key failure.
-    let known_models = ["haiku" "sonnet" "opus"]
+    let known_models = ["haiku" "sonnet" "opus" "fable" "inherit"]
     let known_hook_events = ["PreToolUse" "PostToolUse" "SessionStart" "SessionEnd" "UserPromptSubmit" "Stop" "SubagentStop" "PreCompact" "Notification"]
     mut surface_results = []
 


### PR DESCRIPTION
- Add `plugins/core/agents/comment-reviewer.md` — a new agent (model: `fable`, with a documented capability fallback to `opus` on unavailability) that reviews code comments for terseness across five defect categories: restates-code, over-explains, missing-purpose, missing-inputs, contradicts-code
- Reviews comment QUALITY, not comment PRESENCE — an uncommented well-named function is never a finding
- Fix a real CI-blocking bug found during planning: `test/validate-skills-quality.nu`'s `known_models` allowlist was stale (`["haiku" "sonnet" "opus"]`, missing `fable`/`inherit`) — this is the first agent in the repo to use `model: fable`, and would have failed CI without the fix. A sibling validator already had the correct list with a documented precedent for this exact trap.
- Wire into Forge's Review row in `references/forge.md` (required, core-internal) with a new charter paragraph mirroring the existing Test Reviewer's
- Extend `/core:code-review`'s existing item 4 bullet ("Comments explain 'why' not 'what'") in place rather than adding a 10th checklist item, per the claude-skills-296 anti-duplication precedent
- **AC deviation, disclosed**: the AC asked for "a hook added to github:pr-review's worker prompt," but `pr-review-worker.md` has `tools: Bash, Read, Grep` — no Task/Agent tool, and is explicitly forbidden from editing/committing/merging. Literal spawning is impossible. Reshaped into an optional rubric bullet in `references/review-rubric.md` (gated on the core plugin being installed) plus one sentence in the worker file stating it applies the dimension inline — dispatch of the dedicated agent, if any, is the orchestrator's job, not the worker's
- Full 5-tier adversarial pipeline: P1 Test Planner (opus) designed 9 eval fixtures + a Gate A CI validator; a Test Reviewer (fable) reviewed and approved with fixes before any implementation started; P2 Test Author (sonnet) froze the fixtures; Implementer (sonnet) wrote the agent with zero fixture modifications (verified via diff)
- Live eval (Gate B): 9 independent agent spawns against isolated fixtures (outside the repo tree, so the agent can't see `expected.json`), no hints given — first pass 8/9, with the one miss traced to a factual error in the fixture itself (its comment claimed RFC 3339 permits an omitted timezone offset; independently verified via the IETF datatracker that RFC 3339's grammar makes the offset mandatory). Fixture corrected with a verified replacement (Rust's documented release-build integer-overflow wrapping behavior, cited from the official Rust Book) — re-run confirmed 9/9
- Version bumps: core (0.2.67→0.2.68), github (0.3.13→0.3.14), all-skills (0.4.156→0.4.157)