### PR TITLE
docs(core): replace never-merge axiom with AGENT_LOOP_MERGE_POLICY precondition

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "all-skills",
       "source": "./",
       "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
-      "version": "0.4.170",
+      "version": "0.4.171",
       "category": "meta",
       "keywords": [
         "skills",
@@ -104,7 +104,7 @@
       "source": "./plugins/tools/beads",
       "strict": true,
       "description": "Beads (bd) distributed git-backed graph issue tracker: task management, dependency tracking, AI agent workflows",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "category": "tools",
       "keywords": [
         "beads",
@@ -119,7 +119,7 @@
       "source": "./plugins/tools/claude-code",
       "strict": true,
       "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
-      "version": "0.2.85",
+      "version": "0.2.86",
       "category": "tools",
       "keywords": [
         "claude-code",
@@ -143,7 +143,7 @@
       "source": "./plugins/core",
       "strict": true,
       "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, technical English, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
-      "version": "0.2.79",
+      "version": "0.2.80",
       "category": "development",
       "keywords": [
         "git",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "all-skills",
-  "version": "0.4.170",
+  "version": "0.4.171",
   "description": "Meta-plugin that installs all skills from all plugins in the marketplace",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.2.79",
+  "version": "0.2.80",
   "description": "Essential development skills: Git, TDD, code review, gitleaks secret scanning, documentation, technical English, restraint, anti-fabrication, twelve-factor apps, the agent loop, bees issue tracking, mise, nushell, and Apple Container",
   "author": {
     "name": "vinnie357"

--- a/plugins/core/commands/work.md
+++ b/plugins/core/commands/work.md
@@ -43,6 +43,6 @@ Apply the agent-loop 4-phase execution with Forge as the operating model — no 
 3. **Author + review tests** — Test Author (sonnet) writes failing tests; the Test Reviewer (fable, with haiku hands) verifies plan-conformance and non-redundancy before any implementor starts.
 4. **Implement (fan out)** — one Implementor + Test Runner pair per slice, dispatched in dependency waves. `N=1` for a one-slice issue.
 5. **Review** — Reviewer then Final Reviewer (fable, each with haiku hands consuming a startup index, never searching themselves); review findings route to a Remediation pair, then re-review.
-6. **Validate + submit** — `mise run ci` green, gitleaks, push, open the PR. Agents never merge — report the PR URL and wait for operator approval.
+6. **Validate + submit** — `mise run ci` green, gitleaks, push, open the PR. Merge per the deployment's merge policy (`/core:git` "Merge authorization"); under the default, report the PR URL and wait for operator approval.
 
 Principals never run their own `Grep`/`Glob`/large-`Read` sweeps — they spawn focused read-only hands and read only the returned `file:line` index. Vision research (screenshots, rendered pages, Playwright output) uses a multimodal hands model. See the hands pattern in `references/researcher.md`.

--- a/plugins/core/hooks/session-start.sh
+++ b/plugins/core/hooks/session-start.sh
@@ -42,7 +42,7 @@ when the trigger condition arises.
    any commit, push, PR, or merge.
 
 5. NO Co-Authored-By attribution in commits or PRs. Squash merge only.
-   User approves merges; agents never merge.
+   Merge per AGENT_LOOP_MERGE_POLICY; the default authorizes no agent merge.
 
 [END CORE SESSION-START CONTRACT]
 EOF

--- a/plugins/core/skills/agent-loop/SKILL.md
+++ b/plugins/core/skills/agent-loop/SKILL.md
@@ -102,6 +102,14 @@ The two hands vars follow the same contract as the tier vars: the launching proc
 
 **Contract:** whoever launches the spawning process (shell command, CI job, parent Claude session, external orchestrator) sets these env vars; the spawn script reads `$AGENT_LOOP_*` and passes the resolved model to the Task tool invocation (`subagent_type`/`model` argument) — never as a literal in the prompt body. An empty string (`AGENT_LOOP_LEAD_MODEL=""`) is treated identically to unset, falling through to the default, so orchestrators can emit "" to mean "use default" without special-casing.
 
+One `AGENT_LOOP_*` var selects something other than a model, and the Contract above does not apply to it — the launcher sets it, but no spawn resolves it to a model:
+
+| Selects | Env var | Default |
+|---------|---------|---------|
+| Merge actor | `AGENT_LOOP_MERGE_POLICY` | `operator` |
+
+Its two values are `operator` and `approval`, defined in `/core:git` "Merge authorization"; the default authorizes no agent merge.
+
 The four Forge reviewer vars added above default to a capability fallback: attempt `fable`, and
 retry `opus` if the fable spawn fails due to unavailability. This is explicitly the REVERSE of the
 haiku-to-sonnet-to-opus escalation-on-failure ladder described next — that one promotes on
@@ -223,7 +231,7 @@ Glob patterns like `/core:*` do not expand in Agent prompts. List skill names ex
 - **TDD**: Code without tests is not complete
 - **Merge gates (three)**: Gate 1 — local `mise run ci` green before every commit; Gate 2 — local + remote `gh pr checks` green; Gate 3 — adversarial review of the PR by a separate agent on the strongest available model, findings addressed or answered. All three before any squash merge (see `/core:git` Three-Gate Merge Policy). Gate 3 is distinct from this skill's pipeline reviewers, including Forge's Final Reviewer — it is identified by its defeat-the-change brief, not by when it runs.
 - **Branches**: One feature branch per epic (`feature/<epic-slug>`)
-- **Merge**: Squash merge only, user approves
+- **Merge**: Squash merge only, per the deployment's merge policy — see `/core:git` "Merge authorization". The default authorizes no agent merge.
 - **Agent naming**: Spawn names are `<issue>-<role>-<model>-<n>` (e.g. `318-test-author-sonnet-1`) — see `/claude-code:claude-agents` "Agent Spawning Naming Convention" for the segment definitions and the counter rule
 
 ## Agent Worker Execution Order
@@ -240,7 +248,7 @@ Every agent worker (Tier 3) follows these steps:
 8. **Gate 2** — Watch remote CI (`gh pr checks --watch`) — fix and push until local + remote are green
 9. Close bees issue, notify leader of PR status and URL by calling `SendMessage`. A named agent's plain final text is never delivered to the leader — ending the turn without calling `SendMessage` reports nothing. The PR is NOT merge-ready yet: **Gate 3** — adversarial review by a separate agent — is the leader's to arrange, and merge waits on it
 
-Agents never merge — they report the PR URL to the team leader via `SendMessage`.
+A tier-3 worker never merges, and that follows from the gates rather than from an axiom. Gate 3 does not exist when the worker reports (step 9 above), so the Gate 3 record precondition is unsatisfiable by construction. One feature branch per epic means a worker merge lands sibling workers' partial slices on main. A worker's PR is frequently stacked on the epic branch, which fires no CI and fails the at-least-one-SUCCESS rule. Merge authority sits with the tier that dispatches Gate 3 and holds its record: Team Leader, Sub-team Leader, and a bees-worker or beads-worker acting as one. The worker reports the PR URL to the team leader via `SendMessage`.
 
 ## Agent Prompt Template
 
@@ -363,7 +371,7 @@ Epics WITHOUT a `spec:` field behave exactly as today — all spec-driven steps 
 
 Claude Code dynamic workflows are an optional runtime for the five-tier pipeline. When available and opted-in, the Sub-team Leader encodes one issue's pipeline as a workflow script instead of dispatching five Task spawns — the adversarial separation and stage gates (`test files unmodified before P5`, `mise run ci` green before review) become deterministic script assertions, model escalation becomes a retry ladder, and the validator↔fix iteration becomes a bounded loop. `isolation: 'worktree'` gives each parallel implementer its own tree, replacing the shallow-clone workaround for working-tree contention.
 
-The boundary: decomposition, any Phase 1.5a escalation (the rare fork-or-blocker AskUserQuestion), and merge approval stay in the interactive loop — a workflow has no mid-run user input. The workflow executes already-decomposed issues (gate States A/C/D); it never decomposes them.
+The boundary: decomposition, any Phase 1.5a escalation (the rare fork-or-blocker AskUserQuestion), and the merge decision stay in the interactive loop — a workflow has no mid-run user input. Who may take that decision is set by the deployment's merge policy (`/core:git` "Merge authorization"); the default leaves it with the operator. The workflow executes already-decomposed issues (gate States A/C/D); it never decomposes them.
 
 The Forge shape encodes the same way at larger fan-out: `templates/forge-issue.workflow.js` is the runnable `/forge-issue` workflow — a startup-index hands pass per principal, planner slicing, dep-wave `parallel()` implementor + test-runner fan-out, and the remediation pair.
 

--- a/plugins/core/skills/agent-loop/references/team-leader.md
+++ b/plugins/core/skills/agent-loop/references/team-leader.md
@@ -95,7 +95,7 @@ A failed checkbox blocks the spawn. Fix it before invoking Task.
 2. Open a PR on `feature/<epic-slug>` targeting main
 3. PR description: what the epic delivered (bullet list, no implementation details)
 4. Report: epic ready for user review, include PR link
-5. Wait for user to approve and merge
+5. Merge per the deployment's merge policy — see `/core:git` "Merge authorization"; the default waits for the user
 6. After merge: checkout main, pull, delete feature branch
 7. Report: epic complete, ready for next assignment
 

--- a/plugins/core/skills/agent-loop/references/workflows-execution.md
+++ b/plugins/core/skills/agent-loop/references/workflows-execution.md
@@ -21,7 +21,7 @@ Absent either signal, use the default Task-spawn path. Also skip the substrate â
 A workflow has no mid-run user input; only an agent's own permission prompt pauses a run. Three responsibilities therefore never move into a workflow:
 
 - **Decomposition and Phase 1.5a clarifying questions** (`AskUserQuestion`). The Team Leader decomposes and clarifies in the main loop, then hands the issue list to the workflow. This matches the existing rule: fan-out happens at the Sub-team Leader, not the epic decomposer.
-- **Merge approval** (Phase 4). A workflow drives commit, push, and PR creation up to the squash-merge gate, which stays operator-owned.
+- **The merge decision** (Phase 4). A workflow drives commit, push, and PR creation up to the squash-merge gate. The deployment's merge policy sets who may take that gate â€” see `/core:git` "Merge authorization"; the default leaves it operator-owned.
 - **Escalation to the user** on opus-failure, dependency conflict, or ambiguity. The script surfaces the condition in its return value; the lead escalates.
 
 ## Five-tier pipeline as a script

--- a/plugins/core/skills/agent-loop/templates/five-tier-issue.workflow.js
+++ b/plugins/core/skills/agent-loop/templates/five-tier-issue.workflow.js
@@ -346,7 +346,7 @@ if (!review) return escalate('P5 reviewer failed across escalation chain', { tes
 
 log(`five-tier-issue: ${args.issueId} → ${review.approved ? 'done' : 'rework'}`)
 
-// Merge approval stays operator-owned (Phase 4) — the workflow stops here.
+// Merge follows AGENT_LOOP_MERGE_POLICY (operator by default; see /core:git "Merge authorization") — the workflow stops here.
 return {
   status: review.approved ? 'done' : 'rework',
   issueId: args.issueId,

--- a/plugins/core/skills/agent-loop/templates/forge-issue.workflow.js
+++ b/plugins/core/skills/agent-loop/templates/forge-issue.workflow.js
@@ -426,7 +426,7 @@ if (!final) return escalate('Final Reviewer failed across escalation chain')
 
 log(`forge-issue: ${args.issueId} → ${final.approved ? 'done' : 'rework'}`)
 
-// Merge approval stays operator-owned — the workflow stops at the green PR.
+// Merge follows AGENT_LOOP_MERGE_POLICY (operator by default; see /core:git "Merge authorization") — the workflow stops at the green PR.
 return {
   status: final.approved ? 'done' : 'rework',
   issueId: args.issueId,

--- a/plugins/core/skills/bees/agents/bees-worker.md
+++ b/plugins/core/skills/bees/agents/bees-worker.md
@@ -44,7 +44,7 @@ gh pr create --title "type(scope): description" --body "- Change one
 
 Notify user: "PR created: \<url\>"
 
-Then STOP and wait for user. Never auto-merge.
+Then STOP and report the PR URL. Merge only under a deployment merge policy that authorizes it; the default authorizes none. Never queue an automatic or deferred merge.
 
 #### After Merge (When User Returns)
 
@@ -59,7 +59,7 @@ bees ready                       # Find next issue
 1. **One issue = one branch = one PR**
 2. **Claim before working**: `bees update --status in_progress`
 3. **Minimal PRs**: Title + bullets only
-4. **Wait for user**: Never auto-merge or assume approval
+4. **Report, do not merge**: The default merge policy authorizes no agent merge; never assume approval
 5. **Clean up**: Delete local branch after merge
 
 ---

--- a/plugins/core/skills/git/SKILL.md
+++ b/plugins/core/skills/git/SKILL.md
@@ -167,7 +167,7 @@ No `gh pr merge --squash` while any gate is red. Who may take the merge is set b
 | `operator` (default) | none | The agent reports the PR and stops. |
 | `approval` | a forge review approval bound to `headRefOid` by a non-author identity, read at merge time | A leader-tier agent merges once the precondition holds. |
 
-Unset, `""`, and any unrecognised value resolve to `operator`, emitting one line: `merge-policy: AGENT_LOOP_MERGE_POLICY=<value> not recognized; proceeding as operator`.
+Unset and `""` resolve to `operator` silently. Any other unrecognised value resolves to `operator` and emits one line: `merge-policy: AGENT_LOOP_MERGE_POLICY=<value> not recognized; proceeding as operator`.
 
 Under `operator` no agent merges, so no agent evaluates the precondition. Step 8 of the PR / MR Workflow above is unchanged.
 
@@ -182,11 +182,11 @@ gh pr view <n> --json headRefOid,baseRefName,isCrossRepository,mergeStateStatus,
 ```
 
 1. **Checks.** `statusCheckRollup` returns two types with different fields: `CheckRun` carries `status` and `conclusion`; `StatusContext` carries `state` and no `conclusion`. BLOCK on any `CheckRun` conclusion in {FAILURE, CANCELLED, TIMED_OUT, ACTION_REQUIRED, STARTUP_FAILURE, STALE}, or any `StatusContext` state in {ERROR, FAILURE}. WAIT on any `CheckRun` status other than COMPLETED, or any `StatusContext` state in {PENDING, EXPECTED}. Accept conclusions {SUCCESS, NEUTRAL, SKIPPED} and state SUCCESS. Require at least one SUCCESS — an all-SKIPPED rollup satisfies "a check is present" and proves nothing.
-2. **Gate 3 record.** A PR comment carries, on its own line, `Gate 3: APPROVE <40-hex-oid>` matching `headRefOid` exactly. A free-text sha mention does not satisfy this. Treat a comment whose `includesCreatedEdit` is true as absent.
-3. **Base.** `baseRefName` equals the repository default branch.
-4. **Mergeability.** `mergeStateStatus` is in {CLEAN, HAS_HOOKS}, or UNSTABLE when rule 1 is independently satisfied. On UNKNOWN, re-read a bounded number of times — watching `mergeable` alongside it — then WAIT. Never merge on UNKNOWN.
-5. **Reviews.** Compute each author's latest non-DISMISSED review from `reviews[]` by `submittedAt`. Any author whose latest is CHANGES_REQUESTED blocks, whatever commit it targets. Read `reviews[]`, never `latestReviews[]`.
-6. **Under `approval` only.** A `reviews[]` entry has `state == APPROVED` and `commit.oid == headRefOid`, from a login other than the PR author.
+2. **Gate 3 record.** A PR comment carries, on its own line, `Gate 3: APPROVE <40-hex-oid>` matching `headRefOid` exactly. A free-text sha mention does not satisfy this. Treat a comment whose `includesCreatedEdit` is true as absent. The comment's author must not be the identity performing the merge.
+3. **Base.** `baseRefName` equals the repository default branch. Read the default branch once per session with `gh repo view --json defaultBranchRef -q .defaultBranchRef.name`; `gh pr view --json` carries no such field (verified against gh 2.93.0's field list).
+4. **Mergeability.** `mergeStateStatus` is in {CLEAN, HAS_HOOKS}, or UNSTABLE when rule 1 is independently satisfied. BLOCK on DIRTY, BLOCKED, and BEHIND. On UNKNOWN, re-read a bounded number of times — watching `mergeable` alongside it — then WAIT. Never merge on UNKNOWN.
+5. **Reviews.** Compute each author's latest review from `reviews[]` by `submittedAt`, restricted to entries whose state is APPROVED or CHANGES_REQUESTED. This restriction drops DISMISSED and COMMENTED entries from consideration (a COMMENTED review never clears a CHANGES_REQUESTED block — GitHub keeps the block until dismissal or a new approving review from the same author). Any author whose latest qualifying review is CHANGES_REQUESTED blocks, whatever commit it targets. Read `reviews[]`, never `latestReviews[]`.
+6. **Under `approval` only.** A `reviews[]` entry has `state == APPROVED` and `commit.oid == headRefOid`, from a login other than the PR author and other than the identity performing the merge, which the merging agent learns via `gh api user -q .login`.
 7. **Under `approval` only.** `isCrossRepository == false`.
 
 Then merge pinned to the sha that was read:
@@ -206,21 +206,19 @@ glab mr merge <n> --squash --yes --auto-merge=false --sha <headRefOid>
 
 An APPROVED review pinned to head by a login other than the PR author, with `author.login` as the actor record. That is a distinct forge identity — not a human. Two consequences follow. In a single-identity deployment `approval` is unsatisfiable, because the author cannot self-approve; it is `operator` with a longer read. In a bot-identity deployment, one agent holding tokens for two identities satisfies it with zero humans. The deployment obligation therefore lands on the approving identity: it must not be one the agent can authenticate as. An allowed-approver list or an `authorAssociation` filter is the knob.
 
-The policy is config — it varies between deploys and not within one, so an env var is its home. The per-PR authorization is runtime input — it varies per PR inside one deploy, so an env var is the wrong home for it whatever the convention: a launch-time value cannot be per-PR, and a stale one is the failure this design exists to prevent.
-
 #### Residual risks
 
 1. `approval` guarantees a distinct forge identity, not a human review.
 2. Field consistency inside one `gh pr view --json` read is treated as a consistent snapshot; GitHub does not document it as one. `--match-head-commit` bounds the damage to a check status flipping on an unchanged head.
 3. Base moved, not head: the checks ran against the branch, not against a squash onto current main. BEHIND is reported only under a "require branches up to date" rule, so `mergeStateStatus` does not cover this. Post-merge main verification (`/core:tdd`, `references/ci-discipline.md`) is the only backstop.
-4. `latestReviews[].commit.oid` is reported empty where `reviews[].commit.oid` is populated (cli/cli#14301). Requires verification: read both fields on a PR that carries an approval. A reader using the wrong field gets a value that never equals `headRefOid` — it fails safe, but silently.
+4. `reviews[].commit.oid` is the field this precondition reads. A reader who substitutes `latestReviews[]` may get a value that does not equal `headRefOid` — it fails safe, but silently.
 5. GitLab here is docs-only: `--sha`, `glab mr view` approval fields, and self-approval project settings are unverified, the same evidence class disclosed in "Anti-fabrication" above.
-6. A merge queue inverts the meaning of plain `gh pr merge` — it queues rather than merges. Rule 1 and the forbidden list handle it; it is restated because it changes a command this skill otherwise uses.
+6. A merge queue inverts the meaning of plain `gh pr merge` — it queues rather than merges. The forbidden-command list and the `autoMergeRequest` observable handle it; it is restated because it changes a command this skill otherwise uses.
 7. A repo with no CI, or with fully path-filtered CI, never satisfies the at-least-one-SUCCESS rule and waits permanently under `approval`. That is correct behavior, not a defect.
-8. Pagination: a Gate 3 record beyond the `comments` page reads as absent and waits — safe. A FAILURE beyond the `statusCheckRollup` page is invisible and admits the merge — unsafe. Requires verification: gh's rollup page size and whether it fetches every page.
-9. `mergedBy` records the agent's forge identity, so the audit trail cannot distinguish an agent merge from a human one. Removing the standing axiom grows this risk.
-10. Records are editable. Rule 2 handles it through `includesCreatedEdit`; an implementer who reads records as immutable reintroduces it.
-11. A force-push orphans a review's commit. The `commit.oid == headRefOid` pin handles APPROVED, and the per-author-latest rule keeps a CHANGES_REQUESTED on an unreachable commit blocking.
+8. `mergedBy` records the agent's forge identity, so the audit trail cannot distinguish an agent merge from a human one. Removing the standing axiom grows this risk.
+9. Records are editable. Rule 2 handles it through `includesCreatedEdit`; an implementer who reads records as immutable reintroduces it.
+10. A force-push orphans a review's commit. The `commit.oid == headRefOid` pin handles APPROVED, and the per-author-latest rule keeps a CHANGES_REQUESTED on an unreachable commit blocking.
+11. A repo-local `mise.toml` `[env]` block can set `AGENT_LOOP_MERGE_POLICY`, so on a deployment that trusts repo config the policy is settable by a PR branch. Set the variable in the launcher environment and do not let repo config override it.
 
 ### Gate 3 is not the pipeline's review tier
 
@@ -310,7 +308,7 @@ gh pr create --draft                    # Draft PR
 gh pr list                              # List PRs
 gh pr view 123                          # View PR
 gh pr checkout 123                      # Checkout PR locally
-gh pr merge 123 --squash                # Squash merge PR
+gh pr merge 123 --squash                # Squash merge PR — see "Merge authorization" for the pinned form required at merge time
 ```
 
 ## GitLab MR Commands
@@ -332,6 +330,8 @@ Same workflow, different verbs. `glab` mirrors `gh`'s shape, including the `-R, 
 | Authenticate | `gh auth login` | `glab auth login` |
 
 `gh pr checks` is scoped to the PR; `glab ci status` is scoped to a branch (current branch by default). They are not interchangeable at Gate 2 — on GitLab, confirm the branch being checked is the MR's actual source branch before trusting the result.
+
+The squash-merge row above shows the bare command for reference. Never run it unpinned — see "Merge authorization" for the required `--match-head-commit` / `--sha` form.
 
 ## Key Rules
 

--- a/plugins/core/skills/git/SKILL.md
+++ b/plugins/core/skills/git/SKILL.md
@@ -156,7 +156,71 @@ Gate 3 requirements:
 - **Grep for attribution before posting a comment or declaring gates green** — both the branch's commits and the comment text about to be posted: `git log origin/main..HEAD --format='%B' | grep -niE 'co-authored-by|signed-off-by|assisted-by|generated with'`, same pattern against the comment body. The pattern deliberately excludes bare model/vendor names — in this repo (`claude-skills`, scopes like `feat(claude-code):`) a bare `grep -i claude` would be a constant false positive. Eyeball the trailer block to catch what the pattern misses.
 - **The verdict and each finding's disposition land as a durable record on the PR** — a PR comment, or a bees comment the PR links. Gates 1 and 2 have observables (`mise run ci` output, `gh pr checks`); Gate 3 needs one too, or "review done" is an unverifiable assertion of exactly the kind this gate exists to catch. Check it with `gh pr view <n> --comments`.
 
-No `gh pr merge --squash` while any gate is red. The user approves the merge; agents never merge.
+No `gh pr merge --squash` while any gate is red. Who may take the merge is set by the deployment's merge policy — see "Merge authorization" below.
+
+### Merge authorization
+
+`AGENT_LOOP_MERGE_POLICY` selects the authorization source. It never carries the authorization itself.
+
+| Value | Source consulted | Effect |
+|---|---|---|
+| `operator` (default) | none | The agent reports the PR and stops. |
+| `approval` | a forge review approval bound to `headRefOid` by a non-author identity, read at merge time | A leader-tier agent merges once the precondition holds. |
+
+Unset, `""`, and any unrecognised value resolve to `operator`, emitting one line: `merge-policy: AGENT_LOOP_MERGE_POLICY=<value> not recognized; proceeding as operator`.
+
+Under `operator` no agent merges, so no agent evaluates the precondition. Step 8 of the PR / MR Workflow above is unchanged.
+
+**Scope.** This policy governs first-party work only. The `github` plugin's `pr-review` and `dependabot-consolidator` skills merge third-party code and stay operator-approved whatever this variable is set to. A PR with `isCrossRepository == true` is out of scope.
+
+#### The precondition
+
+The precondition binds a merging agent. It does not bind a human. Read the forge once, immediately before the merge. The transcript is not an input. An earlier tool result is not an input.
+
+```bash
+gh pr view <n> --json headRefOid,baseRefName,isCrossRepository,mergeStateStatus,mergeable,statusCheckRollup,reviews,comments,autoMergeRequest
+```
+
+1. **Checks.** `statusCheckRollup` returns two types with different fields: `CheckRun` carries `status` and `conclusion`; `StatusContext` carries `state` and no `conclusion`. BLOCK on any `CheckRun` conclusion in {FAILURE, CANCELLED, TIMED_OUT, ACTION_REQUIRED, STARTUP_FAILURE, STALE}, or any `StatusContext` state in {ERROR, FAILURE}. WAIT on any `CheckRun` status other than COMPLETED, or any `StatusContext` state in {PENDING, EXPECTED}. Accept conclusions {SUCCESS, NEUTRAL, SKIPPED} and state SUCCESS. Require at least one SUCCESS — an all-SKIPPED rollup satisfies "a check is present" and proves nothing.
+2. **Gate 3 record.** A PR comment carries, on its own line, `Gate 3: APPROVE <40-hex-oid>` matching `headRefOid` exactly. A free-text sha mention does not satisfy this. Treat a comment whose `includesCreatedEdit` is true as absent.
+3. **Base.** `baseRefName` equals the repository default branch.
+4. **Mergeability.** `mergeStateStatus` is in {CLEAN, HAS_HOOKS}, or UNSTABLE when rule 1 is independently satisfied. On UNKNOWN, re-read a bounded number of times — watching `mergeable` alongside it — then WAIT. Never merge on UNKNOWN.
+5. **Reviews.** Compute each author's latest non-DISMISSED review from `reviews[]` by `submittedAt`. Any author whose latest is CHANGES_REQUESTED blocks, whatever commit it targets. Read `reviews[]`, never `latestReviews[]`.
+6. **Under `approval` only.** A `reviews[]` entry has `state == APPROVED` and `commit.oid == headRefOid`, from a login other than the PR author.
+7. **Under `approval` only.** `isCrossRepository == false`.
+
+Then merge pinned to the sha that was read:
+
+```bash
+gh pr merge <n> --squash --match-head-commit <headRefOid>
+glab mr merge <n> --squash --yes --auto-merge=false --sha <headRefOid>
+```
+
+**Forbidden — each one defers the merge or bypasses a requirement.** `gh pr merge --auto` queues a merge that fires later. `gh pr merge --admin` bypasses branch requirements and a merge queue. `glab mr merge` without `--auto-merge=false` queues on a flag that defaults to true. On a repo with a merge queue, plain `gh pr merge` adds the PR to the queue instead of merging it. Detect the queue and wait. `autoMergeRequest` in the read is the observable for "no auto-merge is already queued".
+
+**A missing signal means WAIT, never denied.** Denied is a terminal disposition, and an unattended session may act on it — close the PR, abandon the branch, fail the issue. Wait means this: leave the PR exactly as it is, report what is being waited on, and end the turn. Safe means the PR's forge state is unchanged by the session.
+
+**Re-attestation.** The Gate 3 record names the sha that merges. When commits land after the record, the reviewer reads `git diff <reviewed-sha>..<head>` only, confirms the delta addresses its findings and introduces nothing else, then posts the marker line at the new sha. A marker posted without reading the delta is the unverifiable assertion Gate 3 exists to catch.
+
+#### What `approval` is entitled to claim
+
+An APPROVED review pinned to head by a login other than the PR author, with `author.login` as the actor record. That is a distinct forge identity — not a human. Two consequences follow. In a single-identity deployment `approval` is unsatisfiable, because the author cannot self-approve; it is `operator` with a longer read. In a bot-identity deployment, one agent holding tokens for two identities satisfies it with zero humans. The deployment obligation therefore lands on the approving identity: it must not be one the agent can authenticate as. An allowed-approver list or an `authorAssociation` filter is the knob.
+
+The policy is config — it varies between deploys and not within one, so an env var is its home. The per-PR authorization is runtime input — it varies per PR inside one deploy, so an env var is the wrong home for it whatever the convention: a launch-time value cannot be per-PR, and a stale one is the failure this design exists to prevent.
+
+#### Residual risks
+
+1. `approval` guarantees a distinct forge identity, not a human review.
+2. Field consistency inside one `gh pr view --json` read is treated as a consistent snapshot; GitHub does not document it as one. `--match-head-commit` bounds the damage to a check status flipping on an unchanged head.
+3. Base moved, not head: the checks ran against the branch, not against a squash onto current main. BEHIND is reported only under a "require branches up to date" rule, so `mergeStateStatus` does not cover this. Post-merge main verification (`/core:tdd`, `references/ci-discipline.md`) is the only backstop.
+4. `latestReviews[].commit.oid` is reported empty where `reviews[].commit.oid` is populated (cli/cli#14301). Requires verification: read both fields on a PR that carries an approval. A reader using the wrong field gets a value that never equals `headRefOid` — it fails safe, but silently.
+5. GitLab here is docs-only: `--sha`, `glab mr view` approval fields, and self-approval project settings are unverified, the same evidence class disclosed in "Anti-fabrication" above.
+6. A merge queue inverts the meaning of plain `gh pr merge` — it queues rather than merges. Rule 1 and the forbidden list handle it; it is restated because it changes a command this skill otherwise uses.
+7. A repo with no CI, or with fully path-filtered CI, never satisfies the at-least-one-SUCCESS rule and waits permanently under `approval`. That is correct behavior, not a defect.
+8. Pagination: a Gate 3 record beyond the `comments` page reads as absent and waits — safe. A FAILURE beyond the `statusCheckRollup` page is invisible and admits the merge — unsafe. Requires verification: gh's rollup page size and whether it fetches every page.
+9. `mergedBy` records the agent's forge identity, so the audit trail cannot distinguish an agent merge from a human one. Removing the standing axiom grows this risk.
+10. Records are editable. Rule 2 handles it through `includesCreatedEdit`; an implementer who reads records as immutable reintroduces it.
+11. A force-push orphans a review's commit. The `commit.oid == headRefOid` pin handles APPROVED, and the per-author-latest rule keeps a CHANGES_REQUESTED on an unreachable commit blocking.
 
 ### Gate 3 is not the pipeline's review tier
 
@@ -177,13 +241,15 @@ mise run ci                              # Gate 1: local, already green before t
 gh pr checks <number>                    # Gate 2: remote (GitHub)
 glab ci status --branch <branch>         # Gate 2: remote (GitLab)
 # Gate 3: adversarial review reported, findings addressed or answered
-gh pr merge <number> --squash            # GitHub
-glab mr merge <number> --squash --yes    # GitLab
+# Merge authorization: one forge read immediately before the merge
+gh pr view <number> --json headRefOid,baseRefName,isCrossRepository,mergeStateStatus,mergeable,statusCheckRollup,reviews,comments,autoMergeRequest
+gh pr merge <number> --squash --match-head-commit <headRefOid>               # GitHub
+glab mr merge <number> --squash --yes --auto-merge=false --sha <headRefOid>  # GitLab
 ```
 
 Never use regular merge or rebase merge for PRs or MRs. Squash merge keeps main history clean with one commit per PR.
 
-**`--auto-merge` hazard on `glab mr merge`.** The flag defaults to true — left unset, it can queue an automatic merge that fires later once the pipeline succeeds, a merge the user never explicitly approved at that moment. This conflicts directly with "agents never merge." Always pass `--auto-merge=false` explicitly, or do not run `glab mr merge` at all without explicit user go-ahead.
+**Deferred-firing and bypass paths.** A merge that fires later is a merge nobody authorized at the moment it happened, against forge state nobody read. `glab mr merge`'s `--auto-merge` defaults to true, so an unset flag queues one — always pass `--auto-merge=false`. `gh pr merge --auto` queues the same way. `gh pr merge --admin` bypasses branch requirements and a merge queue. On a repo with a merge queue, plain `gh pr merge` adds the PR to the queue rather than merging it (`gh pr merge --help`, gh 2.93.0). Detect the queue and wait; never queue.
 
 ## Branch Naming
 
@@ -272,7 +338,7 @@ Same workflow, different verbs. `glab` mirrors `gh`'s shape, including the `-R, 
 - **No attribution**: Never add `Co-Authored-By`, `Signed-off-by`, or similar to commits. No "Generated with Claude Code" or similar in PRs
 - **Squash merge PRs**: Always use `gh pr merge --squash`
 - **Single-line commits preferred**: Use body only when explanation is needed
-- **Never merge without approval**: Always wait for user to approve PR merges
+- **Merge per policy**: Under the default, wait for the user; never queue a deferred merge — see "Merge authorization"
 - **Clean up after merge**: Delete branches locally and remotely
 - **Use gcms**: Generate commit messages with `/core:gcms` skill
 

--- a/plugins/core/skills/git/references/gitlab-mr.md
+++ b/plugins/core/skills/git/references/gitlab-mr.md
@@ -88,11 +88,12 @@ cannot be quietly amended; edits leave a visible history.
 | `-y, --yes` | Skip confirmation |
 | `--auto-merge` | Queue automatic merge once checks pass — **defaults to true** |
 
-**Hazard.** `--auto-merge` defaults to true. Left unset, `glab mr merge` can queue
-a merge that fires later when the pipeline succeeds — a merge the user never
-explicitly approved at that moment. Conflicts directly with "agents never merge."
-Always pass `--auto-merge=false`, or do not run `glab mr merge` at all without
-explicit user go-ahead.
+**Hazard — deferred firing.** `--auto-merge` defaults to true. Left unset,
+`glab mr merge` queues a merge that fires later when the pipeline succeeds — a
+merge nobody authorized at the moment it happened, against forge state nobody
+read. Always pass `--auto-merge=false`. Pin the head with `--sha` so a push
+between the read and the merge cannot slip through. `/core:git` "Merge
+authorization" carries the full rule.
 
 ## CI status — `glab ci status [flags]`
 

--- a/plugins/tools/beads/.claude-plugin/plugin.json
+++ b/plugins/tools/beads/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "beads",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Beads (bd) distributed git-backed graph issue tracker: task management, dependency tracking, AI agent workflows",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/beads/skills/beads/agents/beads-worker.md
+++ b/plugins/tools/beads/skills/beads/agents/beads-worker.md
@@ -44,7 +44,7 @@ gh pr create --title "type(scope): description" --body "- Change one
 
 Notify user: "PR created: \<url\>"
 
-Then STOP and wait for user. Never auto-merge.
+Then STOP and report the PR URL. Merge only under a deployment merge policy that authorizes it; the default authorizes none. Never queue an automatic or deferred merge.
 
 #### After Merge (When User Returns)
 
@@ -59,7 +59,7 @@ bd ready                         # Find next task
 1. **One task = one branch = one PR**
 2. **Claim before working**: `bd update --status in_progress`
 3. **Minimal PRs**: Title + bullets only
-4. **Wait for user**: Never auto-merge or assume approval
+4. **Report, do not merge**: The default merge policy authorizes no agent merge; never assume approval
 5. **Clean up**: Delete local branch after merge
 
 ---

--- a/plugins/tools/beads/skills/beads/references/workflow-examples.md
+++ b/plugins/tools/beads/skills/beads/references/workflow-examples.md
@@ -77,7 +77,7 @@ bd ready                         # Find next task
 2. **Claim before working** - `bd update --status in_progress`
 3. **Close with completion** - Document what was done
 4. **Minimal PRs** - Title + bullets only, no templates
-5. **Wait for user** - Never auto-merge or assume approval
+5. **Report, do not merge** - The default merge policy authorizes no agent merge; never assume approval
 6. **Clean up** - Delete local branch after merge
 
 ### AI Agent Task Loop (Automated)

--- a/plugins/tools/claude-code/.claude-plugin/plugin.json
+++ b/plugins/tools/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "description": "Claude Code-specific skills for plugin marketplace management, validation, and component creation",
   "author": {
     "name": "vinnie357"

--- a/plugins/tools/claude-code/templates/CLAUDE.md
+++ b/plugins/tools/claude-code/templates/CLAUDE.md
@@ -53,9 +53,9 @@ Phase 3: Validation
 Phase 4: Submit loop
 - we never commit or pr with attribution
 - we give summary prs without a changes section as git has the diff
-- agents never merge — they report PR URL and wait
+- agents merge only under a merge policy that authorizes it; the documented default is `operator`, under which they report the PR URL and wait
 - three-gate step order (see /core:git Three-Gate Merge Policy): Gate 1 local CI → commit → gitleaks → push → PR → Gate 2 watch remote CI → Gate 3 adversarial review by a separate agent on the strongest available model → notify
-- once all three gates are green we ask the user to squash merge and delete the merged branch
+- once all three gates are green we ask the user to squash merge and delete the merged branch — that is the `operator` default; another policy value follows /core:git "Merge authorization"
 - once merged, close the tracker issue (bees or beads), commit the tracker state, and push
 - we checkout main, pull and delete our merged feature branch
 - we go back to Phase1 to work a new epic


### PR DESCRIPTION
Replaces the standing axiom "agents never merge" with a mechanical precondition, and adds `AGENT_LOOP_MERGE_POLICY` as the authorization-source selector. Closes claude-skills-332.

- Add `### Merge authorization` to `/core:git` as the canonical site: two-value table, the single `gh pr view --json` read, all seven precondition items, the transcript-is-not-an-input rule, wait-not-deny, the forbidden-command list, the pinned merge command, the `approval` entitlement paragraph, the first-party-only carve-out, and eleven residual risks
- Every other site becomes a pointer of at most three lines
- Rewrite the `--auto-merge` hazard to rest on deferred firing rather than the removed axiom; extend it to `gh pr merge --auto`, `--admin`, and merge queues
- State the tier-3 worker rule at `agent-loop/SKILL.md:251` as derived from Gate 3 timing, one-branch-per-epic, and stacked-PR CI, not as an axiom
- Keep the `github` plugin independent: `isCrossRepository == true` is out of scope regardless of policy value
- Bump core, claude-code, beads, and all-skills

Two values only: `operator` (default) and `approval`. The `agent` value stays dropped per the issue's Deferred section.

## Round two — Gate 3 findings applied

The adversarial review returned REJECT with five MAJORs. Commit `43d0b7d` addresses all of them. Two corrections override the issue's own DECIDED text, deliberately:

1. **Rule 5 failed open.** As decided, "each author's latest non-DISMISSED review by `submittedAt`" let a COMMENTED review submitted after a CHANGES_REQUESTED clear the block. GitHub keeps the block until dismissal or a new approving review. Rule 5 now restricts the latest-review computation to APPROVED and CHANGES_REQUESTED states.
2. **The twelve-factor paragraph was false and is deleted.** It claimed the policy "varies between deploys and not within one". Verified on mise 2026.8.10: a repo-local `mise.toml` with `[env] AGENT_LOOP_MERGE_POLICY = "approval"` exports the value, so a PR branch can set it. That exposure now ships as residual risk 11 with its mitigation.

Also fixed: a fabricated citation (`cli/cli#14301` is a Dependabot `azure/login` bump, not a report about `latestReviews[].commit.oid`); the Gate 3 record author and the approver are now both constrained against the merging identity; `MergeStateStatus` members DIRTY, BLOCKED and BEHIND gained dispositions; rule 3 names how the default branch is read; unset and `""` now resolve silently, matching the `DECOMPOSITION_PATH` shape they cite; the pagination risk was retired as verified-safe; and the two unpinned `gh pr merge` examples now point at the pinned form.

**Deliberate deviations from the issue's TEXT PLACEMENT, for reviewer attention:**

1. The `AGENT_LOOP_MERGE_POLICY` entry ships as a separate one-row table after the Contract paragraph rather than as a row inside the model-override table at `agent-loop/SKILL.md:88-99`. That table's Contract paragraph binds every row to "passes the resolved model to the Task tool invocation", which is false for a merge policy; adding the row inline would have shipped a false statement.
2. `plugins/core/hooks/session-start.sh:45` is edited although the issue does not list it. It injects into every session at turn 1 and carried the removed axiom. Verified before editing that no test asserts on that text: `validate-security-hook.nu` targets a different path, `validate-core-list.nu` registers the file as a core-list satellite resolved by anchor-adjacent run detection scoped to the skill-name block, and `grep -rniE "user approves|never merge|agents never" test/` is empty.

**Verification.** The issue's enum claims were checked against the live GitHub API, not read for plausibility: `CheckConclusionState` (9 members), `CheckStatusState` (6), `StatusState` (5), and `MergeStateStatus` (7) all confirmed, with every member now carrying a disposition. `--match-head-commit` and the merge-queue sentence confirmed in `gh pr merge --help` on gh 2.93.0. All nine `--json` fields confirmed valid. No branch protection (404) and no rulesets (`[]`). `includesCreatedEdit` confirmed present and confirmed to flip on a real edited comment.

Local `mise run ci` green at this head. `mise run test:version-bumps origin/main` green — that task is excluded from `mise run test` at `mise.toml:32-35` and was run explicitly. `dupe/28ccd32d` detail_count is exactly 7 with no new `dupe/*` key and `quality-baseline.json` unmodified; the ratchet is bidirectional, so a lower count would also fail. `git/SKILL.md` is 356 lines against the 500 cap. Residual risks count exactly 11.
