### PR TITLE
docs(agent-loop): make Forge tiers model-aware for the 5-series lineup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.158",
+      "version": "0.4.159",
       "category": "meta",
       "keywords": [
         "skills",
@@ -143,7 +143,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
-      "version": "0.2.69",
+      "version": "0.2.70",
       "category": "development",
       "keywords": [
         "git",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.158",
+  "version": "0.4.159",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.69",
+  "version": "0.2.70",
   "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/commands/work.md
+++ b/plugins/core/commands/work.md
@@ -39,10 +39,10 @@ Quote one sentence from `/core:agent-loop` describing Forge as proof of loading.
 Apply the agent-loop 4-phase execution with Forge as the operating model — no need to ask which tier system to use, Forge is the default:
 
 1. **Pre-flight** — load skills (above), confirm the tracker item, branch from fresh `origin/main` (`feat/<slug>`).
-2. **Plan** — spawn a Test Planner (opus) preceded by a hands pass that builds its `## Starting index`; the planner slices the issue into independent test groups. See `references/forge.md`.
-3. **Author + review tests** — Test Author (sonnet) writes failing tests; the Test Reviewer (opus, with haiku hands) verifies plan-conformance and non-redundancy before any implementor starts.
+2. **Plan** — spawn a Test Planner (opus) preceded by a hands pass that builds its `## Starting index`; the planner slices the issue into independent test groups. The Plan Reviewer (fable) checks AC-to-slice coverage, unsatisfiable slices, and dep-wave validity before the Test Author is spawned — the plan pair's own reviewer gate. See `references/forge.md`.
+3. **Author + review tests** — Test Author (sonnet) writes failing tests; the Test Reviewer (fable, with haiku hands) verifies plan-conformance and non-redundancy before any implementor starts.
 4. **Implement (fan out)** — one Implementor + Test Runner pair per slice, dispatched in dependency waves. `N=1` for a one-slice issue.
-5. **Review** — Reviewer then Final Reviewer (opus, each with haiku hands consuming a startup index, never searching themselves); review findings route to a Remediation pair, then re-review.
+5. **Review** — Reviewer then Final Reviewer (fable, each with haiku hands consuming a startup index, never searching themselves); review findings route to a Remediation pair, then re-review.
 6. **Validate + submit** — `mise run ci` green, gitleaks, push, open the PR. Agents never merge — report the PR URL and wait for operator approval.
 
 Principals never run their own `Grep`/`Glob`/large-`Read` sweeps — they spawn focused read-only hands and read only the returned `file:line` index. Vision research (screenshots, rendered pages, Playwright output) uses a multimodal hands model. See the hands pattern in `references/researcher.md`.

--- a/plugins/core/skills/agent-loop/SKILL.md
+++ b/plugins/core/skills/agent-loop/SKILL.md
@@ -91,12 +91,24 @@ Model defaults per tier are exactly that — defaults. Each tier honors an env v
 | 3 Agent Worker | `AGENT_LOOP_WORKER_MODEL` | `haiku` |
 | 4 Validator | `AGENT_LOOP_VALIDATOR_MODEL` | `haiku` |
 | 5 Fix Agent | `AGENT_LOOP_FIX_MODEL` | `haiku` |
+| Plan Reviewer | `AGENT_LOOP_PLAN_REVIEWER_MODEL` | `fable, falling back to opus` |
+| Test Reviewer | `AGENT_LOOP_TEST_REVIEWER_MODEL` | `fable, falling back to opus` |
+| Reviewer | `AGENT_LOOP_REVIEWER_MODEL` | `fable, falling back to opus` |
+| Final Reviewer | `AGENT_LOOP_FINAL_REVIEWER_MODEL` | `fable, falling back to opus` |
 | Research hands (text) | `AGENT_LOOP_HANDS_MODEL` | smallest fast model (`Explore`) |
 | Research hands (vision) | `AGENT_LOOP_HANDS_VISION_MODEL` | a multimodal-capable model the harness offers |
 
 The two hands vars follow the same contract as the tier vars: the launching process resolves them and passes the model to the spawn; no model name appears as a literal in the prompt body. The vision var is set by capability, not by a fixed name — the available multimodal model shifts with the harness and model family. See `references/researcher.md`.
 
 **Contract:** whoever launches the spawning process (shell command, CI job, parent Claude session, external orchestrator) sets these env vars; the spawn script reads `$AGENT_LOOP_*` and passes the resolved model to the Task tool invocation (`subagent_type`/`model` argument) — never as a literal in the prompt body. An empty string (`AGENT_LOOP_LEAD_MODEL=""`) is treated identically to unset, falling through to the default, so orchestrators can emit "" to mean "use default" without special-casing.
+
+The four Forge reviewer vars added above default to a capability fallback: attempt `fable`, and
+retry `opus` if the fable spawn fails due to unavailability. This is explicitly the REVERSE of the
+haiku-to-sonnet-to-opus escalation-on-failure ladder described next — that one promotes on
+repeated failure of the task itself; this one degrades on model unavailability and never fires
+because a review came back unfavorable. The mechanism is already shipped and documented on
+`core:comment-reviewer` (`plugins/core/agents/comment-reviewer.md`, "Model fallback" section);
+these four vars reuse that exact contract rather than defining a second one.
 
 The escalation chain is also overridable: `AGENT_LOOP_ESCALATION_CHAIN` (comma-separated names; default `haiku,sonnet,opus`).
 
@@ -109,6 +121,10 @@ haiku -> sonnet -> opus
 ```
 
 Maximum 2 promotions per agent. If opus fails, escalate to the upstream tier (sub-lead to lead, lead to user).
+
+This ladder is failure-driven and applies to task-executing tiers; it is not the reviewer
+capability fallback described under Model overrides above — that one degrades on unavailability
+and never fires on a bad review.
 
 ## Five-Tier Decomposition Pipeline
 
@@ -124,9 +140,15 @@ For each issue, the Sub-team Leader spawns distinct Agent invocations in order. 
 | P2 Test Author | sonnet | Write failing tests against P1's spec | Reading impl source; modifying after handoff |
 | P3 Implementer | sonnet | Make tests pass | Modifying test files; reading P2's chat context |
 | P4 CI Runner | haiku | Run CI, capture verbatim output, report green/red | Judging correctness; touching code |
-| P5 Reviewer | opus | Verify tests exercise AC, no overfit, no missed edges | Authoring fixes (sends back to P2 or P3 with findings) |
+| P5 Reviewer | fable | Verify tests exercise AC, no overfit, no missed edges | Authoring fixes (sends back to P2 or P3 with findings) |
 
 Each stage owes the restraint ladder its phase duty — see `/core:restraint`'s agent-loop-phases reference for the row mapping (P1 → Test planning, P2 → Test authoring, P3 → Implementation, P5 → Review).
+
+P1 Test Planner and Forge's Plan-pair Test Planner both stay `opus` — decomposition errors
+compound downstream, so the planner stays on the deepest-reasoning model available. P2 Test
+Author and P3 Implementer stay `sonnet`, per the Model Selection table's sonnet row below. P4
+stays `haiku`. Only P5 moves from `opus` to `fable`, tracking Forge's Reviewer row in the pairs
+table — the same role in different fan-out shapes, not two roles.
 
 ### When to apply
 
@@ -273,6 +295,9 @@ Scale the team to the work — choose by role, not by a trivial-vs-complex guess
 | Multi-file implementation | sonnet | New API endpoint, adapter refactor |
 | Test planning, architecture design | opus (or `Plan` subagent) | Test-list design, system integration |
 | Simple ops, monitoring, status checks | haiku | Deploy monitor, log reader, port check |
+| Text-based search / inventory | haiku | Hands passes, file:line index building, catalog sweeps |
+| Running test / CI commands | haiku | `mise run ci` runner, verbatim log capture, green/red report |
+| Playwright- or MCP-tool-driving agents | sonnet | Browser-driven QA, Tidewave runtime introspection |
 
 Hands and reviewer models follow the Forge convention — see "Model overrides" above and `references/forge.md`.
 
@@ -353,4 +378,4 @@ Workflows are a research preview on paid plans. When disabled, the default Task-
 - `references/secret-provisioning.md` — Tier 1 plans include symmetric secret provisioning (generation, store creation, prod/dev deploy diffs); Tier 5 blocker check
 - `references/workflows-execution.md` — Optional workflow substrate for the five-tier pipeline: pipeline-as-script, stage gates, escalation ladder, teams-of-teams; decomposition/merge stay interactive
 - `templates/five-tier-issue.workflow.js` — Runnable `N=1` five-tier pipeline template: stage prompts, `skillProof` schemas, diff-boundary gate, escalation ladder, bounded fix loop
-- `templates/forge-issue.workflow.js` — Runnable Forge workflow: startup-index hands, planner slicing, dep-wave fan-out, opus reviewers with haiku hands, remediation pair
+- `templates/forge-issue.workflow.js` — Runnable Forge workflow: startup-index hands, planner slicing, dep-wave fan-out, fable reviewers paired with haiku hands, remediation pair

--- a/plugins/core/skills/agent-loop/references/forge.md
+++ b/plugins/core/skills/agent-loop/references/forge.md
@@ -19,19 +19,37 @@ are the current defaults, not fixed values.
 
 | Pair | Principal | Hands / partner | Fan-out |
 |------|-----------|-----------------|---------|
-| Plan | Test Planner (opus) | Research hands (smallest) | 1 |
-| Author tests | Test Author (sonnet) | Test Reviewer (opus) + its own hands (smallest) | 1 |
+| Plan | Test Planner (opus) | Plan Reviewer (fable) + research hands (smallest) | 1 |
+| Author tests | Test Author (sonnet) | Test Reviewer (fable) + its own hands (smallest) | 1 |
 | Implement | Implementor (sonnet) | Test Runner (haiku) | × N slices, parallel by dep wave |
-| Review | Reviewer (opus) | Research hands (smallest) + Comment Reviewer (fable) | 1 |
-| Final review | Final Reviewer (opus) | Research hands (smallest) | 1 |
+| Review | Reviewer (fable) | Research hands (smallest) + Comment Reviewer (fable) | 1 |
+| Final review | Final Reviewer (fable) | Research hands (smallest) | 1 |
 | Remediate | Implementor (sonnet) | Test Runner (haiku) | per review-finding batch |
 
 ## Reviewers are the best-thinker tier
 
-Every reviewing role — the Test Reviewer in the author pair, the Reviewer, and the Final Reviewer —
-defaults to opus, each paired with haiku hands. Thinking is expensive and stays on the strong
-model; fetching is cheap and stays on the small model. The reviewer never searches; its hands
-surface the exact artifact to judge.
+Every reviewing role — the Plan Reviewer in the plan pair, the Test Reviewer in the author pair,
+the Reviewer, and the Final Reviewer — defaults to `fable`, each paired with haiku hands.
+Thinking is expensive and stays on the strong model; fetching is cheap and stays on the small
+model. The reviewer never searches; its hands surface the exact artifact to judge.
+
+Each of the four honors its own env-var override — the Plan Reviewer reads
+`AGENT_LOOP_PLAN_REVIEWER_MODEL`, the Test Reviewer reads `AGENT_LOOP_TEST_REVIEWER_MODEL`, the
+Reviewer reads `AGENT_LOOP_REVIEWER_MODEL`, and the Final Reviewer reads
+`AGENT_LOOP_FINAL_REVIEWER_MODEL` — and all four share the exact fable-to-opus capability
+fallback already shipped on `core:comment-reviewer` (`plugins/core/agents/comment-reviewer.md`,
+"Model fallback" section) rather than defining a second mechanism. All four also load
+`/core:restraint`, mirroring `core:comment-reviewer`'s own `skills:` frontmatter.
+
+The **Plan Reviewer** has a specific charter — the one genuinely new gate this update adds, since
+the Plan pair was previously the only pair without a reviewer. Using hands to surface only the
+Test Planner's slice list and the issue's acceptance criteria, it checks three things: does every
+acceptance criterion map to at least one slice, is any slice unsatisfiable as written, and do the
+dependency edges among slices admit a valid wave order. It approves the plan or returns it to the
+Test Planner for revision — it never edits the plan itself. Implementation note:
+`templates/forge-issue.workflow.js` does not yet encode a `planRev` stage for this gate — tracked
+in a follow-up bees issue, "Add planRev stage to forge-issue.workflow.js for the Plan Reviewer
+gate (claude-skills-294 follow-up)".
 
 The **Test Reviewer** has a specific charter: using haiku hands to surface *only* the Test Author's
 new tests, verify the tests follow the Test Planner's plan and carry no redundancy. Catching
@@ -70,13 +88,18 @@ the same path, just narrower. Width scales to the work; the structure is constan
 
 ## Gates between pairs
 
+- The plan reviewed by the Plan Reviewer before the Test Author is spawned.
 - Tests reviewed by the Test Reviewer before any implementor starts.
 - Diff-boundary: an implementor cannot modify the frozen test files (assert the diff is empty;
   check both committed diff and the working tree).
 - CI green per slice before that slice's pair reports done.
 - The Reviewer consumes its hands index rather than searching the tree itself.
 - Review findings route to the Remediation pair (Implementor + Test Runner), which fixes and
-  re-runs; the Final Reviewer then re-checks against the remediation diff.
+  re-runs; the Final Reviewer then re-checks against the remediation diff. A non-approval is not
+  automatically an escalation — a fixable finding goes back through this remediation loop. The
+  user is involved only when a finding can't be resolved in code, or when the remediation pair
+  hits the existing two-promotion escalation cap described in `/core:agent-loop`'s "Model
+  Escalation" section.
 
 ## Why this beats threshold-gating
 

--- a/plugins/core/skills/agent-loop/references/workflows-execution.md
+++ b/plugins/core/skills/agent-loop/references/workflows-execution.md
@@ -206,7 +206,7 @@ Use it only for agents that mutate files in parallel; it is expensive and pointl
 
 ## Budget-gated P5 review panel
 
-The single-opus P5 reviewer is the default. When `budget.total` is set and `budget.remaining()` leaves headroom, run P5 as a panel of distinct lenses — acceptance-criteria coverage, overfit-to-tests, missed edge cases — one `agent()` per lens via `parallel()`. Take the majority verdict; forward the rejecting lenses' findings to the rework dispatch. Guard on `budget.total`, not `remaining()`: `budget.total` is `null` when no target is set, which makes `remaining()` `Infinity` and the guard always true.
+The single P5 reviewer, on the reviewer default (`fable`), is the default shape. When `budget.total` is set and `budget.remaining()` leaves headroom, run P5 as a panel of distinct lenses — acceptance-criteria coverage, overfit-to-tests, missed edge cases — one `agent()` per lens via `parallel()`. Take the majority verdict; forward the rejecting lenses' findings to the rework dispatch. Guard on `budget.total`, not `remaining()`: `budget.total` is `null` when no target is set, which makes `remaining()` `Infinity` and the guard always true.
 
 ```javascript
 let review
@@ -261,7 +261,7 @@ const results = await parallel(ready.map(slice => async () => {
 }))
 ```
 
-Reviewers run on the best-thinker model (`stageModels.review` / `.final`, opus by default) with
+Reviewers run on the best-thinker model (`stageModels.review` / `.final`, `fable` by default) with
 haiku hands; the Reviewer's findings drive a Remediation pair (implementor + test-runner) bounded at
 three cycles, then a fresh-context Final Reviewer with its own hands index.
 

--- a/plugins/core/skills/agent-loop/templates/five-tier-issue.workflow.js
+++ b/plugins/core/skills/agent-loop/templates/five-tier-issue.workflow.js
@@ -21,7 +21,7 @@
 //       "test":   "sonnet",  // P2 — doctrine default: sonnet
 //       "impl":   "sonnet",  // P3 — doctrine default: sonnet
 //       "ci":     "haiku",   // P4 — doctrine default: haiku
-//       "review": "opus"     // P5 — doctrine default: opus
+//       "review": "fable"    // P5 — doctrine default: fable
 //     },
 //     "repo": "/absolute/path/to/repo"
 //   }

--- a/plugins/core/skills/agent-loop/templates/forge-issue.workflow.js
+++ b/plugins/core/skills/agent-loop/templates/forge-issue.workflow.js
@@ -18,13 +18,17 @@
 //     "stageModels": {
 //       "plan":     "opus",    // Test Planner
 //       "author":   "sonnet",  // Test Author
-//       "testRev":  "opus",    // Test Reviewer (best-thinker tier)
+//       "testRev":  "fable",   // Test Reviewer (best-thinker tier)
 //       "impl":     "sonnet",  // Implementor (× N slices)
 //       "ci":       "haiku",   // Test Runner
-//       "review":   "opus",    // Reviewer
-//       "final":    "opus"     // Final Reviewer
+//       "review":   "fable",   // Reviewer
+//       "final":    "fable"    // Final Reviewer
 //     }
 //   }
+//
+// Implementation note: the Plan Reviewer gate described in references/forge.md is not yet
+// encoded here as a "planRev" stage — tracked in a follow-up bees issue, "Add planRev stage
+// to forge-issue.workflow.js for the Plan Reviewer gate (claude-skills-294 follow-up)".
 //
 // Models are config (12-factor): no model name is hardcoded in a prompt body, and
 // the hands model is selected by capability — handsVisionModel for visual objectives,
@@ -35,14 +39,14 @@
 
 export const meta = {
   name: 'forge-issue',
-  description: 'Run one issue through Forge: hands-indexed plan, fanned-out impl pairs, opus reviews',
+  description: 'Run one issue through Forge: hands-indexed plan, fanned-out impl pairs, fable reviews',
   phases: [
     { title: 'Plan', detail: 'Hands index → Test Planner slices the issue' },
     { title: 'Author', detail: 'Test Author writes failing tests' },
-    { title: 'Review-tests', detail: 'Test Reviewer (opus + hands) checks plan-conformance + non-redundancy' },
+    { title: 'Review-tests', detail: 'Test Reviewer (fable + hands) checks plan-conformance + non-redundancy' },
     { title: 'Impl', detail: 'One Implementor + Test Runner pair per slice, by dep wave' },
-    { title: 'Review', detail: 'Reviewer (opus + hands) verifies acceptance criteria' },
-    { title: 'Final', detail: 'Final Reviewer (opus + hands) checks the remediation diff' },
+    { title: 'Review', detail: 'Reviewer (fable + hands) verifies acceptance criteria' },
+    { title: 'Final', detail: 'Final Reviewer (fable + hands) checks the remediation diff' },
     { title: 'Remediate', detail: 'Implementor + Test Runner pair addresses review findings' },
   ],
 }
@@ -342,7 +346,7 @@ phase('Author')
 const testSha = await withEscalation(authorPrompt(args, plan), { phase: 'Author', schema: COMMIT }, args.stageModels.author)
 if (!testSha) return escalate('Test Author failed across escalation chain', { plan })
 
-// Review tests — opus reviewer, haiku hands showing ONLY the new tests.
+// Review tests — fable reviewer, haiku hands showing ONLY the new tests.
 phase('Review-tests')
 const testReviewIndex = await handsPass(
   `Index only the test changes in ${testSha.sha} across ${allTestFiles.join(', ')} — one pointer per new test.`,
@@ -379,7 +383,7 @@ while (remaining.length > 0) {
   log(`forge-issue: ${done.size}/${plan.slices.length} slices green`)
 }
 
-// Review — opus reviewer with a hands-built startup index (diff + ADRs).
+// Review — fable reviewer with a hands-built startup index (diff + ADRs).
 phase('Review')
 const reviewIndex = await handsPass(
   `Index git diff main...HEAD for issue ${args.issueId} plus any decision records (ADRs) it touches.`,
@@ -411,7 +415,7 @@ while (review && !review.approved && cycles < 3) {
 }
 if (!review || !review.approved) return escalate('review unresolved after remediation', { review, cycles })
 
-// Final review — opus, fresh context, hands index of prior notes + remediation diff.
+// Final review — fable, fresh context, hands index of prior notes + remediation diff.
 phase('Final')
 const finalIndex = await handsPass(
   `Index the prior review notes and the full git diff main...HEAD for issue ${args.issueId}.`,


### PR DESCRIPTION
- Adds the Plan Reviewer — the one genuinely new gate: the Plan pair was the only Forge pair without a reviewer, so it now checks AC-to-slice coverage, unsatisfiable slices, and dep-wave validity before the Test Author is spawned
- Everywhere else is a model-default swap on an existing role: Forge's Test Reviewer, Reviewer, and Final Reviewer, plus the five-tier pipeline's P5 Reviewer, move from `opus` to `fable` (capability fallback to `opus` on unavailability, reusing the exact mechanism already shipped on `core:comment-reviewer`)
- P1 Test Planner and Forge's Plan-pair Test Planner stay `opus`; P2 Test Author / P3 Implementer stay `sonnet`; P4 stays `haiku` — only the reviewer roles move
- Adds four new `AGENT_LOOP_*_REVIEWER_MODEL` env-var overrides (Plan/Test/Reviewer/Final), documented alongside the existing tier vars, and disambiguates the fable-to-opus capability fallback from the haiku→sonnet→opus failure-escalation ladder in both `forge.md` and `SKILL.md`
- Adds three new Model Selection table rows (text-search/inventory, CI-running, Playwright/MCP-driving agents) to `SKILL.md`
- Updates `templates/forge-issue.workflow.js` (testRev/review/final stageModels + prose) and `templates/five-tier-issue.workflow.js` (P5 doctrine-default comment) to `fable`; `escalationChain` arrays and `"plan": "opus"` literals are unchanged in both files
- Sweeps `plugins/core/commands/work.md` and `references/workflows-execution.md` for the same opus→fable swap on reviewer prose
- Known gap, disclosed rather than silently left: `templates/forge-issue.workflow.js` does not yet encode a `planRev` stage for the new Plan Reviewer gate — a comment near its `stageModels` block flags this, and the exact follow-up bees issue to file is: "Add planRev stage to forge-issue.workflow.js for the Plan Reviewer gate (claude-skills-294 follow-up)"
- Version bumps: core 0.2.69 -> 0.2.70, all-skills 0.4.158 -> 0.4.159 (all-skills required per `check-version-bumps.nu`'s "in scope whenever any other tracked plugin's content changed" rule)
- `mise run ci` verbatim: all 12 subtasks passed (test:claude, test:comment-fixtures, test:core-list, test:disclosure, test:fenced-literals, test:gitleaks-invocation, test:marketplace, test:no-symlinks, test:plugins, test:security-hook, test:skills-quality, test:sources), exit 0, `validate-core-list.nu` reported "Core list is consistent across all satellite load lists" with zero drift across all ten canonical sites