### PR TITLE
docs(core): drop citation requirement for standing-principle skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.157",
+      "version": "0.4.158",
       "category": "meta",
       "keywords": [
         "skills",
@@ -143,7 +143,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
-      "version": "0.2.68",
+      "version": "0.2.69",
       "category": "development",
       "keywords": [
         "git",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.157",
+  "version": "0.4.158",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.68",
+  "version": "0.2.69",
   "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/hooks/session-start.sh
+++ b/plugins/core/hooks/session-start.sh
@@ -32,8 +32,11 @@ when the trigger condition arises.
 
 3. Every spawned agent's prompt starts with a "## Load skills" block
    listing exact skill names. Require the agent to quote one sentence
-   from each loaded skill in its first response as proof of loading.
-   Do not proceed with the agent's work until proof is received.
+   from each loaded skill in its first response as proof of loading,
+   EXCEPT /core:anti-fabrication, /core:restraint, /core:git, and
+   /core:security — invoke these four by exact name but skip the
+   quote-back. Do not proceed with the agent's work until proof is
+   received for every other loaded skill.
 
 4. Code without tests is not complete. `mise run ci` must pass before
    any commit, push, PR, or merge.

--- a/plugins/core/skills/agent-loop/SKILL.md
+++ b/plugins/core/skills/agent-loop/SKILL.md
@@ -168,6 +168,8 @@ Every agent at every tier loads these before any work, with one bounded exemptio
 /core:bees
 ```
 
+Skill *weight* (how much each skill costs once loaded — reduced by claude-skills-288's skeleton+references conversion) and mandatory *count* (which skills must be force-invoked at all — this list, claude-skills-295) are two separate, additive reductions to the same token-loading tax. Cutting the mandatory list does not make the remaining skills lighter, and a lighter skeleton does not reduce how many skills a session force-invokes — both landed, neither substitutes for the other.
+
 This block is the canonical copy. `test/validate-core-list.nu` drift-checks it against the ten sites it lists — this skill, six tier references (including the two subsetting satellites below, each checked against its declared subset rather than the full list), `/core:work`, the core session-start hook, and the operator CLAUDE.md template. Other files that enumerate core skills are not covered; add a site to that script when it starts carrying the full stack.
 
 **The exemption: a tier may omit an individual skill its role cannot exercise — nothing more.** Apply the test per skill, not per tier. `/core:tdd` is the worked case: `references/validator.md` runs the suite and reports failures without writing code, so it omits `/core:tdd`; `references/fix-agent.md` writes the fix, so it keeps it. `/core:anti-fabrication` is never omissible — every tier reports, and a fabricated pass is worse than a red build. A subsetting tier states what it omits and why in its own pre-flight step, so the omission is a decision on the record rather than an accident.
@@ -253,6 +255,10 @@ Key: always reference existing code and functions to reuse. "Implement X" is vag
 ### Proof of loading
 
 Require each spawned agent to quote one sentence from each loaded skill in its first response. Do not proceed with the agent's work until proof is received. Listing skill names in the prompt is not the same as the agent loading them — proof prevents skipped loads.
+
+**Exemption (claude-skills-295):** `/core:anti-fabrication`, `/core:restraint`, `/core:git`, and `/core:security` are exempt from the quote-back — their standing-principle-broad nature means a citation adds no verification value beyond "I invoked it." Agents still must invoke these four by exact name; only the quote requirement is dropped. Every other loaded skill — the six situational core skills (`/core:tdd`, `/core:twelve-factor`, `/core:mise`, `/core:nushell`, `/core:agent-loop`, `/core:bees`) plus any domain skills — still owes the quote-back in full.
+
+Two sites intentionally stay stricter than this exemption pending separate follow-up bees issues: `/core:bees`'s `bees-manager` agent definition and this skill's `skillProof` schema in `references/workflows-execution.md` both still require full proof-of-loading for every skill, including the four exempt here. That is not drift — a carve-out permits skipping the quote, it does not prohibit carrying it — so a future reader should not "fix" those two sites to match this exemption without a tracked issue first.
 
 ### Leader spawn — concrete example
 

--- a/plugins/core/skills/agent-loop/references/leader-spawn-example.md
+++ b/plugins/core/skills/agent-loop/references/leader-spawn-example.md
@@ -42,7 +42,9 @@ WorkflowController already exposes /export at lib/runex_web/controllers/workflow
 
 ## Execution order
 Follow the 9-step Agent Worker Execution Order. After step 2 (write tests),
-quote one sentence from each loaded skill and post your test code before
+quote one sentence from each loaded skill — except /core:anti-fabrication,
+/core:restraint, /core:git, and /core:security, which are invoked but not
+quoted (see "Proof of loading" exemption) — and post your test code before
 proceeding to step 3.
 ```
 

--- a/plugins/core/skills/agent-loop/references/team-leader.md
+++ b/plugins/core/skills/agent-loop/references/team-leader.md
@@ -61,12 +61,12 @@ This rule applies in every context. A host that runs without a human supplies th
 
 Before invoking the Task tool to spawn any agent, verify:
 
-- [ ] Core skills still loaded (quote one sentence from each as self-check)
+- [ ] Core skills still loaded (quote one sentence from each as self-check, except `/core:anti-fabrication`, `/core:restraint`, `/core:git`, `/core:security` — invoked but not quoted, per the Proof of loading exemption)
 - [ ] `/claude-code:claude-agents` loaded (always)
 - [ ] `/claude-code:claude-teams` loaded (if spawning ≥2 parallel workers)
 - [ ] Spawn prompt names specific files and functions to reuse, not generic goals
 - [ ] Spawn prompt opens with a `## Load skills` block listing exact skill names
-- [ ] Spawn prompt requires the agent to quote one sentence from each loaded skill in its first response
+- [ ] Spawn prompt requires the agent to quote one sentence from each loaded skill in its first response, except the four exempt skills above
 
 A failed checkbox blocks the spawn. Fix it before invoking Task.
 

--- a/test/evals/situational-skills/design.md
+++ b/test/evals/situational-skills/design.md
@@ -9,7 +9,7 @@ gate itself is execution, which is out of scope for this issue.
 
 ## Why this is frozen instead of executed
 
-`claude plugin eval init --bare` exits 1 with `plugin eval` is currently in early access` —
+`claude plugin eval init --bare` exits 1 with `plugin eval` is currently in early access — —
 independently reconfirmed by re-running the exact command in this environment (see also the
 Test Reviewer's prior confirmation). Per `/core:anti-fabrication`, no activation-rate claim, no
 drop/keep decision, and no change to the six skills' mandatory status may ship without an
@@ -24,10 +24,11 @@ Until 295c runs and produces real numbers, all six situational skills stay
 
 No prompt may contain the skill name, the plugin name, or a distinctive phrase lifted from the
 skill's `description` field — doing so would measure keyword-matching against the description,
-not real activation from task shape. Spot-checked against the prompt sets below: none of the
-48 targeted or 10 ambient prompts names `tdd`, `twelve-factor`, `mise`, `nushell`,
-`agent-loop`, or `bees`, nor phrases like "test-driven", "12-factor", "structured data
-pipelines", or "Forge".
+not real activation from task shape. Full pass verified against all 48 targeted and 10 ambient
+prompts: none name `tdd`, `twelve-factor`, `mise`, `nushell`, `agent-loop`, or `bees`, nor
+phrases like "test-driven", "12-factor", "structured data pipelines", or "Forge". Two
+initial leakage instances (nushell "cross-platform automation", bees "local-first tracker")
+were identified and corrected by rewording to preserve task intent.
 
 ## Prompt sets
 
@@ -92,7 +93,7 @@ false-positive baseline.
 1. "Write the section of our style guide that says which scripting language new automation should use and why."
 2. "Document the validation scripts in `test/` — what each one checks and how to run it."
 3. "Draft an ADR on replacing our bash test harness."
-4. "Write a skill that teaches an agent how to write cross-platform automation scripts for this repo."
+4. "Write a skill that teaches an agent how to write scripts that run reliably on any OS and handle edge cases like spaces in filenames."
 
 ### Agent-loop
 
@@ -119,7 +120,7 @@ false-positive baseline.
 **Doc-shaped:**
 1. "Write the section of CONTRIBUTING.md that explains how we track work in this repo."
 2. "Plan this epic and file the resulting slices."
-3. "Draft an ADR comparing our local-first tracker against a hosted one."
+3. "Draft an ADR comparing our on-premises issue tracker against a cloud-hosted alternative."
 4. "Document the labels we use on issues and what each one drives."
 
 ### Ambient (false-positive baseline, no skill named or implied as primary target)

--- a/test/evals/situational-skills/design.md
+++ b/test/evals/situational-skills/design.md
@@ -1,0 +1,205 @@
+# Situational-skills activation benchmark — frozen design (claude-skills-295, Part 2)
+
+**Status: FROZEN, UNVALIDATED.** This artifact designs a `claude plugin eval` benchmark for
+the six situational core skills (`tdd`, `twelve-factor`, `mise`, `nushell`, `agent-loop`,
+`bees`). It has NOT been run against the actual benchmark tool, has NOT been validated by a
+pilot gate, and produces NO activation-rate numbers. Every prompt, threshold, and decision
+rule below is a design artifact only — unvalidated until a pilot gate runs, and the pilot
+gate itself is execution, which is out of scope for this issue.
+
+## Why this is frozen instead of executed
+
+`claude plugin eval init --bare` exits 1 with `plugin eval` is currently in early access` —
+independently reconfirmed by re-running the exact command in this environment (see also the
+Test Reviewer's prior confirmation). Per `/core:anti-fabrication`, no activation-rate claim, no
+drop/keep decision, and no change to the six skills' mandatory status may ship without an
+actual measurement. Because the tool that would produce that measurement is gated, this issue
+authors the design and stops — see the follow-up bees issue described in the writer's report
+(295c) for execution once the tool becomes available.
+
+Until 295c runs and produces real numbers, all six situational skills stay
+**mandatory-with-citation-requirement** (the AC's own explicit fallback).
+
+## Prompt-authoring rule
+
+No prompt may contain the skill name, the plugin name, or a distinctive phrase lifted from the
+skill's `description` field — doing so would measure keyword-matching against the description,
+not real activation from task shape. Spot-checked against the prompt sets below: none of the
+48 targeted or 10 ambient prompts names `tdd`, `twelve-factor`, `mise`, `nushell`,
+`agent-loop`, or `bees`, nor phrases like "test-driven", "12-factor", "structured data
+pipelines", or "Forge".
+
+## Prompt sets
+
+Two categories per skill: **coding-shaped** (task drives toward writing/modifying code,
+running tests, or ops work) and **doc-shaped** (task drives toward documentation, planning, or
+research with no code changes expected). 4 prompts per category per skill × 6 skills × 2
+categories = 48 targeted prompts, plus 5 ambient prompts per category (10 total) that name no
+skill and are not expected to reliably trigger any one situational skill — they establish a
+false-positive baseline.
+
+### TDD
+
+**Coding-shaped:**
+1. "Add a `retry_with_backoff` function to `lib/http_client.py` that retries a failing request up to 3 times with exponential backoff. Make sure it's properly covered before you call it done."
+2. "This `parse_duration()` helper has no coverage and I'm about to change its behavior for negative inputs. Sort that out first, then make the change."
+3. "I want to add a rate limiter to the API middleware. Build it up incrementally rather than dropping the whole thing in at once."
+4. "Fix the off-by-one in `paginate()` — and I don't want to see the fix land without something that would have caught it."
+
+**Doc-shaped:**
+1. "Write the ADR for our new retry policy, and include how we'll know it works."
+2. "Draft the acceptance criteria for this epic so an implementer can turn each one into a check."
+3. "Write the section of our contributing guide that explains what 'done' means for a change."
+4. "Review this issue description — it says 'add caching'. Make it verifiable."
+
+### Twelve-factor
+
+**Coding-shaped:**
+1. "The service reads its DB password from a checked-in `config/production.yaml`. Move it somewhere sane for a container deploy."
+2. "We're about to run three copies of this worker behind a load balancer. It currently writes session state to a local temp dir — what has to change?"
+3. "Write the Dockerfile and deployment manifest for this Go service so it runs on our cluster."
+4. "The app opens a DB connection at import time and caches it in a module global. That's biting us on redeploy — restructure it."
+
+**Doc-shaped:**
+1. "Write the README's deployment section for a service that runs in containers across three environments."
+2. "Document how this project handles configuration across dev, staging, and prod."
+3. "Draft an ADR on where secrets live for our container deployments."
+4. "Write the operations runbook section covering how the service should be started, stopped, and scaled."
+
+### Mise
+
+**Coding-shaped:**
+1. "This repo has a `.tool-versions` and a Makefile. Consolidate the toolchain pinning and the task running into one place."
+2. "Add a single command that runs format, lint, and tests together, so CI and local dev use the exact same entry point."
+3. "The Node version in CI is 18 but everyone locally is on 22. Pin it so both match."
+4. "Set up this project so a new contributor can clone it and get every required binary at the right version with one command."
+
+**Doc-shaped:**
+1. "Write the 'Getting started' section of the README, covering how a new contributor installs the toolchain."
+2. "Document the project's task commands so someone can run the same checks CI runs."
+3. "Draft an ADR proposing we standardize toolchain pinning across all repos."
+4. "Write the CONTRIBUTING.md section on local environment setup."
+
+### Nushell
+
+**Coding-shaped:**
+1. "Write a script that reads every `plugin.json` under `plugins/`, pulls out name and version, and prints them as a table sorted by version."
+2. "This bash script breaks on Windows and chokes on filenames with spaces. Rewrite it so it works everywhere and handles the JSON properly instead of with grep and cut."
+3. "Add a script that queries the GitHub API for open PRs and filters to ones older than 7 days, outputting structured records the CI job can consume."
+4. "Convert `scripts/collect-stats.sh` to something that doesn't need jq and awk to parse its own output."
+
+**Doc-shaped:**
+1. "Write the section of our style guide that says which scripting language new automation should use and why."
+2. "Document the validation scripts in `test/` — what each one checks and how to run it."
+3. "Draft an ADR on replacing our bash test harness."
+4. "Write a skill that teaches an agent how to write cross-platform automation scripts for this repo."
+
+### Agent-loop
+
+**Coding-shaped:**
+1. "Work the top item off the ready queue."
+2. "This change touches four files across two packages and has acceptance criteria. Set it up so the person writing the tests isn't the person making them pass."
+3. "Take this feature request through to a PR: add OAuth device-flow login to the CLI."
+4. "Split this epic into independently deliverable slices and decide who runs each one."
+
+**Doc-shaped:**
+1. "Plan out how we'd deliver this epic — who does what, in what order."
+2. "Write the prompt template our team leads use when spawning implementation workers."
+3. "Draft an ADR describing our multi-agent review pipeline."
+4. "Research how other teams structure adversarial test-authoring and write up a recommendation."
+
+### Bees
+
+**Coding-shaped:**
+1. "Before I start coding, find out what's actually unblocked in this repo's tracker."
+2. "File the three follow-ups this refactor is leaving behind, and make the second one wait on the first."
+3. "I finished the auth work — close it out and get the tracker state committed."
+4. "Show me the dependency graph for the current epic so I know what's blocking what."
+
+**Doc-shaped:**
+1. "Write the section of CONTRIBUTING.md that explains how we track work in this repo."
+2. "Plan this epic and file the resulting slices."
+3. "Draft an ADR comparing our local-first tracker against a hosted one."
+4. "Document the labels we use on issues and what each one drives."
+
+### Ambient (false-positive baseline, no skill named or implied as primary target)
+
+**Coding-shaped (5):**
+1. "CI fails about one run in eight with no obvious pattern — figure out why."
+2. "Add a `--dry-run` flag to the import command that shows what would happen without writing anything."
+3. "This 200-line function does three unrelated things. Break it up."
+4. "Bump the JSON parser dependency to its 3.x line and fix whatever breaks."
+5. "The report generator is slow on large inputs — find out where the time goes."
+
+**Doc-shaped (5):**
+1. "Our README hasn't been touched in a year and doesn't match the current setup. Refresh it."
+2. "Summarize the last 20 commits into something that reads like a release note."
+3. "Compare these two proposals and recommend one, with reasoning."
+4. "Write onboarding docs for a new team member joining next week."
+5. "Review this skill's description — does it actually describe when it should trigger?"
+
+## Decision table
+
+Applied per skill, per category, once real activation and necessity data exist. `necessity`
+(needed / not-needed) is a human/reviewer judgment made against the task category — whether
+the skill's guidance materially changes correct behavior for that category — recorded
+alongside the measured activation rate, not derived from it.
+
+| Activation rate | Necessity | Verdict | Follow-up |
+|---|---|---|---|
+| ≥ 90% | needed | DROP from mandatory (activation is already reliable without forcing) | — |
+| ≤ 33% | needed | KEEP mandatory | — |
+| 34–89% | needed | KEEP mandatory (gray band) | file a description-tuning follow-up |
+| ≥ 90% | not-needed | DROP from mandatory | file an over-broad-description follow-up |
+| ≤ 89% | not-needed | DROP from mandatory | — |
+
+The 90% figure is not invented for this issue — it is
+`claude-code:claude-skills-benchmark`'s own documented target: "Target: 90%+ true positive
+rate, <5% false positive rate" (`plugins/tools/claude-code/skills/claude-skills-benchmark/SKILL.md`).
+
+## Required invocation
+
+`--ablation none` MUST be passed explicitly when this suite is eventually run:
+
+```
+claude plugin eval --ablation none ...
+```
+
+`claude plugin eval --help` documents the default as `with-without` whenever a plugin
+resolves — it adds a no-plugin baseline arm and reports a score delta against it. That baseline
+arm is meaningless here: every prompt in this suite runs inside a workspace where the six
+situational skills are already installed as part of `core`/other marketplace plugins, and
+nothing in the task set can fire a skill without the plugin installed in the first place.
+`--ablation with-without`'s comparison arm would measure "plugin installed vs. not", not
+"skill activates vs. doesn't" — the wrong axis for this benchmark.
+
+## Validity-threat mitigation: the SessionStart hook
+
+`plugins/core/hooks/session-start.sh` force-invokes all ten core skills' *names* into every
+session's turn-1 context as a command contract (see item 2: "invoke each of these by exact
+name" followed by the ten-skill list). If this suite runs inside a workspace where that hook
+fires unmodified, every case trivially reports the skill as "activated" — not because the task
+shape triggered it, but because the hook told the agent to invoke it regardless of the prompt.
+A naive activation-rate run under this condition would read 100% for every skill in every
+category, which is not a measurement, it's an artifact of the harness.
+
+Mitigation required before any real run counts as evidence:
+
+1. **Strip the hook for the run.** Execute the suite in a workspace/plugin configuration where
+   `plugins/core/hooks/session-start.sh` (or any equivalent SessionStart injection) is disabled
+   — a hooks-free workspace, or a `claude plugin eval` invocation that does not load the core
+   plugin's hooks alongside the skill(s) under test.
+2. **Assert a specific marker string is absent from every transcript.** The hook's injected
+   block is bounded by literal markers (`[CORE PLUGIN — SESSION-START COMMAND CONTRACT]` /
+   `[END CORE SESSION-START CONTRACT]`, see `plugins/core/hooks/session-start.sh`). Grep every
+   case transcript for either marker string; any match voids that run — the hook fired and the
+   result cannot be trusted as an unprompted activation measurement.
+3. Only runs that pass step 2 (marker absent) count toward the decision table in the previous
+   section.
+
+## Scope explicitly excluded from this artifact
+
+This design does not run the benchmark, does not report any activation rate, and does not
+change any of the six skills' mandatory status. Execution is 295c (see the writer's report for
+this issue) — blocked on `claude plugin eval` general availability, or a funded fallback
+harness.


### PR DESCRIPTION
- Part 1 (claude-skills-295a, ships now): drop the "quote one sentence as proof of loading" requirement for `/core:anti-fabrication`, `/core:restraint`, `/core:git`, `/core:security` — still mandatory-invoke-by-name, just no citation. Every other skill (including the six situational core skills: tdd, twelve-factor, mise, nushell, agent-loop, bees) still owes the quote-back
- Updated: `plugins/core/skills/agent-loop/SKILL.md` (Proof of loading exemption + two-levers note distinguishing skill weight from mandatory count), `plugins/core/hooks/session-start.sh` item 3 (item 2's ten-name list untouched), `references/team-leader.md` before-spawn checklist, `references/leader-spawn-example.md` worked example annotation
- CLAUDE.md scoping: the repo's own `CLAUDE.md` and `plugins/tools/claude-code/templates/CLAUDE.md` were checked and carry no "Agent discipline" section or citation-requirement text — the citation rule the bees issue describes lives only in the operator's global `~/github/CLAUDE.md`, which is outside this repo's git control. Zero edits made for that part; this is a deliberate scoping decision, not an oversight
- Two sites (`/core:bees`'s bees-manager agent, and `references/workflows-execution.md`'s `skillProof` schema) intentionally stay stricter than this exemption pending separate follow-up bees issues — noted in-place so a future reader doesn't mistake it for drift
- `plugins/core/commands/work.md` line 29 (quote one sentence from `/core:agent-loop`) was verified and needs no change — agent-loop is one of the six situational skills that keeps its citation requirement
- Part 2 (claude-skills-295b): authored `test/evals/situational-skills/design.md` — a FROZEN, UNEXECUTED eval design (48 targeted prompts + 10 ambient prompts across tdd/twelve-factor/mise/nushell/agent-loop/bees, the decision table, the required `--ablation none` flag, and the SessionStart-hook validity-threat mitigation). This is designed only, not run
- Part 2 is unexecuted because `claude plugin eval init --bare` exits 1 with "plugin eval is currently in early access" in this environment — independently reconfirmed here on top of a prior Planner + Test Reviewer confirmation. Per anti-fabrication, no activation rate is reported and no drop/keep decision is made
- The six situational skills' mandatory status is UNCHANGED — they stay mandatory-with-citation-requirement, the AC's own explicit fallback, since no measurement occurred
- A follow-up bees issue should be filed ("Execute the situational-skills activation benchmark (295c)"), scoped to running this frozen design once `claude plugin eval` is generally available (or a funded fallback harness exists), blocked on that external tool gate
- Version bumps: core 0.2.68 -> 0.2.69, all-skills 0.4.157 -> 0.4.158