### PR TITLE
docs(claude-agents): bracket every segment of the agent spawn naming convention

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.166",
+      "version": "0.4.167",
       "category": "meta",
       "keywords": [
         "skills",
@@ -119,7 +119,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
-      "version": "0.2.83",
+      "version": "0.2.84",
       "category": "tools",
       "keywords": [
         "claude-code",
@@ -143,7 +143,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, technical English, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
-      "version": "0.2.75",
+      "version": "0.2.76",
       "category": "development",
       "keywords": [
         "git",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.166",
+  "version": "0.4.167",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.75",
+  "version": "0.2.76",
   "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, technical English, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/skills/agent-loop/SKILL.md
+++ b/plugins/core/skills/agent-loop/SKILL.md
@@ -224,7 +224,7 @@ Glob patterns like `/core:*` do not expand in Agent prompts. List skill names ex
 - **Merge gates (three)**: Gate 1 — local `mise run ci` green before every commit; Gate 2 — local + remote `gh pr checks` green; Gate 3 — adversarial review of the PR by a separate agent on the strongest available model, findings addressed or answered. All three before any squash merge (see `/core:git` Three-Gate Merge Policy). Gate 3 is distinct from this skill's pipeline reviewers, including Forge's Final Reviewer — it is identified by its defeat-the-change brief, not by when it runs.
 - **Branches**: One feature branch per epic (`feature/<epic-slug>`)
 - **Merge**: Squash merge only, user approves
-- **Agent naming**: When spawning agents, embed the model tier and per-session instance counter in the `name` parameter as `task-<model>-<instance>` (e.g., `task-sonnet-1`, `task-opus-2`) — see `/claude-code:claude-agents` for details
+- **Agent naming**: Spawn names are `<issue>-<role>-<model>-<n>` (e.g. `318-test-author-sonnet-1`) — see `/claude-code:claude-agents` "Agent Spawning Naming Convention" for the segment definitions and the counter rule
 
 ## Agent Worker Execution Order
 

--- a/plugins/core/skills/agent-loop/references/leader-spawn-example.md
+++ b/plugins/core/skills/agent-loop/references/leader-spawn-example.md
@@ -54,14 +54,14 @@ Compact. Names files and functions to reuse. Anchors the proof-of-loading checkp
 
 ## Agent naming convention
 
-When spawning the agent via the Agent tool, use the naming convention `task-<model>-<instance>`:
+Name the agent `<issue>-<role>-<model>-<n>`. The worker below is the implementer on issue `runex-142`, running sonnet, and the second agent spawned this session:
 
 ```
 Agent({
-  name: 'task-sonnet-1',
+  name: '142-impl-sonnet-2',
   description: 'Implement /api/workflows/import endpoint',
   prompt: '(the prompt template above)'
 })
 ```
 
-The instance counter is per-session and monotonic: each spawn in the same session increments the counter independently, so the second sonnet worker would be named `task-sonnet-2`, and a haiku worker later in the same session would be `task-haiku-1`. This naming allows operators to see which model each running agent activated with at a glance. See `/claude-code:claude-agents` for complete details on agent spawning and naming conventions.
+`/claude-code:claude-agents` "Agent Spawning Naming Convention" defines each segment and states the counter rule. This file does not restate them.

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.83",
+  "version": "0.2.84",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/skills/claude-agents/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-agents/SKILL.md
@@ -125,7 +125,7 @@ Build the `name` parameter from four segments: `<issue>-<role>-<model>-<n>`. Eve
 
 | Segment | What goes there |
 |---|---|
-| `<issue>` | The tracker issue this agent's team works on (`318`). With no tracker issue, use a short task slug (`audit-ci`). |
+| `<issue>` | The number of the tracker issue this agent's team works on — `318` for `claude-skills-318`. With no tracker issue, use a short task slug (`audit-ci`). |
 | `<role>` | The agent's job on that team (`test-author`, `impl`, `ci`, `review`). |
 | `<model>` | The model tier the agent runs on (`haiku`, `sonnet`, `opus`, `fable`). |
 | `<n>` | The session-global spawn counter. |
@@ -139,7 +139,7 @@ A session that works issue 318 and then moves to 317 names its agents in this or
 - `318-ci-haiku-3`
 - `317-plan-fable-4`
 
-Read `318-ci-haiku-3` as the CI runner on issue 318's team, running haiku, third agent spawned this session. Agents on one team share a prefix, so `318-` selects that team.
+Read `318-ci-haiku-3` as the CI runner on issue 318's team, running haiku, third agent spawned this session. Each segment answers one question without opening the agent: the issue groups one team under a shared prefix, the role says what the agent does, and the model shows which tier it activated with.
 
 Example spawning:
 

--- a/plugins/tools/claude-code/skills/claude-agents/SKILL.md
+++ b/plugins/tools/claude-code/skills/claude-agents/SKILL.md
@@ -121,19 +121,37 @@ Skills not listed in `skills` remain invocable through the Skill tool during the
 
 ## Agent Spawning Naming Convention
 
-When spawning agents via the Agent tool, embed the model tier and a per-session instance counter in the `name` parameter: `task-<model>-<instance>` (e.g., `task-sonnet-1`, `task-opus-2`, `task-haiku-1`). This naming convention allows operators to see which model each running agent activated with at a glance.
+Build the `name` parameter from four segments: `<issue>-<role>-<model>-<n>`. Every segment is a placeholder. None of the four is a literal.
+
+| Segment | What goes there |
+|---|---|
+| `<issue>` | The tracker issue this agent's team works on (`318`). With no tracker issue, use a short task slug (`audit-ci`). |
+| `<role>` | The agent's job on that team (`test-author`, `impl`, `ci`, `review`). |
+| `<model>` | The model tier the agent runs on (`haiku`, `sonnet`, `opus`, `fable`). |
+| `<n>` | The session-global spawn counter. |
+
+Join the segments with hyphens. The assembled name must match `^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$`. Keep every segment kebab-case, and never use a space.
+
+A session that works issue 318 and then moves to 317 names its agents in this order:
+
+- `318-test-author-sonnet-1`
+- `318-impl-sonnet-2`
+- `318-ci-haiku-3`
+- `317-plan-fable-4`
+
+Read `318-ci-haiku-3` as the CI runner on issue 318's team, running haiku, third agent spawned this session. Agents on one team share a prefix, so `318-` selects that team.
 
 Example spawning:
 
 ```
 Agent({
-  name: 'task-sonnet-1',
+  name: '318-impl-sonnet-2',
   description: 'Implement feature endpoint',
   prompt: '...'
 })
 ```
 
-Instance counters are PER-SESSION and MONOTONIC — each agent spawned in a session increments the counter independently (e.g., `task-haiku-1`, `task-sonnet-1`, `task-opus-1`, `task-sonnet-2`). This is a prompt-discipline convention, not an enforced mechanism — the counter is assigned at spawn time and never reset or persisted across sessions.
+The counter is ONE GLOBAL SERIES PER SESSION. The first agent spawned takes `1`, the second takes `2`, whatever its issue, role, or model tier. The trailing number therefore gives both a unique name and the agent's spawn order. Assign the counter at spawn time. Never reset it mid-session, and never carry it into another session. This is a prompt-discipline convention, not an enforced mechanism.
 
 ## Common Agent Patterns
 


### PR DESCRIPTION
- Give the spawn name shape as `<issue>-<role>-<model>-<n>` with all four segments bracketed, plus a table naming what belongs in each
- State that no segment is a literal, and record the Agent tool's `name` pattern the assembled string must satisfy
- Replace every example carrying the literal `task-` prefix with a cross-issue sequence that demonstrates the counter
- Resolve the contradiction between the PER-SESSION sentence and its per-model example: the counter is one global series per session
- Reduce the two restatements in `agent-loop` to an example plus a pointer, so the rule lives in exactly one file
- Bump core, claude-code, and all-skills

Closes claude-skills-318