### PR TITLE
docs(claude-output-styles): sync built-in styles table with current docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.159",
+      "version": "0.4.160",
       "category": "meta",
       "keywords": [
         "skills",
@@ -119,7 +119,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
-      "version": "0.2.80",
+      "version": "0.2.81",
       "category": "tools",
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.159",
+  "version": "0.4.160",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.80",
+  "version": "0.2.81",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/claude-output-styles/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-output-styles/SKILL.md
@@ -32,6 +32,8 @@ Output styles are **always active** once selected, for the whole session. They a
 | Style | Behavior |
 | :--- | :--- |
 | **Default** | Standard software-engineering system prompt |
+| **Proactive** | Executes immediately, makes reasonable assumptions instead of pausing for routine decisions, and prefers action over planning — stronger autonomous-execution guidance than auto mode, applied without changing the permission mode |
+| **Concise** | Leads with the result, skips preamble and narration, keeps responses short by default, while doing the engineering work as thoroughly as Default; error reports, security warnings, and destructive-action confirmations stay in full. Requires Claude Code v2.1.237+ |
 | **Explanatory** | Adds educational "Insights" during task completion |
 | **Learning** | Collaborative mode — Claude inserts `TODO(human)` markers for the user to fill in |
 
@@ -62,6 +64,7 @@ You are an interactive CLI tool that helps users with [domain].
 | `name` | Display name (inherits from filename if omitted) | filename |
 | `description` | Shown in `/config` picker | none |
 | `keep-coding-instructions` | Retain Claude Code's coding-specific system prompt sections | `false` |
+| `force-for-plugin` | Plugin output styles only: apply this style automatically whenever the plugin is enabled, without the user selecting it. Overrides the user's `outputStyle` setting. If multiple enabled plugins set this, Claude Code uses the first one loaded. | `false` |
 
 Set `keep-coding-instructions: true` when the custom style *augments* coding behavior rather than replacing it.
 
@@ -71,7 +74,10 @@ Set `keep-coding-instructions: true` when the custom style *augments* coding beh
 | :--- | :--- |
 | User-level | `~/.claude/output-styles/` |
 | Project-level | `.claude/output-styles/` |
+| Managed policy | `.claude/output-styles/` inside the managed settings directory |
 | Plugin-shipped | `<plugin-root>/output-styles/` |
+
+Project-level resolution is not one flat path — it loads from every `.claude/output-styles/` between the working directory and the repository root. When more than one of these nested directories defines a style with the same name, Claude Code uses the one closest to the working directory.
 
 ### Selecting a Style
 
@@ -121,6 +127,8 @@ The session-level output style modifies the **main agent loop's** system prompt.
 - Skills loaded within a subagent
 
 If you need a subagent to produce output in a specific shape, encode the contract in the agent's own definition or reference a shared contract file.
+
+**Exception: forks.** A fork (`Agent` tool with `subagent_type: "fork"`) is not an independent subagent — it's a continuation of the same conversation, so it inherits the parent's full system prompt, output style included. Regular subagents (any other `subagent_type`) still do not inherit it.
 
 ### Where to Place a Contract
 

--- a/plugins/tools/claude-code/skills/sources.md
+++ b/plugins/tools/claude-code/skills/sources.md
@@ -139,14 +139,14 @@ Structured tracking: [sources.toml](sources.toml) — versions, check methods, a
 ### Claude Code Output Styles Documentation
 - **URL**: https://code.claude.com/docs/en/output-styles
 - **Purpose**: Adapting Claude Code's system prompt for non-engineering roles and response formats
-- **Date Accessed**: 2026-04-17
+- **Date Accessed**: 2026-08-23
 - **Key Topics**:
-  - Built-in styles (Default, Explanatory, Learning)
-  - Custom style frontmatter (`name`, `description`, `keep-coding-instructions`)
-  - File locations: `~/.claude/output-styles/`, `.claude/output-styles/`, plugin `output-styles/`
+  - Built-in styles (Default, Proactive, Concise, Explanatory, Learning)
+  - Custom style frontmatter (`name`, `description`, `keep-coding-instructions`, `force-for-plugin`)
+  - File locations: `~/.claude/output-styles/`, nested `.claude/output-styles/` (nearest wins), managed policy directory, plugin `output-styles/`
   - Session-start scoping (takes effect next session for cache stability)
   - Comparison with CLAUDE.md, `--append-system-prompt`, agents, and skills
-  - Subagents do not inherit session output style — contracts must be explicit
+  - Subagents do not inherit session output style — contracts must be explicit; forks are the exception, inheriting the parent's full system prompt
 - **Used In**: skills/claude-output-styles/SKILL.md, skills/claude-plugins/SKILL.md
 
 ## Plugin Marketplace Skill


### PR DESCRIPTION
- Add Proactive and Concise to the built-in styles table (now 5 total: Default, Proactive, Concise, Explanatory, Learning)
- Add `force-for-plugin` frontmatter field
- Document nested project-level resolution (nearest `.claude/output-styles/` wins) and the managed-policy location
- Document the fork exception to subagent output-style non-inheritance
- Update sources.md Key Topics and Date Accessed
- Bump claude-code plugin version 0.2.80 -> 0.2.81 and all-skills 0.4.159 -> 0.4.160